### PR TITLE
#152/#158 Accessible Footer

### DIFF
--- a/components/AppFooter/AppFooter.styles.ts
+++ b/components/AppFooter/AppFooter.styles.ts
@@ -4,7 +4,6 @@
  */
 
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import { Block } from '@material-ui/icons';
 
 export const appFooterStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/components/AppFooter/AppFooter.styles.ts
+++ b/components/AppFooter/AppFooter.styles.ts
@@ -4,6 +4,7 @@
  */
 
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { Block } from '@material-ui/icons';
 
 export const appFooterStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -52,7 +53,9 @@ export const appFooterStyles = makeStyles((theme: Theme) =>
         content: ':'
       }
     },
-    logoLink: {},
+    logoLink: {
+      display: 'block'
+    },
     logo: {
       width: '100%',
       height: 'auto'

--- a/components/AppFooter/AppFooter.styles.ts
+++ b/components/AppFooter/AppFooter.styles.ts
@@ -33,6 +33,9 @@ export const appFooterStyles = makeStyles((theme: Theme) =>
       color: theme.palette.primary.main,
       '&:is(a)': {
         textDecoration: 'none',
+        display: 'block',
+        minHeight: '48px',
+        minWidth: '48px',
         '&:hover': {
           textDecoration: 'underline'
         }

--- a/components/AppFooter/AppFooter.tsx
+++ b/components/AppFooter/AppFooter.tsx
@@ -44,7 +44,7 @@ export const AppFooter = () => {
             <Link href="https://prx.org/" aria-label="PRX">
               <PrxLogo className={producedByLogoClasses} />
             </Link>
-            <Link href="https://gbh.org/" aria-label="PRX">
+            <Link href="https://gbh.org/" aria-label="GBH">
               <WGBHLogo className={producedByLogoClasses} />
             </Link>
           </Breadcrumbs>
@@ -60,7 +60,7 @@ export const AppFooter = () => {
               separator: classes.fundedByMuiSeparator
             }}
           >
-            <a className={classes.logoLink} href="https://www.carnegie.org/" title="Carnegie Corporation of New York">
+            <a className={classes.logoLink} href="https://www.carnegie.org/" aria-label="Carnegie Corporation of New York">
               <img
                 className={classes.logo}
                 alt="Carnegie Corporation of New York"
@@ -70,7 +70,7 @@ export const AppFooter = () => {
                 height="131"
               />
             </a>
-            <a className={classes.logoLink} href="https://www.macfound.org/" title="MacArthur Foundation">
+            <a className={classes.logoLink} href="https://www.macfound.org/" aria-label="MacArthur Foundation">
               <img
                 className={classes.logo}
                 alt="MacArthur Foundation"
@@ -83,7 +83,7 @@ export const AppFooter = () => {
             <a
               className={classes.logoLink}
               href="https://www.fordfoundation.org/"
-              title="Ford Foundation"
+              aria-label="Ford Foundation"
             >
               <img
                 className={classes.logo}
@@ -94,7 +94,7 @@ export const AppFooter = () => {
                 height="52"
               />
             </a>
-            <a className={classes.logoLink} href="https://cpb.org/" title="Corporation for Public Broadcasting">
+            <a className={classes.logoLink} href="https://cpb.org/" aria-label="Corporation for Public Broadcasting">
               <img
                 className={classes.logo}
                 alt="Corporation for Public Broadcasting"

--- a/components/AppFooter/AppFooter.tsx
+++ b/components/AppFooter/AppFooter.tsx
@@ -41,10 +41,10 @@ export const AppFooter = () => {
               li: classes.producedByMuiLi
             }}
           >
-            <Link href="https://prx.org/">
+            <Link href="https://prx.org/" aria-label="PRX">
               <PrxLogo className={producedByLogoClasses} />
             </Link>
-            <Link href="https://gbh.org/">
+            <Link href="https://gbh.org/" aria-label="PRX">
               <WGBHLogo className={producedByLogoClasses} />
             </Link>
           </Breadcrumbs>
@@ -60,39 +60,48 @@ export const AppFooter = () => {
               separator: classes.fundedByMuiSeparator
             }}
           >
-            <a className={classes.logoLink} href="https://www.carnegie.org/">
+            <a className={classes.logoLink} href="https://www.carnegie.org/" title="Carnegie Corporation of New York">
               <img
                 className={classes.logo}
                 alt="Carnegie Corporation of New York"
                 title="Carnegie Corporation of New York"
                 src="https://media.pri.org/s3fs-public/styles/original_image/public/images/2018/09/carnegie.jpg"
+                width="376"
+                height="131"
               />
             </a>
-            <a className={classes.logoLink} href="https://www.macfound.org/">
+            <a className={classes.logoLink} href="https://www.macfound.org/" title="MacArthur Foundation">
               <img
                 className={classes.logo}
                 alt="MacArthur Foundation"
                 title="MacArthur Foundation"
                 src="https://media.pri.org/s3fs-public/logo-macarthur-color.jpg"
+                width="149"
+                height="52"
               />
             </a>
             <a
               className={classes.logoLink}
               href="https://www.fordfoundation.org/"
+              title="Ford Foundation"
             >
               <img
                 className={classes.logo}
                 alt="Ford Foundation"
                 title="Ford Foundation"
                 src="https://media.pri.org/s3fs-public/styles/original_image/public/images/2018/09/ford.jpg"
+                width="149"
+                height="52"
               />
             </a>
-            <a className={classes.logoLink} href="https://cpb.org/">
+            <a className={classes.logoLink} href="https://cpb.org/" title="Corporation for Public Broadcasting">
               <img
                 className={classes.logo}
                 alt="Corporation for Public Broadcasting"
                 title="Corporation for Public Broadcasting"
                 src="https://media.pri.org/s3fs-public/images/2020/01/cpb-logo.png"
+                width="304"
+                height="104"
               />
             </a>
           </Breadcrumbs>

--- a/components/AppHeader/AppHeader.tsx
+++ b/components/AppHeader/AppHeader.tsx
@@ -73,7 +73,7 @@ export const AppHeader = () => {
           </NoSsr>
 
           <Link href="/">
-            <a href="/">
+            <a href="/" aria-label="The World">
               <Logo className={cx({ twLogo: true })} />
             </a>
           </Link>


### PR DESCRIPTION
Closes #158
Closes #152 

Since these are mostly fixes to the same file:
- Adds height and width to sponsor names
- Adds discernible text to links containing only SVGs/images (logos in header/footer)
- Footer links to have min-height and width, tappable at least 48x48.

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Go to site footer, ensure things are properly labeled, sized. Run the page through 