### PR TITLE
59: Add headers to routes

### DIFF
--- a/now.json
+++ b/now.json
@@ -2,9 +2,24 @@
   "version": 2,
   "routes": [
     { "handle": "filesystem" },
-    { "src": "/_next/.*" },
+    { "src": "/_next/.*",
+      "headers": {
+        "x-control-type-options": "nosniff",
+        "X-frame-options": "DENY",
+        "x-xss-protextion": "1; mode=block"
+      }
+    },
     { "src": "/.+\\.[^/]+$" },
-    { "src": "/api/.*" },
-    { "src": "(/.+)$", "dest": "/?alias=$1" }
+    { "src": "/api/.*",
+      "headers": {
+        "cache-control": "public, max-age=0, must-revalidate"
+      }
+    },
+    { "src": "(/.+)$",
+      "dest": "/?alias=$1",
+      "headers": {
+        "cache-control": "public, max-age=900, s-maxage=900, stale-while-revalidate"
+      }
+    }
   ]
 }


### PR DESCRIPTION
 Closes #59

- Adds headers to routes, namely cache-control headers.

## To Review
- [x] Use the Preview link located in the Now comment below.
- [x] Open network inspector and filter to the doc.
- [x] Reload page and confirm response headers include `cache-control: public, max-age=900` header.
