### PR TITLE
75: api proxy endpoints

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -54,3 +54,7 @@ rules:
   react/react-in-jsx-scope: 2
   '@typescript-eslint/indent': 0
   prettier/prettier: 'error'
+overrides:
+  - 'files': ['./pages/**/*', './pages/*']
+    'rules':
+      'import/no-default-export': 0

--- a/contexts/AppContext.ts
+++ b/contexts/AppContext.ts
@@ -4,5 +4,19 @@
  */
 
 import React from 'react';
+import { IPriApiResource } from 'pri-api-library/types';
+import { IButton } from '@interfaces/button';
 
-export const AppContext = React.createContext(null);
+export interface IAppContext {
+  copyrightDate?: string | number;
+  latestStories: IPriApiResource[];
+  menus?: {
+    [K: string]: IButton[];
+  };
+}
+
+export const AppContext = React.createContext({
+  copyrightDate: new Date().getFullYear(),
+  latestStories: [],
+  menus: {}
+} as IAppContext);

--- a/interfaces/content/content.interface.ts
+++ b/interfaces/content/content.interface.ts
@@ -6,15 +6,9 @@
 import { FunctionComponent } from 'react';
 import { IPriApiResource } from 'pri-api-library/types';
 
-export interface FetchDataFunc {
-  (id?: number|string): object
-}
-
-export interface IContentComponent extends FunctionComponent {
-  fetchData: FetchDataFunc
-}
+export interface IContentComponent extends FunctionComponent {}
 
 export interface IContentComponentProxyProps {
-  data?: IPriApiResource,
-  errorCode?: number
+  data?: IPriApiResource;
+  errorCode?: number;
 }

--- a/interfaces/page/page.interface.ts
+++ b/interfaces/page/page.interface.ts
@@ -7,5 +7,5 @@ import { Component } from 'react';
 import { IPriApiResource } from 'pri-api-library/types';
 
 export interface IPageComponent extends Component {
-  data: IPriApiResource
+  data: IPriApiResource;
 }

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -1,0 +1,33 @@
+/**
+ * @file fetchApi.js
+ * Exports a mechanism that makes GET requests to API easier to manage.
+ */
+
+import fetch from 'isomorphic-unfetch';
+import { IPriApiResource } from 'pri-api-library/types';
+import { IncomingMessage } from 'http';
+
+/**
+ * Metho that simplifies GET queries for resource item using URL path alias.
+ *
+ * @param alias
+ *    Alias used by resource item to display data.
+ *
+ * @returns
+ *    Denormalized resource item.
+ */
+export const fetchApiQueryAlias = async (
+  alias: string,
+  req: IncomingMessage
+): Promise<IPriApiResource> => {
+  const baseUrl = req
+    ? `${req.headers['x-forwarded-proto']}://${req.headers.host}`
+    : '';
+
+  if (req) {
+    console.log(req.headers);
+    console.log(process.env);
+  }
+
+  return fetch(`${baseUrl}/api/query/alias${alias}`).then(resp => resp.json());
+};

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -8,10 +8,30 @@ import { IPriApiResource } from 'pri-api-library/types';
 import { IncomingMessage } from 'http';
 
 /**
+ * Method that simplifies GET requests.
+ *
+ * @param path
+ *    Path to the resource being requested.
+ * @param req
+ *    Request object from `getInitialProps` ctx object.
+ *
+ * @returns
+ *    Denormalized response to request, or error object.
+ */
+export const fetchApi = async (path: string, req: IncomingMessage) => {
+  const baseUrl = req
+    ? `${req.headers['x-forwarded-proto']}://${req.headers.host}`
+    : '';
+  return fetch(`${baseUrl}/api/${path}`).then(resp => resp.json());
+};
+
+/**
  * Metho that simplifies GET queries for resource item using URL path alias.
  *
  * @param alias
  *    Alias used by resource item to display data.
+ * @param req
+ *    Request object from `getInitialProps` ctx object.
  *
  * @returns
  *    Denormalized resource item.
@@ -19,15 +39,4 @@ import { IncomingMessage } from 'http';
 export const fetchApiQueryAlias = async (
   alias: string,
   req: IncomingMessage
-): Promise<IPriApiResource> => {
-  const baseUrl = req
-    ? `${req.headers['x-forwarded-proto']}://${req.headers.host}`
-    : '';
-
-  if (req) {
-    console.log(req.headers);
-    console.log(process.env);
-  }
-
-  return fetch(`${baseUrl}/api/query/alias${alias}`).then(resp => resp.json());
-};
+): Promise<IPriApiResource> => fetchApi(`query/alias${alias}`, req);

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -26,7 +26,7 @@ export const fetchApi = async (path: string, req: IncomingMessage) => {
 };
 
 /**
- * Metho that simplifies GET queries for resource item using URL path alias.
+ * Method that simplifies GET queries for resource item using URL path alias.
  *
  * @param alias
  *    Alias used by resource item to display data.
@@ -40,3 +40,63 @@ export const fetchApiQueryAlias = async (
   alias: string,
   req: IncomingMessage
 ): Promise<IPriApiResource> => fetchApi(`query/alias${alias}`, req);
+
+/**
+ * Method that simplifies GET queries for app data.
+ *
+ * @param req
+ *    Request object from `getInitialProps` ctx object.
+ *
+ * @returns
+ *    App data object.
+ */
+export const fetchApiApp = async (req: IncomingMessage) => fetchApi('app', req);
+
+/**
+ * Method that simplifies GET queries for homepage data.
+ *
+ * @param req
+ *    Request object from `getInitialProps` ctx object.
+ *
+ * @returns
+ *    Homepage data object.
+ */
+export const fetchApiHomepage = async (req: IncomingMessage) =>
+  fetchApi('homepage', req);
+
+/**
+ * Method that simplifies GET queries for story data.
+ *
+ * @param alias
+ *    Alias used by resource item to display data.
+ * @param req
+ *    Request object from `getInitialProps` ctx object.
+ *
+ * @returns
+ *    Story data object.
+ */
+export const fetchApiStory = async (
+  id: string | number,
+  req: IncomingMessage
+) => fetchApi(`story/${id}`, req);
+
+/**
+ * Map resource type to their fetch function.
+ */
+export const resourceTypeFetchMap = {
+  'node--stories': fetchApiStory
+};
+
+export const fetchApiContent = async (
+  type: string,
+  id: string | number,
+  req: IncomingMessage
+) => {
+  if (type === 'homepage') {
+    return fetchApiHomepage(req);
+  }
+
+  const func = resourceTypeFetchMap[type];
+
+  return func ? func(id, req) : new Promise(resolve => resolve(null));
+};

--- a/lib/fetch/api/fetchPriApi.ts
+++ b/lib/fetch/api/fetchPriApi.ts
@@ -10,7 +10,7 @@ import {
 } from 'pri-api-library';
 import { PriApiResourceResponse, IPriApiResponse } from 'pri-api-library/types';
 import { ILink } from '@interfaces/link';
-import { priApi as priApiConfig} from '../../../config';
+import { priApi as priApiConfig } from '../../../config';
 
 /**
  * Method that simplifies GET requests.
@@ -48,7 +48,11 @@ export const fetchPriApi = async (
  * @returns
  *    Denormalized resource collection.
  */
-export const fetchPriApiQuery = async (type: string, params?: object, keys?: object): Promise<PriApiResourceResponse> =>
+export const fetchPriApiQuery = async (
+  type: string,
+  params?: object,
+  keys?: object
+): Promise<PriApiResourceResponse> =>
   libFetchPriApiQuery(type, params, keys, priApiConfig);
 
 /**
@@ -73,7 +77,8 @@ export const fetchPriApiItem = async (
   id: number | string,
   params?: object,
   keys?: object
-): Promise<PriApiResourceResponse> => libFetchPriApiItem(type, id, params, keys, priApiConfig);
+): Promise<PriApiResourceResponse> =>
+  libFetchPriApiItem(type, id, params, keys, priApiConfig);
 
 /**
  * Metho that simplifies GET queries for resource item using URL path alias.
@@ -90,8 +95,16 @@ export const fetchPriApiItem = async (
  * @returns
  *    Denormalized resource item.
  */
-export const fetchPriApiQueryAlias = async (alias: string, params?: object, keys?: object): Promise<PriApiResourceResponse> =>
-  fetchPriApi(`query/alias/${alias.replace(/^\/+|\/+$/, '')}`, params, keys).then(resp => !resp.isFailure && resp.response);
+export const fetchPriApiQueryAlias = async (
+  alias: string,
+  params?: object,
+  keys?: object
+): Promise<PriApiResourceResponse> =>
+  fetchPriApi(
+    `query/alias/${alias.replace(/^\/+|\/+$/, '')}`,
+    params,
+    keys
+  ).then(resp => !resp.isFailure && resp.response);
 
 /**
  * Metho that simplifies GET queries for menu.
@@ -102,5 +115,9 @@ export const fetchPriApiQueryAlias = async (alias: string, params?: object, keys
  * @returns
  *    Denormalized resource item.
  */
-export const fetchPriApiQueryMenu = async (menuName: string): Promise<ILink[]> =>
-  fetchPriApi(`menu/tree/${menuName}`).then(resp => !resp.isFailure && resp.response as ILink[]);
+export const fetchPriApiQueryMenu = async (
+  menuName: string
+): Promise<ILink[]> =>
+  fetchPriApi(`menu/tree/${menuName}`).then(
+    resp => !resp.isFailure && (resp.response as ILink[])
+  );

--- a/lib/fetch/api/index.ts
+++ b/lib/fetch/api/index.ts
@@ -1,1 +1,2 @@
 export * from './fetchPriApi';
+export * from './fetchApi';

--- a/lib/parse/audio/download.ts
+++ b/lib/parse/audio/download.ts
@@ -6,14 +6,19 @@
 import { parse } from 'url';
 import { IPriApiResource } from 'pri-api-library/types';
 
-export const generateAudioDownloadFilename = ({
-  program,
-  metatags: { canonical },
-  metadata
-}: IPriApiResource, prefixOverride: string = null) => {
+export const generateAudioDownloadFilename = (
+  { program, metatags: { canonical }, metadata }: IPriApiResource,
+  prefixOverride: string = null
+) => {
+  console.log('generateAudioDownloadFilename >> program', program);
   const { pathname } = parse(canonical);
-  const parts = pathname.split('/').filter(item => !!item && !!item.length && item !== 'file');
-  const prefix = prefixOverride || (program && program.title.toLowerCase().replace(/\s+/, '-')) || 'tw';
+  const parts = pathname
+    .split('/')
+    .filter(item => !!item && !!item.length && item !== 'file');
+  const prefix =
+    prefixOverride ||
+    (!!program && program.title.toLowerCase().replace(/\s+/, '-')) ||
+    'tw';
   const format = (metadata && metadata.audio_url) || 'mp3';
 
   return `${[prefix, ...parts].join('--')}.${format}`;

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "next-absolute-url": "^1.0.2",
     "next-compose-plugins": "^2.2.0",
     "next-fonts": "^0.17.0",
+    "now": "^19.1.1",
     "postcss-easy-media-query": "^1.0.0",
     "pri-api-library": "^1.1.0",
     "prop-types": "^15.7.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,19 +8,18 @@ import App, { AppContext as NextAppContext, AppProps } from 'next/app';
 import classNames from 'classnames/bind';
 import { Box, CssBaseline } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
-import { PriApiResource } from 'pri-api-library/types';
-import { ILink } from '@interfaces/link';
-import { parseMenu } from '@lib/parse/menu';
+import { IPriApiResource } from 'pri-api-library/types';
+import { IButton } from '@interfaces/button';
 import { AppContext } from '@contexts/AppContext';
 import { AppHeader } from '@components/AppHeader';
 import { AppFooter } from '@components/AppFooter';
-import { fetchPriApiQuery, fetchPriApiQueryMenu } from '@lib/fetch';
+import { fetchApiApp } from '@lib/fetch/api';
 import { baseMuiTheme, appTheme } from '@theme/App.theme';
 
 interface TwAppProps extends AppProps {
-  latestStories?: PriApiResource[];
+  latestStories?: IPriApiResource[];
   menus?: {
-    [K: string]: PriApiResource[];
+    [K: string]: IButton[];
   };
 }
 
@@ -30,39 +29,15 @@ interface TwAppState {
 
 class TwApp extends App<TwAppProps, {}, TwAppState> {
   static async getInitialProps(ctx: NextAppContext) {
+    const { req } = ctx.ctx;
     const initialProps = await App.getInitialProps(ctx);
 
     // Fetch Menus
-    const [
-      drawerMainNav,
-      drawerSocialNav,
-      drawerTopNav,
-      footerNav,
-      headerNav,
-      latestStories
-    ] = await Promise.all([
-      fetchPriApiQueryMenu('menu-drawer-main-nav'),
-      fetchPriApiQueryMenu('menu-drawer-social-nav'),
-      fetchPriApiQueryMenu('menu-drawer-top-nav'),
-      fetchPriApiQueryMenu('menu-footer'),
-      fetchPriApiQueryMenu('menu-header-nav'),
-      fetchPriApiQuery('node--stories', {
-        'filter[status]': 1,
-        sort: '-date_published',
-        range: 10
-      })
-    ]);
+    const data = await fetchApiApp(req);
 
     return {
       ...initialProps,
-      latestStories,
-      menus: {
-        drawerMainNav: parseMenu(drawerMainNav as ILink[]),
-        drawerSocialNav: parseMenu(drawerSocialNav as ILink[]),
-        drawerTopNav: parseMenu(drawerTopNav as ILink[]),
-        footerNav: parseMenu(footerNav as ILink[]),
-        headerNav: parseMenu(headerNav as ILink[])
-      }
+      ...data
     };
   }
 
@@ -97,12 +72,11 @@ class TwApp extends App<TwAppProps, {}, TwAppState> {
     const appClasses = cx({
       noJs: javascriptDisabled
     });
-    const copyrightDate = new Date().getFullYear();
 
     return (
       <ThemeProvider theme={baseMuiTheme}>
         <ThemeProvider theme={appTheme}>
-          <AppContext.Provider value={{ latestStories, menus, copyrightDate }}>
+          <AppContext.Provider value={{ latestStories, menus }}>
             <Box
               className={appClasses}
               minHeight="100vh"

--- a/pages/api/app.ts
+++ b/pages/api/app.ts
@@ -1,0 +1,42 @@
+/**
+ * @file app.ts
+ * Gather app data from CMS API.
+ */
+import { NextApiRequest, NextApiResponse } from 'next';
+import { fetchPriApiQuery, fetchPriApiQueryMenu } from '@lib/fetch/api';
+import { parseMenu } from '@lib/parse/menu';
+import { ILink } from '@interfaces/link';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const [
+    drawerMainNav,
+    drawerSocialNav,
+    drawerTopNav,
+    footerNav,
+    headerNav,
+    latestStories
+  ] = await Promise.all([
+    fetchPriApiQueryMenu('menu-drawer-main-nav'),
+    fetchPriApiQueryMenu('menu-drawer-social-nav'),
+    fetchPriApiQueryMenu('menu-drawer-top-nav'),
+    fetchPriApiQueryMenu('menu-footer'),
+    fetchPriApiQueryMenu('menu-header-nav'),
+    fetchPriApiQuery('node--stories', {
+      'filter[status]': 1,
+      sort: '-date_published',
+      range: 10
+    })
+  ]);
+  const apiResp = {
+    latestStories,
+    menus: {
+      drawerMainNav: parseMenu(drawerMainNav as ILink[]),
+      drawerSocialNav: parseMenu(drawerSocialNav as ILink[]),
+      drawerTopNav: parseMenu(drawerTopNav as ILink[]),
+      footerNav: parseMenu(footerNav as ILink[]),
+      headerNav: parseMenu(headerNav as ILink[])
+    }
+  };
+
+  res.status(200).json(apiResp);
+};

--- a/pages/api/homepage.ts
+++ b/pages/api/homepage.ts
@@ -1,41 +1,11 @@
 /**
- * @file Homepage.tsx
- * Component for Homepage.
+ * @file app.ts
+ * Gather homepage data from CMS API.
  */
-import React, { useContext } from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
-import { ContentContext } from '@contexts/ContentContext';
+import { NextApiRequest, NextApiResponse } from 'next';
 
-export const Homepage = () => {
-  const {
-    data: { links }
-  } = useContext(ContentContext);
-
-  return (
-    <>
-      <Head>
-        <title>The World</title>
-      </Head>
-      <h1>Hello, The World!</h1>
-      <p>Homepage coming soon...</p>
-      {links && (
-        <ul>
-          {links.map(({ href, label }) => (
-            <li key={label}>
-              <Link href={href} as={href.query.alias}>
-                <a>{label}</a>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
-    </>
-  );
-};
-
-Homepage.fetchData = async () => {
-  return {
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const apiResp = {
     type: 'homepage',
     links: [
       {
@@ -84,4 +54,6 @@ Homepage.fetchData = async () => {
       }
     ]
   };
+
+  res.status(200).json(apiResp);
 };

--- a/pages/api/query/alias/[...slugs].ts
+++ b/pages/api/query/alias/[...slugs].ts
@@ -1,0 +1,25 @@
+/**
+ * @file alias.ts
+ * Query API for data related to the provided URL path alias.
+ */
+import { NextApiRequest, NextApiResponse } from 'next';
+import { fetchPriApiQueryAlias } from '@lib/fetch/api';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const { slugs } = req.query;
+  const path = (slugs as string[]).join('/');
+
+  if (path.length) {
+    const apiResp = await fetchPriApiQueryAlias(path, {
+      fields: ['id']
+    });
+
+    if (apiResp) {
+      res.status(200).json(apiResp);
+    } else {
+      res.status(404);
+    }
+  }
+
+  res.status(400);
+};

--- a/pages/api/query/alias/[...slugs].ts
+++ b/pages/api/query/alias/[...slugs].ts
@@ -1,6 +1,6 @@
 /**
- * @file alias.ts
- * Query API for data related to the provided URL path alias.
+ * @file [..slugs].ts
+ * Query CMS API for data related to the provided URL path alias.
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchPriApiQueryAlias } from '@lib/fetch/api';
@@ -17,9 +17,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     if (apiResp) {
       res.status(200).json(apiResp);
     } else {
-      res.status(404);
+      res.status(404).json({});
     }
+
+    return;
   }
 
-  res.status(400);
+  res.status(400).json({});
 };

--- a/pages/api/story/[id].ts
+++ b/pages/api/story/[id].ts
@@ -1,0 +1,60 @@
+/**
+ * @file [id].ts
+ * Gather story data from CMS API.
+ */
+import { NextApiRequest, NextApiResponse } from 'next';
+import { fetchPriApiItem, fetchPriApiQuery } from '@lib/fetch/api';
+import { IPriApiResource } from 'pri-api-library/types';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const { id } = req.query;
+
+  if (id) {
+    const story = (await fetchPriApiItem('node--stories', id as string, {
+      include: [
+        'audio.program',
+        'byline.credit_type',
+        'byline.person',
+        'format',
+        'image',
+        'categories',
+        'opencalais_city',
+        'opencalais_continent',
+        'opencalais_country',
+        'opencalais_province',
+        'opencalais_region',
+        'opencalais_person',
+        'primary_category',
+        'program',
+        'tags',
+        'verticals',
+        'video'
+      ]
+    })) as IPriApiResource;
+
+    if (story) {
+      const { type, primaryCategory } = story;
+      const related =
+        primaryCategory &&
+        ((await fetchPriApiQuery('node--stories', {
+          'filter[primary_category]': primaryCategory.id,
+          'filter[status]': 1,
+          range: 4,
+          sort: '-date_published',
+          include: ['image'],
+          fields: ['image', 'metatags', 'title']
+        })) as IPriApiResource[]);
+      const apiResp = {
+        type,
+        story,
+        ...(related && { related })
+      };
+
+      res.status(200).json(apiResp);
+    } else {
+      res.status(404);
+    }
+  }
+
+  res.status(400);
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,12 +5,11 @@
 
 import React from 'react';
 import { NextPageContext } from 'next';
-import { useAmp } from 'next/amp';
 import Error from 'next/error';
 
 import { IPriApiResource } from 'pri-api-library/types';
 import { IContentComponentProxyProps } from '@interfaces/content';
-import { fetchApiQueryAlias } from '@lib/fetch/api';
+import { fetchApiQueryAlias, fetchApiContent } from '@lib/fetch/api';
 import { ContentContext } from '@contexts/ContentContext';
 import { importComponent, preloadComponent } from '@lib/import/component';
 
@@ -27,10 +26,9 @@ const ContentProxy = (props: IContentComponentProxyProps) => {
       data: { type }
     } = props;
     const ContentComponent = importComponent(type);
-    const isAmp = useAmp();
 
     output = (
-      <ContentContext.Provider value={{ data, isAmp }}>
+      <ContentContext.Provider value={{ data }}>
         <ContentComponent />
       </ContentContext.Provider>
     );
@@ -53,7 +51,7 @@ ContentProxy.getInitialProps = async (ctx: NextPageContext) => {
     const apiResp = await fetchApiQueryAlias(alias as string, req);
 
     // Update resource id and type.
-    if (apiResp) {
+    if (apiResp?.id) {
       const { id, type } = apiResp as IPriApiResource;
       resourceId = id;
       resourceType = type;
@@ -68,7 +66,7 @@ ContentProxy.getInitialProps = async (ctx: NextPageContext) => {
 
     // Use content comonent to fetch its data.
     if (ContentComponent) {
-      const data = await ContentComponent.fetchData(resourceId);
+      const data = await fetchApiContent(resourceType, resourceId, req);
 
       return { data };
     }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,13 +10,13 @@ import Error from 'next/error';
 
 import { IPriApiResource } from 'pri-api-library/types';
 import { IContentComponentProxyProps } from '@interfaces/content';
-import { fetchPriApiQueryAlias } from '@lib/fetch/api';
+import { fetchApiQueryAlias } from '@lib/fetch/api';
 import { ContentContext } from '@contexts/ContentContext';
 import { importComponent, preloadComponent } from '@lib/import/component';
 
 const ContentProxy = (props: IContentComponentProxyProps) => {
   const { errorCode } = props;
-  let output;
+  let output: any;
 
   // Render error page.
   if (errorCode) {
@@ -42,6 +42,7 @@ const ContentProxy = (props: IContentComponentProxyProps) => {
 ContentProxy.getInitialProps = async (ctx: NextPageContext) => {
   const {
     res,
+    req,
     query: { alias }
   } = ctx;
   let resourceId: string | number;
@@ -49,9 +50,7 @@ ContentProxy.getInitialProps = async (ctx: NextPageContext) => {
 
   // Get data for alias.
   if (alias) {
-    const apiResp = await fetchPriApiQueryAlias(alias as string, {
-      fields: ['id']
-    });
+    const apiResp = await fetchApiQueryAlias(alias as string, req);
 
     // Update resource id and type.
     if (apiResp) {
@@ -78,7 +77,7 @@ ContentProxy.getInitialProps = async (ctx: NextPageContext) => {
   // There was a problem locating components or data.
   const statusCode = 404;
 
-  if(res) {
+  if (res) {
     res.statusCode = statusCode;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1863,6 +1863,45 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
+"@vercel/build-utils@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-2.4.0.tgz#c756a3804f072cc693ebe0bbcc1adcce61b9f15c"
+  integrity sha512-VRXMLBPDcpFUHQMgHdgYHBl9SRwqNFb43tgkMdTYaNml2HgqlLNvNuINKlqwB2/Q/tARIWcm4jmPKR0gu1CaEQ==
+
+"@vercel/go@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@vercel/go/-/go-1.1.2.tgz#0b0067a56616e4c56eeac8a8b33a9bb64a79be71"
+  integrity sha512-1k7w6gY2Uj4DVqvvqm5VXZZeCqmzV5Fw3T3hjfgt13WVXPVwYfXf50ya4VvwpF9/IEvXpAhXLRcHD7ZTCMoXKA==
+
+"@vercel/next@2.6.7":
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/@vercel/next/-/next-2.6.7.tgz#e522ab1e4c2af83b51df430dec1f98f64d7d202e"
+  integrity sha512-zzcalT/TRpI7EH4glRqhD09jkeGqbjZ4JbiOkCdwTAMJDme8bf6wsYffBGu92DLv/2zDFPLj0EcNsGVhb7bk0w==
+
+"@vercel/node@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@vercel/node/-/node-1.7.1.tgz#cdf9b2226cbc469228aae6369b2b21db4c83dc69"
+  integrity sha512-Lp6l3526xQ/srCqkXE9/E+gykAcpM/vut4zFo5NA9+syGxZt1nlVAznhNVkgsSW4mbRIE67KIfi7SII55dW7uw==
+  dependencies:
+    "@types/node" "*"
+    ts-node "8.9.1"
+    typescript "3.9.3"
+
+"@vercel/python@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@vercel/python/-/python-1.2.2.tgz#52e8e2a0d3a65153b8bd25a63db36b704aafde72"
+  integrity sha512-+rHfbjJaySdac59Oa11a7/nZzpXC98Kqw5tPh8DT1I5OG8YTfgJnwgfBoytZOAZZQBcggoJspnjAd+wGVCoVXw==
+
+"@vercel/ruby@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@vercel/ruby/-/ruby-1.2.2.tgz#0a6ef704d9eec7a88d3bf12f462cd52046b75361"
+  integrity sha512-5kKFNS84EvjHRI/umZqL31KdyvoWO05qbIeR3YHHJBCPSBIUlGimM0Wx7OsdAK+TMDzpWszBF/6bgk//KpmYbg==
+
+"@vercel/static-build@0.17.3":
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/@vercel/static-build/-/static-build-0.17.3.tgz#43ce2f605df946c11b697b5bf1b8f91cdc148cf6"
+  integrity sha512-Xf4b6AEVl5EnTSecG0p9hwi3F4MuvwsYyGmvhbNfoV5c8T4Q9gPgTY0f738OAUv1f81DdzRXcgijK4rFQ1ysTQ==
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -2239,6 +2278,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -3912,7 +3956,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.2.6:
+debug@^3.0.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3943,11 +3987,6 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -4035,11 +4074,6 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
-
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -4059,6 +4093,11 @@ diff-sequences@^25.2.0:
   version "25.2.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.0.tgz#180bd89ff45c490b175de6dbb1d346db7b998a94"
   integrity sha512-qTbUrz80F9q6rmEZjUoK2/SQTwgaOvnE5WjKlemKuod1iuB4WlSjY5ft2VUXacsqD9pXrWmERMPLi+j9RldxGg==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -5208,13 +5247,6 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -5736,7 +5768,7 @@ hyphenate-style-name@^1.0.3:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5783,13 +5815,6 @@ ignore-loader@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ignore-loader/-/ignore-loader-0.1.2.tgz#d81f240376d0ba4f0d778972c3ad25874117a463"
   integrity sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -5889,7 +5914,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -7431,7 +7456,7 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -7684,21 +7709,6 @@ minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mississippi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
@@ -7838,15 +7848,6 @@ nearley@^2.7.10:
     railroad-diagrams "^1.0.0"
     randexp "0.4.6"
     semver "^5.4.1"
-
-needle@^2.2.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.3.tgz#a041ad1d04a871b0ebb666f40baaf1fb47867117"
-  integrity sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -8055,22 +8056,6 @@ node-notifier@^6.0.0:
     shellwords "^0.1.1"
     which "^1.3.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.44, node-releases@^1.1.52:
   version "1.1.52"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.52.tgz#bcffee3e0a758e92e44ecfaecd0a47554b0bcba9"
@@ -8107,14 +8092,6 @@ node-sass@^4.12.0:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-html-whitespace@1.0.0:
   version "1.0.0"
@@ -8158,26 +8135,18 @@ normalize-url@1.9.1:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+now@^19.1.1:
+  version "19.1.1"
+  resolved "https://registry.yarnpkg.com/now/-/now-19.1.1.tgz#260f4bdc74e6ee233bd2d93eea7f9a912ae0e5ce"
+  integrity sha512-rRnPdv0yH+/bn2KaqS8XnPcUz0d762t9dGtPOQhX60kN5i8JT2ms3fW8hJ30Y3ziO2EBqHQdGyYcj9Mt3jcMdQ==
   dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
+    "@vercel/build-utils" "2.4.0"
+    "@vercel/go" "1.1.2"
+    "@vercel/next" "2.6.7"
+    "@vercel/node" "1.7.1"
+    "@vercel/python" "1.2.2"
+    "@vercel/ruby" "1.2.2"
+    "@vercel/static-build" "0.17.3"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -8193,7 +8162,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -8410,7 +8379,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.4:
+osenv@0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -9499,16 +9468,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-copy-to-clipboard@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.2.tgz#d82a437e081e68dfca3761fbd57dbf2abdda1316"
@@ -10045,7 +10004,7 @@ rework@1.0.1:
     convert-source-map "^0.3.3"
     css "^2.0.0"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -10177,7 +10136,7 @@ sass-loader@8.0.2:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
-sax@^1.2.4, sax@~1.2.1:
+sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -10232,7 +10191,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -10464,6 +10423,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.16"
@@ -10810,11 +10777,6 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 style-loader@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.0.0.tgz#1d5296f9165e8e2c85d24eee0b7caf9ec8ca1f82"
@@ -10929,19 +10891,6 @@ tar@^2.0.0:
     block-stream "*"
     fstream "^1.0.12"
     inherits "2"
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -11222,6 +11171,17 @@ ts-jest@^25.0.0:
     semver "^5.5"
     yargs-parser "^16.1.0"
 
+ts-node@8.9.1:
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.9.1.tgz#2f857f46c47e91dcd28a14e052482eb14cfd65a5"
+  integrity sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-pnp@^1.1.2:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"
@@ -11317,6 +11277,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
+  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
 typescript@^3.6.4:
   version "3.8.3"
@@ -11905,7 +11870,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
@@ -11982,3 +11947,8 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
 Closes #77 

- Adds proxy API endpoints so browser doesn't communicate with remote API directly and receive cookies from API server.

## To Review
- [x] Use the Preview link located in the Now comment below.

>  ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `now dev`.
- [ ] Go to [localhost:3000](https://localhost:3000).

>  ...then...

- [x] Open inspector and go to Network tab.
- [x] Click on a homepage link to load that story.
- [x] Note that fewer requests are being made.
- [x] Go to Application tab and look at the cookies for the localhost domain.
- [x] If you see cookies, clear them then visit another story.
- [x] Note that no cookies are created.
