### PR TITLE
#98: Add Team Page

### DIFF
--- a/components/AppLoadingBar/AppLoadingBar.tsx
+++ b/components/AppLoadingBar/AppLoadingBar.tsx
@@ -30,7 +30,7 @@ export const AppLoadingBar = () => {
   });
 
   useEffect(() => {
-    if (!isLoading && !wasLoading) {
+    if (!isLoading && !wasLoading && progress > 0) {
       setTimeout(() => {
         setBuffer(0);
         setProgress(0);

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -76,20 +76,12 @@ export const Bio = () => {
     'featured story'
   );
   const featuredStory = featuredStoryState.items[1][0];
-  const { items: featuredStories } = getCollectionData(
-    state,
-    type,
-    id,
-    'featured stories'
-  );
+  const { items: featuredStories } =
+    getCollectionData(state, type, id, 'featured stories') || {};
   const storiesState = getCollectionData(state, type, id, 'stories');
-  const { items: stories, page, next } = storiesState;
-  const { items: latestStories } = getCollectionData(
-    state,
-    'app',
-    undefined,
-    'latest'
-  );
+  const { items: stories, page, next } = storiesState || {};
+  const { items: latestStories } =
+    getCollectionData(state, 'app', undefined, 'latest') || {};
   const segmentsState = getCollectionData(state, type, id, 'segments');
   const { items: segments, count: segmentsCount, size: segmentsSize } =
     segmentsState || {};
@@ -324,7 +316,7 @@ Bio.fetchData = (
   const data = getDataByResource(state, type, id);
 
   // Get missing content data.
-  if (!data) {
+  if (!data?.complete) {
     dispatch({
       type: 'FETCH_CONTENT_DATA_REQUEST',
       payload: {
@@ -343,7 +335,10 @@ Bio.fetchData = (
 
     dispatch({
       type: 'FETCH_CONTENT_DATA_SUCCESS',
-      payload
+      payload: {
+        ...payload,
+        complete: true
+      }
     });
 
     dispatch(

--- a/components/pages/ResourceComponentMap.ts
+++ b/components/pages/ResourceComponentMap.ts
@@ -10,6 +10,7 @@ const DynamicNewsletter = dynamic(() => import('./Newsletter') as any);
 const DynamicPage = dynamic(() => import('./Page') as any);
 const DynamicProgram = dynamic(() => import('./Program') as any);
 const DynamicStory = dynamic(() => import('./Story') as any);
+const DynamicTeam = dynamic(() => import('./Team') as any);
 const DynamicTerm = dynamic(() => import('./Term') as any);
 
 // Map dyanmic component to a data/resource type.
@@ -23,5 +24,6 @@ export const ResourceComponentMap = {
   'node--programs': DynamicProgram,
   'node--stories': DynamicStory,
   'taxonomy_term--categories': DynamicCategory,
-  'taxonomy_term--terms': DynamicTerm
+  'taxonomy_term--terms': DynamicTerm,
+  team: DynamicTeam
 };

--- a/components/pages/Team/Team.styles.ts
+++ b/components/pages/Team/Team.styles.ts
@@ -1,0 +1,89 @@
+/**
+ * @file Team.styles.tsx
+ * Theme and styles for Team layout.
+ */
+
+import {
+  createMuiTheme,
+  createStyles,
+  makeStyles,
+  Theme
+} from '@material-ui/core/styles';
+
+export const teamTheme = (theme: Theme) =>
+  createMuiTheme(theme, {
+    typography: {
+      h1: {
+        fontSize: theme.typography.pxToRem(46)
+      },
+      h4: {
+        fontSize: theme.typography.pxToRem(20)
+      }
+    },
+    overrides: {
+      MuiCard: {
+        root: {
+          height: '100%',
+          color: theme.palette.primary.main
+        }
+      },
+      MuiCardActionArea: {
+        root: {
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'start',
+          alignItems: 'stretch',
+          height: '100%'
+        }
+      },
+      MuiCardMedia: {
+        root: {
+          position: 'relative',
+          width: '100%'
+        }
+      },
+      MuiCardContent: {
+        root: {
+          position: 'relative',
+          overflow: 'hidden',
+          color: theme.palette.text.primary
+        }
+      },
+      MuiDivider: {
+        root: {
+          marginBottom: theme.typography.pxToRem(theme.spacing(3))
+        }
+      }
+    }
+  });
+
+export const teamStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    imageWrapper: {
+      paddingTop: '100%'
+    },
+    link: {
+      position: 'absolute',
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      overflow: 'hidden',
+      textIndent: '-2000vw'
+    },
+    loadingBar: {
+      transition: 'transform 400ms ease-out',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      transform: 'translateY(-100%)',
+      '$isLoading &': {
+        transform: 'translateY(0)'
+      }
+    },
+    isLoading: {
+      boxShadow: theme.shadows[5]
+    }
+  })
+);

--- a/components/pages/Team/Team.tsx
+++ b/components/pages/Team/Team.tsx
@@ -1,0 +1,110 @@
+/**
+ * @file Team.tsx
+ * Component for Team.
+ */
+import React, { useContext } from 'react';
+import { IncomingMessage } from 'http';
+import Head from 'next/head';
+import { AnyAction } from 'redux';
+import { useStore } from 'react-redux';
+import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import classNames from 'classnames/bind';
+import { IPriApiResource } from 'pri-api-library/types';
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  CardMedia,
+  Container,
+  Grid,
+  LinearProgress,
+  Typography
+} from '@material-ui/core';
+import { ThemeProvider } from '@material-ui/core/styles';
+import { Image } from '@components/Image';
+import { ContentLink } from '@components/ContentLink';
+import { AppContext } from '@contexts/AppContext';
+import { fetchTeamData } from '@store/actions';
+import { getCollectionData, getLoading } from '@store/reducers';
+import { teamStyles, teamTheme } from './Team.styles';
+import { TeamHeader } from './components/TeamHeader';
+
+export const Team = () => {
+  const {
+    page: {
+      resource: { type, id }
+    }
+  } = useContext(AppContext);
+  const store = useStore();
+  const state = store.getState();
+  const classes = teamStyles({});
+  const cx = classNames.bind(classes);
+  const title = 'The World Team';
+  const { items } = getCollectionData(state, type, id, 'members');
+  const loading = getLoading(state);
+  const isLoading = (item: IPriApiResource) =>
+    item.id === loading.id && item.type === loading.type;
+
+  return (
+    <ThemeProvider theme={teamTheme}>
+      <Head>
+        <title>{title}</title>
+        {/* TODO: WIRE UP ANALYTICS */}
+      </Head>
+      <Container fixed>
+        <TeamHeader title={title} />
+        <Grid container spacing={3}>
+          {items
+            .reduce((a, p) => [...a, ...p], [])
+            .map((item: IPriApiResource) => (
+              <Grid item xs={12} sm={6} md={4} lg={3} key={item.id}>
+                <Card
+                  className={cx({
+                    [classes.isLoading]: isLoading(item) || false
+                  })}
+                >
+                  <CardActionArea>
+                    {item.image && (
+                      <CardMedia>
+                        <Image
+                          data={item.image}
+                          width={{
+                            xl: 290,
+                            lg: 290,
+                            md: 288,
+                            sm: 264,
+                            xs: '100vw'
+                          }}
+                          wrapperClassName={classes.imageWrapper}
+                        />
+                      </CardMedia>
+                    )}
+                    <CardContent>
+                      <LinearProgress
+                        className={classes.loadingBar}
+                        color="secondary"
+                      />
+                      <Typography variant="h4">{item.title}</Typography>
+                      <Typography variant="subtitle1">
+                        {item.position}
+                      </Typography>
+                    </CardContent>
+                    <ContentLink data={item} className={classes.link} />
+                  </CardActionArea>
+                </Card>
+              </Grid>
+            ))}
+        </Grid>
+      </Container>
+    </ThemeProvider>
+  );
+};
+
+Team.fetchData = (
+  id: string,
+  req: IncomingMessage
+): ThunkAction<void, {}, {}, AnyAction> => async (
+  dispatch: ThunkDispatch<{}, {}, AnyAction>
+): Promise<void> => {
+  await dispatch<any>(fetchTeamData(req));
+};

--- a/components/pages/Team/Team.tsx
+++ b/components/pages/Team/Team.tsx
@@ -39,7 +39,7 @@ export const Team = () => {
   const state = store.getState();
   const classes = teamStyles({});
   const cx = classNames.bind(classes);
-  const title = 'The World Team';
+  const title = "The World's Team";
   const { items } = getCollectionData(state, type, id, 'members');
   const loading = getLoading(state);
   const isLoading = (item: IPriApiResource) =>

--- a/components/pages/Team/components/TeamHeader/TeamHeader.styles.ts
+++ b/components/pages/Team/components/TeamHeader/TeamHeader.styles.ts
@@ -1,0 +1,14 @@
+/**
+ * @file TeamHeader.style.tsx
+ * Styles for team header.
+ */
+
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+
+export const teamHeaderStyles = makeStyles(() =>
+  createStyles({
+    root: {
+      fontSize: '1.2rem'
+    }
+  })
+);

--- a/components/pages/Team/components/TeamHeader/TeamHeader.tsx
+++ b/components/pages/Team/components/TeamHeader/TeamHeader.tsx
@@ -1,0 +1,24 @@
+/**
+ * @file TeamHeader.ts
+ * Component for ream header.
+ */
+
+import React from 'react';
+import { Box, Typography } from '@material-ui/core';
+import { teamHeaderStyles } from './TeamHeader.styles';
+
+interface Props {
+  title: string;
+}
+
+export const TeamHeader = ({ title }: Props) => {
+  const classes = teamHeaderStyles({});
+
+  return (
+    <Box className={classes.root} mt={4} mb={2}>
+      <Box mb={3}>
+        <Typography variant="h1">{title}</Typography>
+      </Box>
+    </Box>
+  );
+};

--- a/components/pages/Team/components/TeamHeader/index.ts
+++ b/components/pages/Team/components/TeamHeader/index.ts
@@ -1,0 +1,1 @@
+export * from './TeamHeader';

--- a/components/pages/Team/components/index.ts
+++ b/components/pages/Team/components/index.ts
@@ -1,0 +1,1 @@
+export * from './TeamHeader';

--- a/components/pages/Team/index.ts
+++ b/components/pages/Team/index.ts
@@ -1,0 +1,2 @@
+export * from './Team';
+export { Team as default } from './Team'; // eslint-disable-line import/no-default-export

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -407,6 +407,19 @@ export const fetchApiPage = async (
 ): Promise<IPriApiResource> => fetchApi(`page/${id}`, req);
 
 /**
+ * Method that simplifies GET queries for team data.
+ *
+ * @param req
+ *    Request object from `getInitialProps` ctx object.
+ *
+ * @returns
+ *    Person data object.
+ */
+export const fetchApiTeam = async (
+  req?: IncomingMessage
+): Promise<IPriApiResource> => fetchApi('team', req);
+
+/**
  * Method that simplifies GET queries for person data.
  *
  * @param id

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -52,6 +52,10 @@ const TwApp = ({ Component, pageProps }: TwAppProps) => {
     }
   }, []);
 
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0 });
+  }, [type, id]);
+
   return (
     <ThemeProvider theme={baseMuiTheme}>
       <ThemeProvider theme={appTheme}>

--- a/pages/api/team.ts
+++ b/pages/api/team.ts
@@ -1,0 +1,25 @@
+/**
+ * @file team.ts
+ * Gather team data from CMS API.
+ */
+import { NextApiRequest, NextApiResponse } from 'next';
+import { IPriApiCollectionResponse } from 'pri-api-library/types';
+import { fetchPriApiQuery } from '@lib/fetch';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  // Persons assigned to The World program
+  const teamMembers = (await fetchPriApiQuery('node--people', {
+    include: ['image'],
+    'filter[status]': 1,
+    'filter[department][value]': 'the_world',
+    'filter[department][operator]': '"CONTAINS"',
+    sort: 'title',
+    range: 100
+  })) as IPriApiCollectionResponse;
+
+  const apiResp = {
+    teamMembers
+  };
+
+  res.status(200).json(apiResp);
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -55,17 +55,27 @@ ContentProxy.getInitialProps = async (
 
   // Get data for alias.
   if (alias) {
-    const aliasData = await store.dispatch<any>(
-      fetchAliasData(alias as string, req)
-    );
+    switch (alias) {
+      case '/programs/the-world/team':
+        resourceId = 'the_world';
+        resourceType = 'team';
+        break;
 
-    // Update resource id and type.
-    if (aliasData?.id) {
-      const { id, type } = aliasData as IPriApiResource;
-      resourceId = id as string;
-      resourceType = type;
-    } else {
-      resourceType = null;
+      default: {
+        const aliasData = await store.dispatch<any>(
+          fetchAliasData(alias as string, req)
+        );
+
+        // Update resource id and type.
+        if (aliasData?.id) {
+          const { id, type } = aliasData as IPriApiResource;
+          resourceId = id as string;
+          resourceType = type;
+        } else {
+          resourceType = null;
+        }
+        break;
+      }
     }
   }
 

--- a/store/actions/fetchTeamData.ts
+++ b/store/actions/fetchTeamData.ts
@@ -1,0 +1,39 @@
+/**
+ * @file fetchHomepageData.ts
+ *
+ * Actions to fetch data for homepage.
+ */
+import { IncomingMessage } from 'http';
+import { AnyAction } from 'redux';
+import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import { RootState } from '@interfaces/state';
+import { fetchApiTeam } from '@lib/fetch/api';
+import { getCollectionData } from '@store/reducers';
+import { appendResourceCollection } from './appendResourceCollection';
+
+export const fetchTeamData = (
+  req: IncomingMessage
+): ThunkAction<void, {}, {}, AnyAction> => async (
+  dispatch: ThunkDispatch<{}, {}, AnyAction>,
+  getState: () => RootState
+): Promise<void> => {
+  const state = getState();
+  const type = 'team';
+  const id = 'the_world';
+  const dataCheck = getCollectionData(state, type, id, 'members');
+
+  if (!dataCheck) {
+    dispatch({
+      type: 'FETCH_TEAM_DATA_REQUEST'
+    });
+
+    const apiResp = await fetchApiTeam(req);
+    const { teamMembers } = apiResp;
+
+    dispatch(appendResourceCollection(teamMembers, type, id, 'members'));
+
+    dispatch({
+      type: 'FETCH_TEAM_DATA_SUCCESS'
+    });
+  }
+};

--- a/store/actions/index.ts
+++ b/store/actions/index.ts
@@ -7,3 +7,4 @@ export * from './fetchEpisodeData';
 export * from './fetchHomepageData';
 export * from './fetchPageData';
 export * from './fetchStoryData';
+export * from './fetchTeamData';

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,8 @@
   },
   "routes": [
     { "handle": "filesystem" },
-    { "src": "/_next/.*",
+    {
+      "src": "/_next/.*",
       "headers": {
         "x-control-type-options": "nosniff",
         "X-frame-options": "DENY",
@@ -13,12 +14,14 @@
       }
     },
     { "src": "/.+\\.[^/]+$" },
-    { "src": "/api/.*",
+    {
+      "src": "/api/.*",
       "headers": {
         "cache-control": "public, max-age=0, must-revalidate"
       }
     },
-    { "src": "(/.+)$",
+    {
+      "src": "(/.+)$",
       "dest": "/?alias=$1",
       "headers": {
         "cache-control": "public, max-age=900, s-maxage=900, stale-while-revalidate"


### PR DESCRIPTION
Closes #98 

- add team page component and routing
- refactor alias handling to handle internal aliases
- ensure app scrolls to top when content type/id changes

## To Review

- [x] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Click **Meet the Team** link in the footer.
- [x] Click any team member and note loading state of card.
- [x] After bio loads, click back button to get back to team page. Should load scrolled to the position you clicked the link.
- [x] Scroll to bottom and click the **About** link in the footer.
- [x] Once that loads, click the **Privacy** link in the footer.
- [x] Ensure window is scrolled to top when the page content changes.
