### PR TITLE
#138: Update newsletter data fetch pattern

### DIFF
--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -53,8 +53,12 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
   };
 
   return (
-    <>
-      {ReactHtmlParser(cleanHtml(html), { transform: transform as Transform })}
-    </>
+    html && (
+      <>
+        {ReactHtmlParser(cleanHtml(html), {
+          transform: transform as Transform
+        })}
+      </>
+    )
   );
 };

--- a/pages/api/newsletter/[id].ts
+++ b/pages/api/newsletter/[id].ts
@@ -1,17 +1,13 @@
 /**
  * @file [id].ts
- * Gather story data from CMS API.
+ * Gather newsletter data from CMS API.
  */
 import { NextApiRequest, NextApiResponse } from 'next';
-import { fetchPriApiItem, postJsonPriApiCtaRegion } from '@lib/fetch/api';
-import {
-  IPriApiResource,
-  IPriApiResourceResponse
-} from 'pri-api-library/types';
+import { fetchPriApiItem } from '@lib/fetch/api';
+import { IPriApiResourceResponse } from 'pri-api-library/types';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
-  const getContext = (data: IPriApiResource): string[] => [`node:${data.id}`];
 
   if (id) {
     const newsletter = (await fetchPriApiItem(
@@ -23,32 +19,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     )) as IPriApiResourceResponse;
 
     if (newsletter) {
-      const {
-        data,
-        data: { type }
-      } = newsletter;
-
-      // Fetch CTA Messages.
-      const context = getContext(data);
-      const regionsGroup = (await postJsonPriApiCtaRegion(
-        'tw_cta_regions_content',
-        {
-          context
-        }
-      )) as IPriApiResourceResponse;
-      const { data: regionsGroupData } = regionsGroup || {};
-      const { subqueues: ctaRegions } =
-        regionsGroupData || ({} as IPriApiResource);
-
-      // Build response object.
-      const apiResp = {
-        type,
-        context,
-        ctaRegions,
-        data
-      };
-
-      res.status(200).json(apiResp);
+      res.status(200).json(newsletter.data);
     } else {
       res.status(404);
     }

--- a/store/actions/fetchNewsletterData.ts
+++ b/store/actions/fetchNewsletterData.ts
@@ -1,0 +1,43 @@
+/**
+ * @file fetchStoryData.ts
+ *
+ * Actions to fetch data for a story resource.
+ */
+import { IncomingMessage } from 'http';
+import { AnyAction } from 'redux';
+import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import { RootState } from '@interfaces/state';
+import { fetchApiNewsletter } from '@lib/fetch/api';
+import { getDataByResource } from '@store/reducers';
+
+export const fetchNewsletterData = (
+  id: string,
+  req?: IncomingMessage
+): ThunkAction<void, {}, {}, AnyAction> => async (
+  dispatch: ThunkDispatch<{}, {}, AnyAction>,
+  getState: () => RootState
+): Promise<void> => {
+  const state = getState();
+  const type = 'node--newsletter_sign_ups';
+  let data = getDataByResource(state, type, id);
+
+  if (!data || !data.complete) {
+    dispatch({
+      type: 'FETCH_CONTENT_DATA_REQUEST',
+      payload: {
+        type,
+        id
+      }
+    });
+
+    data = await fetchApiNewsletter(id, req);
+
+    dispatch({
+      type: 'FETCH_CONTENT_DATA_SUCCESS',
+      payload: {
+        ...data,
+        complete: true
+      }
+    });
+  }
+};

--- a/store/actions/index.ts
+++ b/store/actions/index.ts
@@ -5,6 +5,7 @@ export * from './fetchAudioData';
 export * from './fetchCtaData';
 export * from './fetchEpisodeData';
 export * from './fetchHomepageData';
+export * from './fetchNewsletterData';
 export * from './fetchPageData';
 export * from './fetchStoryData';
 export * from './fetchTeamData';


### PR DESCRIPTION
Closes #138 

- Fixes newsletter data fetching so pages should load once again.

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Visit any newsletter page alias URL and ensure the page loads.

> DO NOT MERGE until PublicRadioInternational/pri.org#1506 is deployed.
