### PR TITLE
#132: Handle external redirects for aliases

### DIFF
--- a/interfaces/content/content.interface.ts
+++ b/interfaces/content/content.interface.ts
@@ -26,6 +26,7 @@ export interface IContentComponentProxyProps {
   type?: string;
   id?: string;
   errorCode?: number;
+  redirect?: string;
 }
 
 export interface IContentContext {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@
  * Exports the Home component.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { NextPageContext } from 'next';
 import Error from 'next/error';
@@ -23,12 +23,16 @@ interface StateProps extends RootState {}
 type Props = StateProps & DispatchProps & IContentComponentProxyProps;
 
 const ContentProxy = (props: Props) => {
-  const { errorCode } = props;
-  let output: JSX.Element;
+  const { errorCode, redirect } = props;
+  let output: JSX.Element = <></>;
 
   if (errorCode) {
     // Render error page.
     output = <Error statusCode={errorCode} />;
+  } else if (redirect) {
+    useEffect(() => {
+      window.location.assign(redirect);
+    });
   } else {
     // Render content component.
     const { type, id } = props;
@@ -51,7 +55,7 @@ ContentProxy.getInitialProps = async (
   } = ctx;
   let resourceId: string;
   let resourceType: string = 'homepage';
-  // let state = store.getState() as RootState;
+  let redirect: string;
 
   // Get data for alias.
   if (alias) {
@@ -60,13 +64,20 @@ ContentProxy.getInitialProps = async (
     );
 
     // Update resource id and type.
-    if (aliasData?.id) {
+    if (aliasData?.type === 'redirect--external') {
+      redirect = aliasData.url;
+    } else if (aliasData?.id) {
       const { id, type } = aliasData as IPriApiResource;
       resourceId = id as string;
       resourceType = type;
     } else {
       resourceType = null;
     }
+  }
+
+  // Return object with redirect url.
+  if (redirect) {
+    return { redirect };
   }
 
   // Preload content component.


### PR DESCRIPTION
Closes #132 

- Adds logic to do redirect to external URL returned from alias look up query.

## To Review
- [x] Make sure your Lando server is running the branch from PublicRadioInternational/pri.org#1500

> ...then...

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Visit `http://localhost:3000/survey`.
- [x] Ensure it redirects you to the external page.
