### PR TITLE
#130: Handle missing story image

### DIFF
--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -16,7 +16,7 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
     root: {},
     title: {
       [theme.breakpoints.down('xs')]: {
-        fontSize: '16px',
+        fontSize: theme.typography.pxToRem(16),
         '$feature &': {
           fontSize: theme.typography.pxToRem(22)
         }
@@ -55,6 +55,7 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
         gridTemplateColumns: '100px 1fr',
         alignItems: 'center'
       },
+      '$noImage &': {},
       '$feature &': {
         display: 'flex',
         gridGap: 0,

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -62,7 +62,7 @@ export const StoryCard = ({ data, feature }: StoryCardProps) => {
 
   return (
     <ThemeProvider theme={storyCardTheme}>
-      <Card square elevation={1} className={cx({ feature })}>
+      <Card square elevation={1} className={cx({ feature: feature || !image })}>
         <CardActionArea classes={{ root: classes.MuiCardActionAreaRoot }}>
           {image && (
             <CardMedia classes={{ root: classes.MuiCardMediaRoot }}>

--- a/components/pages/Story/layouts/default/components/StoryLede/StoryLede.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryLede/StoryLede.default.tsx
@@ -15,7 +15,7 @@ interface Props {
 export const StoryLede = ({ data }: Props) => {
   const { image, video } = data;
 
-  return (
+  return image || video ? (
     <>
       {(video && <LedeVideo data={video[0]} />) || (
         <LedeImage
@@ -30,5 +30,5 @@ export const StoryLede = ({ data }: Props) => {
         />
       )}
     </>
-  );
+  ) : null;
 };


### PR DESCRIPTION
- default story layout renders w/o error
- story card looks better

Closes #130 

- Default story views should no longer fatal error when image is missing.
- Story card layout should look better when an image is missing.

## To Review

- [x] Use the Preview link located in the Now comment below.

> ...or...

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to 3rd page of this bio: `people/rebecca-kanthor`
- [x] Visit the story without the image.
