### PR TITLE
#32: Term pages

### DIFF
--- a/components/Bio/Bio.tsx
+++ b/components/Bio/Bio.tsx
@@ -235,10 +235,7 @@ export const Bio = () => {
   return (
     <>
       <Head>
-        <title>
-          {title}
-          {page > 1 ? ` - Page ${page}` : ''}
-        </title>
+        <title>{title}</title>
       </Head>
       <BioHeader
         title={title}

--- a/components/Category/Category.tsx
+++ b/components/Category/Category.tsx
@@ -264,10 +264,7 @@ export const Category = () => {
   return (
     <>
       <Head>
-        <title>
-          {title}
-          {page > 1 ? ` - Page ${page}` : ''}
-        </title>
+        <title>{title}</title>
       </Head>
       <LandingPageHeader
         title={title}

--- a/components/ResourceComponentMap.ts
+++ b/components/ResourceComponentMap.ts
@@ -7,6 +7,7 @@ const DynamicHomepage = dynamic(() => import('./Homepage') as any);
 const DynamicNewsletter = dynamic(() => import('./Newsletter') as any);
 const DynamicProgram = dynamic(() => import('./Program') as any);
 const DynamicStory = dynamic(() => import('./Story') as any);
+const DynamicTerm = dynamic(() => import('./Term') as any);
 
 // Map dyanmic component to a data/resource type.
 export const ResourceComponentMap = {
@@ -15,5 +16,6 @@ export const ResourceComponentMap = {
   'node--people': DynamicBio,
   'node--programs': DynamicProgram,
   'node--stories': DynamicStory,
-  'taxonomy_term--categories': DynamicCategory
+  'taxonomy_term--categories': DynamicCategory,
+  'taxonomy_term--terms': DynamicTerm
 };

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -8,6 +8,7 @@ import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
 import Link from 'next/link';
 import {
+  Box,
   Button,
   Card,
   CardActionArea,
@@ -55,13 +56,15 @@ export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
     <ThemeProvider theme={sidebarEpisodeTheme}>
       <Card square elevation={1}>
         <CardActionArea>
-          <CardMedia>
-            <Image
-              data={image}
-              width={imageWidth}
-              wrapperClassName={classes.imageWrapper}
-            />
-          </CardMedia>
+          {image && (
+            <CardMedia>
+              <Image
+                data={image}
+                width={imageWidth}
+                wrapperClassName={classes.imageWrapper}
+              />
+            </CardMedia>
+          )}
           <CardContent>
             {label && (
               <Typography variant="overline" gutterBottom>
@@ -81,8 +84,11 @@ export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
               />{' '}
               {title}
             </Typography>
-            <Typography variant="body1" component="p" color="textSecondary">
-              {teaser}
+            <Typography variant="body1" component="div" color="textSecondary">
+              <Box
+                className={cx('body')}
+                dangerouslySetInnerHTML={{ __html: teaser }}
+              />
             </Typography>
             <ContentLink data={data} className={cx('link')} />
           </CardContent>

--- a/components/Story/layouts/default/Story.default.tsx
+++ b/components/Story/layouts/default/Story.default.tsx
@@ -46,7 +46,13 @@ export const StoryDefault = ({ data }: Props) => {
     popoutPlayerUrl,
     categories,
     primaryCategory,
-    tags
+    tags,
+    opencalaisCity,
+    opencalaisContinent,
+    opencalaisCountry,
+    opencalaisProvince,
+    opencalaisRegion,
+    opencalaisPerson
   } = data;
   const store = useStore();
   const state = store.getState();
@@ -88,7 +94,16 @@ export const StoryDefault = ({ data }: Props) => {
   const classes = storyStyles({});
   const hasRelated = related && !!related.length;
   const hasCategories = categories && !!categories.length;
-  const hasTags = tags && !!tags.length;
+  const allTags = [
+    ...(tags || []),
+    ...(opencalaisCity || []),
+    ...(opencalaisContinent || []),
+    ...(opencalaisCountry || []),
+    ...(opencalaisProvince || []),
+    ...(opencalaisRegion || []),
+    ...(opencalaisPerson || [])
+  ];
+  const hasTags = !!allTags.length;
 
   // TODO: Parse body...
   //    - Insert mobile ad positions
@@ -134,7 +149,7 @@ export const StoryDefault = ({ data }: Props) => {
                   </aside>
                 )}
                 {hasCategories && <Tags data={categories} label="Categories" />}
-                {hasTags && <Tags data={tags} label="Tags" />}
+                {hasTags && <Tags data={allTags} label="Tags" />}
               </Box>
               <Sidebar container className={classes.sidebar}>
                 {latestStories && (

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -64,13 +64,15 @@ export const StoryCard = ({ data, feature }: StoryCardProps) => {
     <ThemeProvider theme={storyCardTheme}>
       <Card square elevation={1} className={cx({ feature })}>
         <CardActionArea classes={{ root: classes.MuiCardActionAreaRoot }}>
-          <CardMedia classes={{ root: classes.MuiCardMediaRoot }}>
-            <Image
-              data={image}
-              width={imageWidth}
-              wrapperClassName={classes.imageWrapper}
-            />
-          </CardMedia>
+          {image && (
+            <CardMedia classes={{ root: classes.MuiCardMediaRoot }}>
+              <Image
+                data={image}
+                width={imageWidth}
+                wrapperClassName={classes.imageWrapper}
+              />
+            </CardMedia>
+          )}
           <CardContent classes={{ root: classes.MuiCardContentRoot }}>
             {primaryCategory && (
               <Typography variant="overline" gutterBottom>

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -79,13 +79,15 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
             return (
               <Card square elevation={1} key={id}>
                 <CardActionArea>
-                  <CardMedia>
-                    <Image
-                      data={image}
-                      width={imageWidth}
-                      wrapperClassName={cxCard('imageWrapper')}
-                    />
-                  </CardMedia>
+                  {image && (
+                    <CardMedia>
+                      <Image
+                        data={image}
+                        width={imageWidth}
+                        wrapperClassName={cxCard('imageWrapper')}
+                      />
+                    </CardMedia>
+                  )}
                   <CardContent>
                     {primaryCategory && (
                       <Typography variant="overline" gutterBottom>

--- a/components/Tags/Tags.styles.ts
+++ b/components/Tags/Tags.styles.ts
@@ -23,12 +23,14 @@ export const tagsStyles = makeStyles((theme: Theme) =>
       fontWeight: theme.typography.fontWeightBold
     },
     tag: {
+      textTransform: 'capitalize',
       '&::after': {
         content: '",\x20"'
       },
       '&:last-child': {
         '&:before': {
-          content: '"and\x20"'
+          content: '"and\x20"',
+          textTransform: 'none'
         },
         '&::after': {
           content: 'none'

--- a/components/Term/Term.tsx
+++ b/components/Term/Term.tsx
@@ -1,6 +1,6 @@
 /**
- * @file Program.tsx
- * Component for Program.
+ * @file Term.tsx
+ * Component for Term.
  */
 import React, { useContext, useEffect, useState } from 'react';
 import { IncomingMessage } from 'http';
@@ -10,13 +10,7 @@ import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
-import {
-  Box,
-  Button,
-  Hidden,
-  ListSubheader,
-  Typography
-} from '@material-ui/core';
+import { Box, Button, Hidden, Typography } from '@material-ui/core';
 import { MenuBookRounded, NavigateNext } from '@material-ui/icons';
 import { LandingPage } from '@components/LandingPage';
 import { CtaRegion } from '@components/CtaRegion';
@@ -29,7 +23,7 @@ import {
 } from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
-import { fetchApiProgram, fetchApiProgramStories } from '@lib/fetch';
+import { fetchApiTerm, fetchApiTermStories } from '@lib/fetch';
 import { LandingPageHeader } from '@components/LandingPageHeader';
 import { SidebarEpisode } from '@components/Sidebar/SidebarEpisode';
 import { SidebarContent } from '@components/Sidebar/SidebarContent';
@@ -42,7 +36,7 @@ import {
   getDataByResource
 } from '@store/reducers';
 
-export const Program = () => {
+export const Term = () => {
   const {
     page: {
       resource: { type, id }
@@ -103,15 +97,7 @@ export const Program = () => {
     'latest episode'
   );
   const latestEpisode = latestEpisodeState && latestEpisodeState.items[0];
-  const {
-    title,
-    teaser,
-    bannerImage,
-    podcastLogo,
-    hosts,
-    sponsors,
-    body
-  } = data;
+  const { title, description } = data;
   const [loading, setLoading] = useState(false);
   const [oldscrollY, setOldScrollY] = useState(0);
 
@@ -125,7 +111,7 @@ export const Program = () => {
   const loadMoreStories = async () => {
     setLoading(true);
 
-    const { data: moreStories } = await fetchApiProgramStories(id, page + 1);
+    const { data: moreStories } = await fetchApiTermStories(id, page + 1);
 
     setOldScrollY(window.scrollY);
     setLoading(false);
@@ -205,28 +191,15 @@ export const Program = () => {
           {latestEpisode && (
             <SidebarEpisode data={latestEpisode} label="Latest Edition" />
           )}
-          <Box mt={2}>
-            <Sidebar item elevated>
-              {body && (
-                <SidebarContent dangerouslySetInnerHTML={{ __html: body }} />
-              )}
-              {hosts && !!hosts.length && (
-                <SidebarList
-                  data={hosts.map((item: IPriApiResource) => ({
-                    ...item,
-                    avatar: item.image
-                  }))}
-                  subheader={<ListSubheader>Hosted by</ListSubheader>}
+          {description && (
+            <Box mt={2}>
+              <Sidebar item elevated>
+                <SidebarContent
+                  dangerouslySetInnerHTML={{ __html: description }}
                 />
-              )}
-              {sponsors && !!sponsors.length && (
-                <SidebarList
-                  data={sponsors}
-                  subheader={<ListSubheader>Supported by</ListSubheader>}
-                />
-              )}
-            </Sidebar>
-          </Box>
+              </Sidebar>
+            </Box>
+          )}
           {ctaSidebarTop && (
             <Box mt={3}>
               <Hidden only="sm">
@@ -285,25 +258,20 @@ export const Program = () => {
       <Head>
         <title>{title}</title>
       </Head>
-      <LandingPageHeader
-        title={title}
-        subhead={teaser}
-        image={bannerImage}
-        logo={podcastLogo}
-      />
+      <LandingPageHeader title={title} subhead={description} />
       <LandingPage main={mainElements} sidebar={sidebarElements} />
     </>
   );
 };
 
-Program.fetchData = (
+Term.fetchData = (
   id: string,
   req: IncomingMessage
 ): ThunkAction<void, {}, {}, AnyAction> => async (
   dispatch: ThunkDispatch<{}, {}, AnyAction>,
   getState: () => RootState
 ): Promise<void> => {
-  const type = 'node--programs';
+  const type = 'taxonomy_term--terms';
   const state = getState();
   const data = getDataByResource(state, type, id);
 
@@ -323,7 +291,7 @@ Program.fetchData = (
       latestEpisode,
       stories,
       ...payload
-    } = await fetchApiProgram(id, req);
+    } = await fetchApiTerm(id, req);
 
     dispatch({
       type: 'FETCH_CONTENT_DATA_SUCCESS',
@@ -351,7 +319,7 @@ Program.fetchData = (
   }
 
   // Get CTA message data.
-  const context = [`node:${id}`];
+  const context = [`term:${id}`];
   await dispatch<any>(
     fetchCtaData('tw_cta_regions_landing', type, id, context, req)
   );

--- a/components/Term/index.ts
+++ b/components/Term/index.ts
@@ -1,0 +1,2 @@
+export * from './Term';
+export { Term as default } from './Term'; // eslint-disable-line import/no-default-export

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -218,7 +218,7 @@ export const fetchApiProgramStories = async (
  *    Request object from `getInitialProps` ctx object.
  *
  * @returns
- *    Story data object.
+ *    Category data object.
  */
 export const fetchApiCategory = async (
   id: string,
@@ -259,6 +259,51 @@ export const fetchApiCategoryStories = async (
   });
 
 /**
+ * Method that simplifies GET queries for term data.
+ *
+ * @param id
+ *    API id of term.
+ * @param req
+ *    Request object from `getInitialProps` ctx object.
+ *
+ * @returns
+ *    Term data object.
+ */
+export const fetchApiTerm = async (
+  id: string,
+  req?: IncomingMessage
+): Promise<IPriApiResource> => fetchApi(`term/${id}`, req);
+
+/**
+ * Method that simplifies GET queries for term stories data.
+ *
+ * @param id
+ *    API id of term.
+ * @param page
+ *    Page number of stories to return.
+ * @param range
+ *    Number of stories to return for the page.
+ * @param exclude
+ *    Array of story ids to exclude from query.
+ * @param req
+ *    Request object from `getInitialProps` ctx object.
+ *
+ * @returns
+ *    Promise that returns Collection of Story data objects.
+ */
+export const fetchApiTermStories = async (
+  id: string,
+  page: number = 1,
+  range?: number,
+  exclude?: string[],
+  req?: IncomingMessage
+): Promise<{ data: IPriApiResource[] }> =>
+  fetchApi(`term/${id}/stories/${page}`, req, {
+    ...(range && { range: `${range}` }),
+    ...(exclude && { exclude })
+  });
+
+/**
  * Method that simplifies GET queries for person data.
  *
  * @param id
@@ -267,7 +312,7 @@ export const fetchApiCategoryStories = async (
  *    Request object from `getInitialProps` ctx object.
  *
  * @returns
- *    Story data object.
+ *    Person data object.
  */
 export const fetchApiPerson = async (
   id: string,

--- a/pages/api/term/[id]/index.ts
+++ b/pages/api/term/[id]/index.ts
@@ -1,0 +1,67 @@
+/**
+ * @file category/[id]/index.ts
+ * Gather category data from CMS API.
+ */
+import { NextApiRequest, NextApiResponse } from 'next';
+import { IPriApiResource } from 'pri-api-library/types';
+import {
+  fetchApiTermStories,
+  fetchPriApiItem,
+  fetchPriApiQuery
+} from '@lib/fetch/api';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const { id } = req.query;
+
+  if (id) {
+    const term = (await fetchPriApiItem(
+      'taxonomy_term--terms',
+      id as string,
+      {}
+    )) as IPriApiResource;
+
+    if (term) {
+      const { featuredStories } = term;
+
+      // Fetch list of stories. Paginated.
+      const { data: stories } = await fetchApiTermStories(
+        id as string,
+        1,
+        undefined,
+        undefined,
+        req
+      );
+
+      // Latest Episode
+      const latestEpisode = await fetchPriApiQuery('node--episodes', {
+        include: ['image', 'audio.segments'],
+        'filter[status]': 1,
+        'filter[tags][value]': id,
+        'filter[tags][operator]': '"CONTAINS"',
+        sort: '-date_published',
+        range: 1
+      }).then((resp: IPriApiResource[]) => resp.shift());
+
+      // Build response object.
+      const apiResp = {
+        ...term,
+        featuredStory: featuredStories
+          ? featuredStories.shift()
+          : stories.shift(),
+        featuredStories: featuredStories
+          ? featuredStories.concat(
+              stories.splice(0, 4 - featuredStories.length)
+            )
+          : stories.splice(0, 4),
+        stories,
+        latestEpisode
+      };
+
+      res.status(200).json(apiResp);
+    } else {
+      res.status(404);
+    }
+  }
+
+  res.status(400);
+};

--- a/pages/api/term/[id]/stories/[page].ts
+++ b/pages/api/term/[id]/stories/[page].ts
@@ -1,0 +1,79 @@
+/**
+ * @file term/[id]/stories.ts
+ * Gather term stories data from CMS API.
+ */
+import { NextApiRequest, NextApiResponse } from 'next';
+import _ from 'lodash';
+import { IPriApiResource } from 'pri-api-library/types';
+import { fetchPriApiItem, fetchPriApiQuery } from '@lib/fetch/api';
+import { basicStoryParams } from '@lib/fetch/api/params';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const { id, page = '1', range = 15, exclude } = req.query;
+  const storyTermFields = [
+    'opencalais_city',
+    'opencalais_continent',
+    'opencalais_country',
+    'opencalais_province',
+    'opencalais_region',
+    'opencalais_person',
+    'tags'
+  ];
+
+  if (id) {
+    const term = (await fetchPriApiItem(
+      'taxonomy_term--terms',
+      id as string
+    )) as IPriApiResource;
+
+    if (term) {
+      const { featuredStories } = term;
+      const excluded = (exclude || featuredStories) && [
+        ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
+        ...(featuredStories ? featuredStories.map(({ id: i }) => i) : [])
+      ];
+
+      // Fetch list of stories. Paginated.
+      const data = _.orderBy(
+        (await Promise.all(
+          storyTermFields.map(field =>
+            fetchPriApiQuery('node--stories', {
+              ...basicStoryParams,
+              'filter[status]': 1,
+              [`filter[${field}]`]: id,
+              ...(excluded && {
+                'filter[id][value]': excluded,
+                'filter[id][operator]': '<>'
+              }),
+              sort: '-date_published',
+              range,
+              page
+            })
+          )
+        ).then(resp =>
+          resp.reduce(
+            (acc, stories) =>
+              stories
+                ? {
+                    ...acc,
+                    ...stories
+                  }
+                : acc,
+            []
+          )
+        )) as IPriApiResource[],
+        story => story.datePublished,
+        'desc'
+      );
+
+      // Build response object.
+      const apiResp = { data };
+
+      res.status(200).json(apiResp);
+    } else {
+      res.status(404).end();
+    }
+  }
+
+  res.status(400).end();
+};


### PR DESCRIPTION
Closes #32 

- Adds pages for Terms (tags, open calais fields, etc.)

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Look up the alias for your favorite term, preferably one that has been used a lot, such as `country/united-states`.
- [x] Ensure layout looks as expected.
- [x] Ensure additional stories load when you click the __More Stories__ button.
