### PR TITLE
#144: Update Vercel config to used `headers` and `rewrites`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ config/local.js
 .now
 .vercel
 report.*
+*.old.*

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,5 +1,6 @@
 declare module '*.svg' {
   import React = require('react');
+
   export const ReactComponent: React.SFC<React.SVGProps<SVGSVGElement>>;
   const src: string;
   export default src; // eslint-disable-line import/no-default-export

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -82,7 +82,7 @@ export const fetchApi = async (
 export const fetchApiQueryAlias = async (
   alias: string,
   req?: IncomingMessage
-): Promise<IPriApiResource> => fetchApi(`query/alias${alias}`, req);
+): Promise<IPriApiResource> => fetchApi(`query/alias/${alias}`, req);
 
 /**
  * Method that simplifies GET queries for app data.

--- a/lib/routing/content.ts
+++ b/lib/routing/content.ts
@@ -29,7 +29,7 @@ export const generateLinkHrefForContent = (
 export const generateLinkPropsForContent = (
   data: IPriApiResource,
   query?: { [k: string]: string }
-): { href: UrlWithParsedQuery; as: UrlWithParsedQuery } | false => {
+): { href: UrlWithParsedQuery; as: UrlWithParsedQuery } => {
   const url = generateLinkHrefForContent(data);
 
   if (url) {
@@ -51,5 +51,8 @@ export const generateLinkPropsForContent = (
     };
   }
 
-  return false;
+  return {
+    href: null,
+    as: null
+  };
 };

--- a/lib/routing/content.ts
+++ b/lib/routing/content.ts
@@ -29,7 +29,7 @@ export const generateLinkHrefForContent = (
 export const generateLinkPropsForContent = (
   data: IPriApiResource,
   query?: { [k: string]: string }
-): { href: UrlWithParsedQuery; as: UrlWithParsedQuery } => {
+): { href: UrlWithParsedQuery; as: UrlWithParsedQuery } | false => {
   const url = generateLinkHrefForContent(data);
 
   if (url) {
@@ -38,9 +38,9 @@ export const generateLinkPropsForContent = (
       ...(query && { query })
     };
     const href = {
-      ...parse('/'),
+      ...parse('/render/[...alias]'),
       query: {
-        alias: alias.pathname,
+        alias: alias.pathname.split('/'),
         ...query
       }
     };
@@ -50,4 +50,6 @@ export const generateLinkPropsForContent = (
       as: alias
     };
   }
+
+  return false;
 };

--- a/lib/routing/handleButtonClick.spec.ts
+++ b/lib/routing/handleButtonClick.spec.ts
@@ -8,7 +8,7 @@ describe('generateLinkHrefFromUrl', () => {
 
     expect(result).toHaveProperty('query');
     expect(result.query).toHaveProperty('alias');
-    expect(result.query.alias).toEqual('/alias/path/foo');
+    expect(result.query.alias).toEqual(['alias', 'path', 'foo']);
   });
 
   test('should return with query property as `null`', () => {

--- a/lib/routing/handleButtonClick.ts
+++ b/lib/routing/handleButtonClick.ts
@@ -6,7 +6,7 @@
 import { MouseEvent } from 'react';
 import Router from 'next/router';
 import { Url } from 'url';
-import { isLocalUrl } from '@lib/parse/url';
+import { isLocalUrl } from '../parse/url';
 
 /**
  * Helper function to convert generic Url object for use in app relative aliseed
@@ -19,10 +19,14 @@ import { isLocalUrl } from '@lib/parse/url';
  *    Url object with alias query relative to app.
  */
 export const generateLinkHrefFromUrl = (url: Url) => {
-  const query = url.pathname !== '/' ? { alias: url.pathname } : null;
+  const pathname = url.pathname !== '/' ? '/render/[...alias]' : '/';
+  const query =
+    url.pathname !== '/'
+      ? { alias: url.pathname.replace(/^\/+|\/+$/g, '').split('/') }
+      : null;
 
   return {
-    pathname: '/',
+    pathname,
     query
   };
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.9.0 <=12"
+    "node": ">=12 <14"
   },
   "scripts": {
     "dev": "next --port $PORT",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "next-absolute-url": "^1.0.2",
     "next-compose-plugins": "^2.2.0",
     "next-fonts": "^0.17.0",
-    "next-redux-wrapper": "^6.0.2",
+    "next-redux-wrapper": "7.0.0-rc.2",
     "postcss-easy-media-query": "^1.0.0",
     "pri-api-library": "^1.3.9",
     "prop-types": "^15.7.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,24 +4,21 @@
  */
 
 import React, { useEffect } from 'react';
-import App, { AppContext as NextAppContext, AppProps } from 'next/app';
 import { useStore } from 'react-redux';
-import { Box, CssBaseline } from '@material-ui/core';
-import { ThemeProvider } from '@material-ui/core/styles';
-import { AppContext } from '@contexts/AppContext';
+import { AppProps } from 'next/app';
+import { ThemeProvider, Box, CssBaseline } from '@material-ui/core';
 import { AppCtaBanner } from '@components/AppCtaBanner';
 import { AppCtaLoadUnder } from '@components/AppCtaLoadUnder';
-import { AppHeader } from '@components/AppHeader';
 import { AppFooter } from '@components/AppFooter';
+import { AppHeader } from '@components/AppHeader';
 import { AppLoadingBar } from '@components/AppLoadingBar';
-import { wrapper } from '@store';
-import { fetchAppData, fetchCtaData } from '@store/actions';
+import { AppContext } from '@contexts/AppContext';
 import { baseMuiTheme, appTheme } from '@theme/App.theme';
+import { wrapper } from '@store';
 import { getCtaContext } from '@store/reducers';
+import { fetchAppData, fetchCtaData } from '@store/actions';
 
-interface TwAppProps extends AppProps {}
-
-const TwApp = ({ Component, pageProps }: TwAppProps) => {
+const TwApp = ({ Component, pageProps }: AppProps) => {
   const store = useStore();
   const { type, id } = pageProps;
   const contextValue = {
@@ -77,21 +74,78 @@ const TwApp = ({ Component, pageProps }: TwAppProps) => {
   );
 };
 
-TwApp.getInitialProps = async (ctx: NextAppContext) => {
-  const { req, store } = ctx.ctx;
-  const initialProps = await App.getInitialProps(ctx);
+TwApp.getInitialProps = wrapper.getInitialAppProps(
+  store => async ({ Component, ctx }) => {
+    const { req } = ctx;
 
-  store.dispatch({ type: 'LOADING_APP_DATA' });
+    store.dispatch({ type: 'LOADING_APP_DATA' });
 
-  // Fetch App Data
-  await store.dispatch<any>(fetchAppData(req));
+    // Fetch App Data
+    await store.dispatch<any>(fetchAppData(req));
 
-  store.dispatch({ type: 'LOADING_COMPLETE' });
+    return {
+      pageProps: {
+        // Call page-level getInitialProps
+        // DON'T FORGET TO PROVIDE STORE TO PAGE
+        ...(Component.getInitialProps
+          ? await Component.getInitialProps({ ...ctx, store })
+          : {})
+      }
+    };
+  }
+);
 
-  return {
-    ...initialProps,
-    store
-  };
-};
+// class MyApp extends App<AppInitialProps> {
+//   public static getInitialProps = wrapper.getInitialAppProps(
+//     store => async ({ Component, ctx }) => {
+//       store.dispatch({ type: 'TOE', payload: 'was set in _app' });
+
+//       return {
+//         pageProps: {
+//           // Call page-level getInitialProps
+//           // DON'T FORGET TO PROVIDE STORE TO PAGE
+//           ...(Component.getInitialProps
+//             ? await Component.getInitialProps({ ...ctx, store })
+//             : {}),
+//           // Some custom thing for all pages
+//           pathname: ctx.pathname
+//         }
+//       };
+//     }
+//   );
+
+//   public render() {
+//     const { Component, pageProps } = this.props;
+//     const { type, id } = pageProps;
+//     const contextValue = {
+//       page: {
+//         resource: {
+//           type,
+//           id
+//         }
+//       }
+//     };
+
+//     return (
+//       <ThemeProvider theme={baseMuiTheme}>
+//         <ThemeProvider theme={appTheme}>
+//           <AppContext.Provider value={contextValue}>
+//             <Box minHeight="100vh" display="flex" flexDirection="column">
+//               <AppLoadingBar />
+//               <AppCtaBanner />
+//               <AppHeader />
+//               <Box flexGrow={1}>
+//                 <Component {...pageProps} />
+//               </Box>
+//               <AppFooter />
+//               <AppCtaLoadUnder />
+//             </Box>
+//           </AppContext.Provider>
+//           <CssBaseline />
+//         </ThemeProvider>
+//       </ThemeProvider>
+//     );
+//   }
+// }
 
 export default wrapper.withRedux(TwApp); // eslint-disable-line import/no-default-export

--- a/pages/api/query/alias/[...slugs].ts
+++ b/pages/api/query/alias/[...slugs].ts
@@ -10,9 +10,13 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const path = (slugs as string[]).join('/');
 
   if (path.length) {
+    console.log('fetching alias data: ', path);
+
     const apiResp = await fetchPriApiQueryAlias(path, {
       fields: ['id']
     });
+
+    console.log(apiResp);
 
     if (apiResp) {
       res.status(200).json(apiResp.data);

--- a/pages/api/query/alias/[...slugs].ts
+++ b/pages/api/query/alias/[...slugs].ts
@@ -10,13 +10,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const path = (slugs as string[]).join('/');
 
   if (path.length) {
-    console.log('fetching alias data: ', path);
-
     const apiResp = await fetchPriApiQueryAlias(path, {
       fields: ['id']
     });
-
-    console.log(apiResp);
 
     if (apiResp) {
       res.status(200).json(apiResp.data);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,16 +3,14 @@
  * Exports the Home component.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { NextPageContext } from 'next';
 import Error from 'next/error';
 import { IncomingMessage } from 'http';
-import { IPriApiResource } from 'pri-api-library/types';
 import { IContentComponentProxyProps } from '@interfaces/content';
 import { importComponent, preloadComponent } from '@lib/import/component';
 import { RootState } from '@interfaces/state';
-import { fetchAliasData } from '@store/actions';
 
 interface DispatchProps {
   fetchAliasData: (alias: string, req: IncomingMessage) => void;
@@ -22,93 +20,43 @@ interface StateProps extends RootState {}
 
 type Props = StateProps & DispatchProps & IContentComponentProxyProps;
 
-const ContentProxy = (props: Props) => {
-  const { errorCode, redirect } = props;
+const IndexPage = (props: Props) => {
+  const { errorCode } = props;
   let output: JSX.Element = <></>;
 
   if (errorCode) {
     // Render error page.
     output = <Error statusCode={errorCode} />;
-  } else if (redirect) {
-    useEffect(() => {
-      window.location.assign(redirect);
-    });
   } else {
     // Render content component.
-    const { type, id } = props;
+    const { type } = props;
     const ContentComponent = importComponent(type);
 
-    output = <ContentComponent id={id} />;
+    output = <ContentComponent />;
   }
 
   return output;
 };
 
-ContentProxy.getInitialProps = async (
+IndexPage.getInitialProps = async (
   ctx: NextPageContext
 ): Promise<IContentComponentProxyProps> => {
-  const {
-    res,
-    req,
-    store,
-    query: { alias }
-  } = ctx;
-  let resourceId: string;
-  let resourceType: string = 'homepage';
-  let redirect: string;
+  const { res, req, store } = ctx;
+  const resourceType: string = 'homepage';
+  const ContentComponent = await preloadComponent(resourceType);
 
-  console.log(alias);
+  // Use content component to fetch its data.
+  if (ContentComponent) {
+    // Dispatch action returned from content component fetchData.
+    store.dispatch({ type: 'LOADING_CONTENT_DATA' });
 
-  // Get data for alias.
-  if (alias) {
-    switch (alias) {
-      case '/programs/the-world/team':
-        resourceId = 'the_world';
-        resourceType = 'team';
-        break;
+    await store.dispatch(ContentComponent.fetchData(undefined, req));
 
-      default: {
-        const aliasData = await store.dispatch(
-          fetchAliasData(`/${alias}` as string, req)
-        );
-
-        // Update resource id and type.
-        if (aliasData?.type === 'redirect--external') {
-          redirect = aliasData.url;
-        } else if (aliasData?.id) {
-          const { id, type } = aliasData as IPriApiResource;
-          resourceId = id as string;
-          resourceType = type;
-        } else {
-          resourceType = null;
-        }
-        break;
-      }
-    }
+    store.dispatch({ type: 'LOADING_COMPLETE' });
+    return { type: resourceType, id: undefined };
   }
 
-  // Return object with redirect url.
-  if (redirect) {
-    return { redirect };
-  }
-
-  // Preload content component.
-  if (resourceType) {
-    const ContentComponent = await preloadComponent(resourceType);
-
-    // Use content component to fetch its data.
-    if (ContentComponent) {
-      // Dispatch action returned from content component fetchData.
-      store.dispatch({ type: 'LOADING_CONTENT_DATA' });
-
-      await store.dispatch(ContentComponent.fetchData(resourceId, req));
-
-      store.dispatch({ type: 'LOADING_COMPLETE' });
-      return { type: resourceType, id: resourceId };
-    }
-  }
-
-  // There was a problem locating components or data.
+  // There was a problem locating components.
   const statusCode = 404;
 
   if (res) {
@@ -125,4 +73,4 @@ const mapStateToProps = (state: RootState): StateProps => state;
 export const config = { amp: 'hybrid' };
 export default connect<StateProps, DispatchProps, IContentComponentProxyProps>(
   mapStateToProps
-)(ContentProxy); // eslint-disable-line import/no-default-export
+)(IndexPage); // eslint-disable-line import/no-default-export

--- a/pages/render/[...alias].tsx
+++ b/pages/render/[...alias].tsx
@@ -38,10 +38,12 @@ const ContentProxy = (props: Props) => {
     const { type, id } = props;
     const ContentComponent = importComponent(type);
 
+    console.log(type, id, ContentComponent);
+
     output = <ContentComponent id={id} />;
   }
 
-  return output;
+  return !redirect && output;
 };
 
 ContentProxy.getInitialProps = async (
@@ -57,20 +59,22 @@ ContentProxy.getInitialProps = async (
   let resourceType: string = 'homepage';
   let redirect: string;
 
-  console.log(alias);
-
   // Get data for alias.
   if (alias) {
-    switch (alias) {
+    const aliasPath = (alias as string[]).join('/');
+
+    console.log(alias, aliasPath);
+
+    switch (aliasPath) {
       case '/programs/the-world/team':
         resourceId = 'the_world';
         resourceType = 'team';
         break;
 
       default: {
-        const aliasData = await store.dispatch(
-          fetchAliasData(`/${alias}` as string, req)
-        );
+        const aliasData = await store.dispatch(fetchAliasData(aliasPath, req));
+
+        console.log(aliasData);
 
         // Update resource id and type.
         if (aliasData?.type === 'redirect--external') {
@@ -104,6 +108,7 @@ ContentProxy.getInitialProps = async (
       await store.dispatch(ContentComponent.fetchData(resourceId, req));
 
       store.dispatch({ type: 'LOADING_COMPLETE' });
+
       return { type: resourceType, id: resourceId };
     }
   }
@@ -120,7 +125,7 @@ ContentProxy.getInitialProps = async (
   };
 };
 
-const mapStateToProps = (state: RootState): StateProps => state;
+const mapStateToProps = (state: RootState) => state;
 
 export const config = { amp: 'hybrid' };
 export default connect<StateProps, DispatchProps, IContentComponentProxyProps>(

--- a/pages/render/[...alias].tsx
+++ b/pages/render/[...alias].tsx
@@ -35,12 +35,10 @@ const ContentProxy = (props: Props) => {
     });
   } else {
     // Render content component.
-    const { type, id } = props;
+    const { type } = props;
     const ContentComponent = importComponent(type);
 
-    console.log(type, id, ContentComponent);
-
-    output = <ContentComponent id={id} />;
+    output = <ContentComponent />;
   }
 
   return !redirect && output;
@@ -63,8 +61,6 @@ ContentProxy.getInitialProps = async (
   if (alias) {
     const aliasPath = (alias as string[]).join('/');
 
-    console.log(alias, aliasPath);
-
     switch (aliasPath) {
       case '/programs/the-world/team':
         resourceId = 'the_world';
@@ -73,8 +69,6 @@ ContentProxy.getInitialProps = async (
 
       default: {
         const aliasData = await store.dispatch(fetchAliasData(aliasPath, req));
-
-        console.log(aliasData);
 
         // Update resource id and type.
         if (aliasData?.type === 'redirect--external') {

--- a/store/actions/fetchAppData.ts
+++ b/store/actions/fetchAppData.ts
@@ -18,7 +18,7 @@ export const fetchAppData = (
   getState: () => RootState
 ): Promise<void> => {
   const state = getState();
-  const latest = getCollectionData(state, 'app', null, 'latest');
+  const latest = getCollectionData(state, 'app', undefined, 'latest');
 
   if (!latest) {
     dispatch({

--- a/store/configureStore.ts
+++ b/store/configureStore.ts
@@ -2,14 +2,16 @@
  * @file configureStore.ts
  */
 
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, Store } from 'redux';
 import { MakeStore, createWrapper } from 'next-redux-wrapper';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import thunkMiddleware from 'redux-thunk';
 import { RootState } from '@interfaces/state';
 import { reducers } from './reducers';
 
-const makeStore: MakeStore<RootState> = () =>
+const makeStore: MakeStore<Store<RootState>> = () =>
   createStore(reducers, composeWithDevTools(applyMiddleware(thunkMiddleware)));
 
-export const wrapper = createWrapper<RootState>(makeStore, { debug: false });
+export const wrapper = createWrapper<Store<RootState>>(makeStore, {
+  debug: false
+});

--- a/vercel.json
+++ b/vercel.json
@@ -22,7 +22,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=900, s-maxage=900, stale-while-revalidate"
+          "value": "public, max-age=900, s-maxage=900, stale-while-revalidate, stale-if-error"
         }
       ]
     },
@@ -31,7 +31,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=900, s-maxage=900, stale-while-revalidate"
+          "value": "public, max-age=86400, s-maxage=86400, stale-while-revalidate, stale-if-error"
         },
         {
           "key": "Permissions-Policy",

--- a/vercel.json
+++ b/vercel.json
@@ -1,39 +1,58 @@
 {
-  "version": 2,
-  "env": {
-    "CM_API_KEY": "@cm-api-key"
-  },
-  "routes": [
-    { "handle": "filesystem" },
+  "headers": [
     {
-      "src": "/_next/.*",
-      "headers": {
-        "x-control-type-options": "nosniff",
-        "X-frame-options": "DENY",
-        "x-xss-protextion": "1; mode=block"
-      }
-    },
-    { "src": "/.+\\.[^/]+$" },
-    {
-      "src": "/api/.*",
-      "headers": {
-        "cache-control": "public, max-age=0, must-revalidate"
-      }
+      "source": "/_next/(.*)",
+      "headers": [
+        {
+          "key": "x-control-type-options",
+          "value": "nosniff"
+        },
+        {
+          "key": "x-frame-options",
+          "value": "DENY"
+        },
+        {
+          "key": "x-xss-protection",
+          "value": "1; mode=block"
+        }
+      ]
     },
     {
-      "src": "(/.+)$",
-      "dest": "/?alias=$1",
-      "headers": {
-        "cache-control": "public, max-age=900, s-maxage=900, stale-while-revalidate",
-        "Permissions-Policy": "interest-cohort=()"
-      }
+      "source": "/api/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=900, s-maxage=900, stale-while-revalidate"
+        }
+      ]
     },
     {
-      "src": "/",
-      "headers": {
-        "cache-control": "public, max-age=900, s-maxage=900, stale-while-revalidate",
-        "Permissions-Policy": "interest-cohort=()"
-      }
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=900, s-maxage=900, stale-while-revalidate"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "interest-cohort=()"
+        },
+        {
+          "key": "x-frame-options",
+          "value": "DENY"
+        },
+        {
+          "key": "x-xss-protection",
+          "value": "1; mode=block"
+        }
+      ]
+    }
+  ],
+  "rewrites": [
+    { "source": "(/.+\\.[^/]+$)", "destination": "$1" },
+    {
+      "source": "/((?!_next/|__nextjs_original-stack-frame|api/).+)",
+      "destination": "/render/$1"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -22,7 +22,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=900, s-maxage=900, stale-while-revalidate, stale-if-error"
+          "value": "public, max-age=0, s-maxage=1, stale-while-revalidate"
         }
       ]
     },
@@ -31,7 +31,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=86400, s-maxage=86400, stale-while-revalidate, stale-if-error"
+          "value": "public, max-age=0, s-maxage=1, stale-while-revalidate"
         },
         {
           "key": "Permissions-Policy",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8080,10 +8080,10 @@ next-fonts@^0.17.0:
     file-loader "^2.0.0"
     url-loader "^1.1.1"
 
-next-redux-wrapper@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/next-redux-wrapper/-/next-redux-wrapper-6.0.2.tgz#b8dcd214e7b5cedd7a2a611ddb60422384d24374"
-  integrity sha512-I9CnIYhQwI/qEoNdc9VAPjIyuq4rFFhCTa4rKhoDHWEVHGB1DXZy8TAyGpwvWizESd8IoTI/OKlP6bFpCbXsOw==
+next-redux-wrapper@7.0.0-rc.2:
+  version "7.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/next-redux-wrapper/-/next-redux-wrapper-7.0.0-rc.2.tgz#8d6673ea2a1f1dbd98de710d928f739241fa2e37"
+  integrity sha512-3djAs4zdmwHJhA3vg7uhVazJcDlubsrU1qRm96GxFmuRHC3/2+lOh4q/1CnQHnBz9dQLNmTNcR6k22PSCYXpFg==
 
 next-tick@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Closes #144 

- Refactors vercel config to use non-legacy configuration props.
- Adds a `render/[...alias]` catch-all page.
- Refactors app and redux initialization.

## To Review

- [x] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure homepage loaded with cache control and floc blocking headers.
- [x] Ensure interior pages loaded with cache control and floc blocking headers.
