### PR TITLE
157 Defer webfont load

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "font-awesome": "4.7.0",
     "isomorphic-unfetch": "^3.0.0",
     "jsonapi-relate": "^2.0.0",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.21",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
     "next": "^9.1.5",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -9,23 +9,27 @@ import { ServerStyleSheets } from '@material-ui/core/styles';
 
 class TwDocument extends Document {
   render() {
+    const googleFontDomain = 'https://fonts.gstatic.com';
+    const googleFontsUrl =
+      'https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Sans+Pro:400,700,400italic|Montserrat:400,700|Alegreya:400,400italic|Roboto|Roboto+Slab|Sanchez&display=swap';
     return (
       <Html lang="en">
         <Head>
           <link
-            href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Sans+Pro:400,700,400italic|Montserrat:400,700|Alegreya:400,400italic|Roboto|Roboto+Slab|Sanchez"
-            rel="stylesheet"
-            type="text/css"
-            defer
+            rel="preconnect"
+            href={googleFontDomain}
+            crossOrigin="use-credentials"
           />
-          <link href="/images/apple-touch-icon.png" rel="apple-touch-icon" />
+          <link rel="preload" as="style" href={googleFontsUrl} />
+          <link rel="stylesheet" type="text/css" href={googleFontsUrl} />
+          <link rel="apple-touch-icon" href="/images/apple-touch-icon.png" />
           <link
-            href="/opensearch.xml"
             rel="search"
             title="priorg"
             type="application/opensearchdescription+xml"
+            href="/opensearch.xml"
           />
-          <link href="/images/favicon.png" rel="icon" />
+          <link rel="icon" href="/images/favicon.png" />
         </Head>
         <body>
           <Main />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -16,6 +16,7 @@ class TwDocument extends Document {
             href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Sans+Pro:400,700,400italic|Montserrat:400,700|Alegreya:400,400italic|Roboto|Roboto+Slab|Sanchez"
             rel="stylesheet"
             type="text/css"
+            defer
           />
           <link href="/images/apple-touch-icon.png" rel="apple-touch-icon" />
           <link

--- a/vercel.json
+++ b/vercel.json
@@ -49,9 +49,8 @@
     }
   ],
   "rewrites": [
-    { "source": "(/.+\\.[^/]+$)", "destination": "$1" },
     {
-      "source": "/((?!_next/|__nextjs_original-stack-frame|api/).+)",
+      "source": "/((?!_next/|__nextjs_original-stack-frame|api/|images/)(?:[^/.]+/?)+$)",
       "destination": "/render/$1"
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7564,6 +7564,11 @@ lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.1
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 lolex@^5.0.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"


### PR DESCRIPTION
Closes #157 

- defers initial webfont load

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] view source to ensure webfonts are, indeed, deferred. 