### PR TITLE
#135: Add component for sidebar latest stories

### DIFF
--- a/components/Sidebar/SidebarLatestStories/SidebarLatestStories.styles.ts
+++ b/components/Sidebar/SidebarLatestStories/SidebarLatestStories.styles.ts
@@ -1,0 +1,20 @@
+/**
+ * @file SidebarLatestStories.style.tsx
+ * Styles for default sidebar latest stories card.
+ */
+
+import {
+  createMuiTheme,
+  createStyles,
+  makeStyles,
+  Theme
+} from '@material-ui/core/styles';
+
+export const sidebarLatestStoriesStyles = makeStyles(() =>
+  createStyles({
+    root: {}
+  })
+);
+
+export const sidebarLatestStoriesTheme = (theme: Theme) =>
+  createMuiTheme(theme, {});

--- a/components/Sidebar/SidebarLatestStories/SidebarLatestStories.tsx
+++ b/components/Sidebar/SidebarLatestStories/SidebarLatestStories.tsx
@@ -1,0 +1,61 @@
+/**
+ * @file SidebarLatestStories.tsx
+ * Component for sidebar latest story links list.
+ */
+
+import React from 'react';
+import { useStore } from 'react-redux';
+import Link from 'next/link';
+import { IPriApiResource } from 'pri-api-library/types';
+import { Button, Typography } from '@material-ui/core';
+import { MenuBookRounded, NavigateNext } from '@material-ui/icons';
+import { getCollectionData } from '@store/reducers';
+import { Sidebar } from '../Sidebar';
+import { SidebarHeader } from '../SidebarHeader';
+import { SidebarFooter } from '../SidebarFooter';
+import { SidebarList } from '../SidebarList';
+
+export interface SidebarLatestStoriesProps {
+  data?: IPriApiResource[];
+  label?: string;
+}
+
+export const SidebarLatestStories = ({
+  data,
+  label
+}: SidebarLatestStoriesProps) => {
+  const store = useStore();
+  const state = store.getState();
+  const listItems =
+    data || getCollectionData(state, 'app', null, 'latest')?.items[1];
+
+  return (
+    listItems?.length && (
+      <Sidebar item elevated>
+        <SidebarHeader>
+          <Typography variant="h2">
+            <MenuBookRounded /> {label || 'Latest world news headlines'}
+          </Typography>
+        </SidebarHeader>
+        <SidebarList disablePadding data={listItems} />
+        <SidebarFooter>
+          <Link
+            href="/?alias=/programs/the-world"
+            as="/programs/the-world"
+            passHref
+          >
+            <Button
+              component="a"
+              color="primary"
+              variant="contained"
+              fullWidth
+              disableElevation
+            >
+              More stories <NavigateNext />
+            </Button>
+          </Link>
+        </SidebarFooter>
+      </Sidebar>
+    )
+  );
+};

--- a/components/Sidebar/SidebarLatestStories/index.ts
+++ b/components/Sidebar/SidebarLatestStories/index.ts
@@ -1,0 +1,1 @@
+export * from './SidebarLatestStories';

--- a/components/Sidebar/index.ts
+++ b/components/Sidebar/index.ts
@@ -4,5 +4,6 @@ export * from './SidebarCta';
 export * from './SidebarEpisode';
 export * from './SidebarHeader';
 export * from './SidebarFooter';
+export * from './SidebarLatestStories';
 export * from './SidebarList';
 export * from './SidebarAudioList';

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -6,18 +6,12 @@ import React, { useContext, useEffect, useState } from 'react';
 import { IncomingMessage } from 'http';
 import classNames from 'classnames/bind';
 import Head from 'next/head';
-import Link from 'next/link';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import { Box, Button, Hidden, Typography } from '@material-ui/core';
-import {
-  EqualizerRounded,
-  MenuBookRounded,
-  NavigateNext,
-  PublicRounded
-} from '@material-ui/icons';
+import { EqualizerRounded, PublicRounded } from '@material-ui/icons';
 import Pagination from '@material-ui/lab/Pagination';
 import { LandingPage } from '@components/LandingPage';
 import { CtaRegion } from '@components/CtaRegion';
@@ -28,6 +22,7 @@ import {
   SidebarCta,
   SidebarFooter,
   SidebarHeader,
+  SidebarLatestStories,
   SidebarList
 } from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
@@ -80,8 +75,6 @@ export const Bio = () => {
     getCollectionData(state, type, id, 'featured stories') || {};
   const storiesState = getCollectionData(state, type, id, 'stories');
   const { items: stories, page, next } = storiesState || {};
-  const { items: latestStories } =
-    getCollectionData(state, 'app', undefined, 'latest') || {};
   const segmentsState = getCollectionData(state, type, id, 'segments');
   const { items: segments, count: segmentsCount, size: segmentsSize } =
     segmentsState || {};
@@ -251,27 +244,7 @@ export const Bio = () => {
       key: 'sidebar bottom',
       children: (
         <Box mt={3}>
-          <Sidebar item elevated>
-            <SidebarHeader>
-              <Typography variant="h2">
-                <MenuBookRounded /> Latest world news headlines
-              </Typography>
-            </SidebarHeader>
-            <SidebarList disablePadding data={latestStories[1]} />
-            <SidebarFooter>
-              <Link href="/latest/stories" passHref>
-                <Button
-                  component="a"
-                  color="primary"
-                  variant="contained"
-                  fullWidth
-                  disableElevation
-                >
-                  More stories <NavigateNext />
-                </Button>
-              </Link>
-            </SidebarFooter>
-          </Sidebar>
+          <SidebarLatestStories />
           {ctaSidebarBottom && (
             <Box mt={3}>
               <Hidden only="sm">

--- a/components/pages/Category/Category.tsx
+++ b/components/pages/Category/Category.tsx
@@ -5,26 +5,17 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { IncomingMessage } from 'http';
 import Head from 'next/head';
-import Link from 'next/link';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
-import {
-  Box,
-  Button,
-  Hidden,
-  ListSubheader,
-  Typography
-} from '@material-ui/core';
-import { MenuBookRounded, NavigateNext } from '@material-ui/icons';
+import { Box, Button, Hidden, ListSubheader } from '@material-ui/core';
 import { LandingPage } from '@components/LandingPage';
 import { CtaRegion } from '@components/CtaRegion';
 import {
   Sidebar,
   SidebarCta,
-  SidebarFooter,
-  SidebarHeader,
+  SidebarLatestStories,
   SidebarList
 } from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
@@ -90,12 +81,6 @@ export const Category = () => {
   );
   const storiesState = getCollectionData(state, type, id, 'stories');
   const { items: stories, page, next } = storiesState;
-  const { items: latestStories } = getCollectionData(
-    state,
-    'app',
-    undefined,
-    'latest'
-  );
   const { title, teaser, bannerImage, logo, hosts, sponsors, body } = data;
   const [loading, setLoading] = useState(false);
   const [oldscrollY, setOldScrollY] = useState(0);
@@ -237,27 +222,7 @@ export const Category = () => {
       key: 'sidebar bottom',
       children: (
         <Box mt={3}>
-          <Sidebar item elevated>
-            <SidebarHeader>
-              <Typography variant="h2">
-                <MenuBookRounded /> Latest world news headlines
-              </Typography>
-            </SidebarHeader>
-            <SidebarList disablePadding data={latestStories[1]} />
-            <SidebarFooter>
-              <Link href="/latest/stories" passHref>
-                <Button
-                  component="a"
-                  color="primary"
-                  variant="contained"
-                  fullWidth
-                  disableElevation
-                >
-                  More stories <NavigateNext />
-                </Button>
-              </Link>
-            </SidebarFooter>
-          </Sidebar>
+          <SidebarLatestStories />
           {ctaSidebarBottom && (
             <Box mt={3}>
               <Hidden only="sm">

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -5,14 +5,12 @@
 import React, { useContext, useEffect } from 'react';
 import { IncomingMessage } from 'http';
 import Head from 'next/head';
-import Link from 'next/link';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
   Box,
-  Button,
   Container,
   Divider,
   Grid,
@@ -21,11 +19,7 @@ import {
   Typography
 } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
-import {
-  EqualizerRounded,
-  MenuBookRounded,
-  NavigateNext
-} from '@material-ui/icons';
+import { EqualizerRounded } from '@material-ui/icons';
 import { AudioPlayer } from '@components/AudioPlayer';
 import { HtmlContent } from '@components/HtmlContent';
 import {
@@ -34,7 +28,8 @@ import {
   SidebarCta,
   SidebarHeader,
   SidebarFooter,
-  SidebarList
+  SidebarList,
+  SidebarLatestStories
 } from '@components/Sidebar';
 import { SpotifyPlayer } from '@components/SpotifyPlayer';
 import { StoryCard } from '@components/StoryCard';
@@ -103,12 +98,6 @@ export const Episode = () => {
     type,
     id as string,
     'tw_cta_region_content_sidebar_02'
-  );
-  const { items: latestStories } = getCollectionData(
-    state,
-    'app',
-    null,
-    'latest'
   );
 
   useEffect(() => {
@@ -251,29 +240,7 @@ export const Episode = () => {
                     </Sidebar>
                   </Hidden>
                 )}
-                {latestStories && (
-                  <Sidebar item elevated>
-                    <SidebarHeader>
-                      <Typography variant="h2">
-                        <MenuBookRounded /> Latest world news headlines
-                      </Typography>
-                    </SidebarHeader>
-                    <SidebarList disablePadding data={latestStories[1]} />
-                    <SidebarFooter>
-                      <Link href="/latest/stories" passHref>
-                        <Button
-                          component="a"
-                          color="primary"
-                          variant="contained"
-                          fullWidth
-                          disableElevation
-                        >
-                          More stories <NavigateNext />
-                        </Button>
-                      </Link>
-                    </SidebarFooter>
-                  </Sidebar>
-                )}
+                <SidebarLatestStories />
                 {ctaSidebarBottom && (
                   <Hidden smDown>
                     <Sidebar item>

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -5,21 +5,13 @@
 import React, { useEffect } from 'react';
 import { IncomingMessage } from 'http';
 import Head from 'next/head';
-import Link from 'next/link';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import { Box, Button, Hidden, Typography } from '@material-ui/core';
-import { MenuBookRounded, NavigateNext } from '@material-ui/icons';
+import { Box, Hidden } from '@material-ui/core';
 import { LandingPage } from '@components/LandingPage';
 import { CtaRegion } from '@components/CtaRegion';
-import {
-  Sidebar,
-  SidebarCta,
-  SidebarFooter,
-  SidebarHeader,
-  SidebarList
-} from '@components/Sidebar';
+import { SidebarCta, SidebarLatestStories } from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
 import { IPriApiResource } from 'pri-api-library/types';
@@ -168,27 +160,7 @@ export const Homepage = () => {
       key: 'sidebar bottom',
       children: (
         <Box mt={3}>
-          <Sidebar item elevated>
-            <SidebarHeader>
-              <Typography variant="h2">
-                <MenuBookRounded /> Latest world news headlines
-              </Typography>
-            </SidebarHeader>
-            <SidebarList disablePadding data={latestStories[1]} />
-            <SidebarFooter>
-              <Link href="/latest/stories" passHref>
-                <Button
-                  component="a"
-                  color="primary"
-                  variant="contained"
-                  fullWidth
-                  disableElevation
-                >
-                  More stories <NavigateNext />
-                </Button>
-              </Link>
-            </SidebarFooter>
-          </Sidebar>
+          <SidebarLatestStories data={latestStories[1]} />
           {sidebarBottom && (
             <Box mt={3}>
               <Hidden only="sm">

--- a/components/pages/Program/Program.tsx
+++ b/components/pages/Program/Program.tsx
@@ -5,7 +5,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { IncomingMessage } from 'http';
 import Head from 'next/head';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
@@ -19,10 +18,8 @@ import {
   Hidden,
   ListSubheader,
   Tab,
-  Tabs,
-  Typography
+  Tabs
 } from '@material-ui/core';
-import { MenuBookRounded, NavigateNext } from '@material-ui/icons';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { CtaRegion } from '@components/CtaRegion';
 import { HtmlContent } from '@components/HtmlContent';
@@ -32,8 +29,7 @@ import {
   SidebarContent,
   SidebarCta,
   SidebarEpisode,
-  SidebarFooter,
-  SidebarHeader,
+  SidebarLatestStories,
   SidebarList
 } from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
@@ -107,12 +103,6 @@ export const Program = () => {
   );
   const storiesState = getCollectionData(state, type, id, 'stories');
   const { items: stories, page, next, count } = storiesState;
-  const { items: latestStories } = getCollectionData(
-    state,
-    'app',
-    undefined,
-    'latest'
-  );
   const hasStories = count > 0;
   const episodesState = getCollectionData(state, type, id, 'episodes');
   const {
@@ -345,27 +335,7 @@ export const Program = () => {
       key: 'sidebar bottom',
       children: (
         <Box mt={3}>
-          <Sidebar item elevated>
-            <SidebarHeader>
-              <Typography variant="h2">
-                <MenuBookRounded /> Latest world news headlines
-              </Typography>
-            </SidebarHeader>
-            <SidebarList disablePadding data={latestStories[1]} />
-            <SidebarFooter>
-              <Link href="/latest/stories" passHref>
-                <Button
-                  component="a"
-                  color="primary"
-                  variant="contained"
-                  fullWidth
-                  disableElevation
-                >
-                  More stories <NavigateNext />
-                </Button>
-              </Link>
-            </SidebarFooter>
-          </Sidebar>
+          <SidebarLatestStories />
           {ctaSidebarBottom && (
             <Box mt={3}>
               <Hidden only="sm">

--- a/components/pages/Story/layouts/default/Story.default.tsx
+++ b/components/pages/Story/layouts/default/Story.default.tsx
@@ -5,27 +5,12 @@
 
 import React from 'react';
 import { convertNodeToElement, Transform } from 'react-html-parser';
-import Link from 'next/link';
 import { DomElement } from 'htmlparser2';
 import { useStore } from 'react-redux';
 import { ThemeProvider } from '@material-ui/core/styles';
-import {
-  Box,
-  Button,
-  Container,
-  Grid,
-  Hidden,
-  Typography
-} from '@material-ui/core';
-import { MenuBookRounded, NavigateNext } from '@material-ui/icons';
+import { Box, Container, Grid, Hidden } from '@material-ui/core';
 import { AudioPlayer } from '@components/AudioPlayer';
-import {
-  Sidebar,
-  SidebarCta,
-  SidebarHeader,
-  SidebarFooter,
-  SidebarList
-} from '@components/Sidebar';
+import { Sidebar, SidebarCta, SidebarLatestStories } from '@components/Sidebar';
 import { CtaRegion } from '@components/CtaRegion';
 import { HtmlContent } from '@components/HtmlContent';
 import { Tags } from '@components/Tags';
@@ -99,12 +84,6 @@ export const StoryDefault = ({ data }: Props) => {
     type,
     id as string,
     'tw_cta_region_content_sidebar_02'
-  );
-  const { items: latestStories } = getCollectionData(
-    state,
-    'app',
-    null,
-    'latest'
   );
   const classes = storyStyles({});
   const hasRelated = related && !!related.length;
@@ -219,29 +198,7 @@ export const StoryDefault = ({ data }: Props) => {
                 {hasTags && <Tags data={allTags} label="Tags" />}
               </Box>
               <Sidebar container className={classes.sidebar}>
-                {latestStories && (
-                  <Sidebar item elevated>
-                    <SidebarHeader>
-                      <Typography variant="h2">
-                        <MenuBookRounded /> Latest world news headlines
-                      </Typography>
-                    </SidebarHeader>
-                    <SidebarList disablePadding data={latestStories[1]} />
-                    <SidebarFooter>
-                      <Link href="/latest/stories" passHref>
-                        <Button
-                          component="a"
-                          color="primary"
-                          variant="contained"
-                          fullWidth
-                          disableElevation
-                        >
-                          More stories <NavigateNext />
-                        </Button>
-                      </Link>
-                    </SidebarFooter>
-                  </Sidebar>
-                )}
+                <SidebarLatestStories />
                 <Hidden smDown>
                   {ctaSidebarTop && (
                     <Sidebar item stretch>

--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -5,7 +5,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { IncomingMessage } from 'http';
 import Head from 'next/head';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
@@ -18,19 +17,11 @@ import {
   Container,
   Hidden,
   Tab,
-  Tabs,
-  Typography
+  Tabs
 } from '@material-ui/core';
-import { MenuBookRounded, NavigateNext } from '@material-ui/icons';
 import { LandingPage } from '@components/LandingPage';
 import { CtaRegion } from '@components/CtaRegion';
-import {
-  Sidebar,
-  SidebarCta,
-  SidebarFooter,
-  SidebarHeader,
-  SidebarList
-} from '@components/Sidebar';
+import { SidebarCta, SidebarLatestStories } from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
 import {
@@ -101,12 +92,6 @@ export const Term = () => {
   );
   const storiesState = getCollectionData(state, type, id, 'stories');
   const { items: stories, page, next, count } = storiesState;
-  const { items: latestStories } = getCollectionData(
-    state,
-    'app',
-    undefined,
-    'latest'
-  );
   const hasStories = count > 0;
   const episodesState = getCollectionData(state, type, id, 'episodes');
   const {
@@ -307,27 +292,7 @@ export const Term = () => {
       key: 'sidebar bottom',
       children: (
         <Box mt={3}>
-          <Sidebar item elevated>
-            <SidebarHeader>
-              <Typography variant="h2">
-                <MenuBookRounded /> Latest world news headlines
-              </Typography>
-            </SidebarHeader>
-            <SidebarList disablePadding data={latestStories[1]} />
-            <SidebarFooter>
-              <Link href="/latest/stories" passHref>
-                <Button
-                  component="a"
-                  color="primary"
-                  variant="contained"
-                  fullWidth
-                  disableElevation
-                >
-                  More stories <NavigateNext />
-                </Button>
-              </Link>
-            </SidebarFooter>
-          </Sidebar>
+          <SidebarLatestStories />
           {ctaSidebarBottom && (
             <Box mt={3}>
               <Hidden only="sm">


### PR DESCRIPTION
Closes #135

- moves latest stories list card tp its own component
- update pages w/ sidebar to use new latest stories component

## To Review

- [x] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure pages w/ sidebar have a latest stories card
