### PR TITLE
(WIP) #120: Subscribe modal

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/components/AppFooter/AppFooter.tsx
+++ b/components/AppFooter/AppFooter.tsx
@@ -60,7 +60,11 @@ export const AppFooter = () => {
               separator: classes.fundedByMuiSeparator
             }}
           >
-            <a className={classes.logoLink} href="https://www.carnegie.org/" aria-label="Carnegie Corporation of New York">
+            <a
+              className={classes.logoLink}
+              href="https://www.carnegie.org/"
+              aria-label="Carnegie Corporation of New York"
+            >
               <img
                 className={classes.logo}
                 alt="Carnegie Corporation of New York"
@@ -70,7 +74,11 @@ export const AppFooter = () => {
                 height="131"
               />
             </a>
-            <a className={classes.logoLink} href="https://www.macfound.org/" aria-label="MacArthur Foundation">
+            <a
+              className={classes.logoLink}
+              href="https://www.macfound.org/"
+              aria-label="MacArthur Foundation"
+            >
               <img
                 className={classes.logo}
                 alt="MacArthur Foundation"
@@ -94,7 +102,11 @@ export const AppFooter = () => {
                 height="52"
               />
             </a>
-            <a className={classes.logoLink} href="https://cpb.org/" aria-label="Corporation for Public Broadcasting">
+            <a
+              className={classes.logoLink}
+              href="https://cpb.org/"
+              aria-label="Corporation for Public Broadcasting"
+            >
               <img
                 className={classes.logo}
                 alt="Corporation for Public Broadcasting"

--- a/components/AppHeader/AppHeader.tsx
+++ b/components/AppHeader/AppHeader.tsx
@@ -81,8 +81,6 @@ export const AppHeader = () => {
 
           <div className={cx('grow')} />
 
-          {/* Subscribe Button */}
-
           {/* Header Nav */}
           <AppHeaderNav />
         </Toolbar>

--- a/components/AppHeader/AppHeaderNav/AppHeaderNav.styles.ts
+++ b/components/AppHeader/AppHeaderNav/AppHeaderNav.styles.ts
@@ -33,7 +33,9 @@ export const appHeaderNavStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       display: 'flex',
-      columnGap: theme.typography.pxToRem(theme.spacing(1))
+      alignItems: 'center',
+      columnGap: theme.typography.pxToRem(theme.spacing(1)),
+      lineHeight: 0
     }
   })
 );

--- a/components/AppHeader/AppHeaderNav/AppHeaderNav.tsx
+++ b/components/AppHeader/AppHeaderNav/AppHeaderNav.tsx
@@ -5,11 +5,13 @@
 
 import React from 'react';
 import { useStore } from 'react-redux';
-import { Button } from '@material-ui/core';
+import { Button, NoSsr } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { FavoriteSharp } from '@material-ui/icons';
+import { SubscribeButton } from '@components/SubscribeButton';
 import { handleButtonClick } from '@lib/routing';
 import { getMenusData } from '@store/reducers';
+import { blue } from '@theme/colors';
 import { appHeaderNavStyles, appHeaderNavTheme } from './AppHeaderNav.styles';
 
 const iconComponentMap = new Map();
@@ -29,6 +31,19 @@ export const AppHeaderNav = () => {
     (headerNav?.length && (
       <ThemeProvider theme={appHeaderNavTheme}>
         <div className={classes.root}>
+          {/* Subscribe Button */}
+          <NoSsr>
+            <SubscribeButton
+              title="The World: Latest Edition"
+              feedUrl="http://feeds.feedburner.com/pri/theworld"
+              itunesLinkUrl="https://itunes.apple.com/us/podcast/pris-the-world-latest-edition/id278196007?mt=2"
+              coverImageUrl="https://f.prxu.org/299/images/24f4a36e-7038-42dc-8464-2eee24774457/tw-podcast-3000.png"
+              size="medium"
+              variant="filled"
+              color={blue[500]}
+            />
+          </NoSsr>
+
           {headerNav.map(
             ({ color, icon, name, url, key, attributes, itemLinkClass }) => (
               <Button

--- a/components/CtaRegion/components/CtaMessageNewsletter/CtaMessageNewsletter.styles.ts
+++ b/components/CtaRegion/components/CtaMessageNewsletter/CtaMessageNewsletter.styles.ts
@@ -24,7 +24,7 @@ export const ctaMessageNewsletterTheme = (theme: Theme) => {
         }
       },
       MuiInputLabel: {
-        outlinedPrimary: {
+        outlined: {
           color: theme.palette.grey[700]
         }
       },

--- a/components/SubscribeButton/SubscribeButton.tsx
+++ b/components/SubscribeButton/SubscribeButton.tsx
@@ -1,0 +1,83 @@
+/**
+ * @file SubscribeButton.tsx
+ * Component for podcast feed subscription button.
+ */
+
+import React, { MutableRefObject, useEffect, useRef } from 'react';
+import Link from 'next/link';
+import { Button } from '@material-ui/core';
+
+export interface ISubscribeButton {
+  title: string;
+  feedUrl: string;
+  subtitle?: string;
+  description?: string;
+  coverImageUrl?: string;
+  itunesLinkUrl?: string;
+  color?: string;
+  size?: 'small' | 'medium' | 'big';
+  format?: 'rectangle' | 'square' | 'cover';
+  variant?: 'filled' | 'outline' | 'frameless';
+}
+
+export const SubscribeButton = ({
+  title,
+  feedUrl,
+  subtitle,
+  description,
+  coverImageUrl,
+  itunesLinkUrl,
+  color,
+  format,
+  variant
+}: ISubscribeButton) => {
+  const spanRef: MutableRefObject<HTMLSpanElement> = useRef();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const dataKey = `podcastData-${feedUrl}`;
+    window[dataKey] = {
+      title,
+      subtitle,
+      description,
+      cover: coverImageUrl,
+      feeds: [
+        {
+          type: 'audio',
+          format: 'mp3',
+          url: feedUrl,
+          'directory-url-itunes': itunesLinkUrl
+        }
+      ]
+    };
+
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://cdn.podlove.org/subscribe-button/javascripts/app.js';
+
+    script.setAttribute('class', 'podlove-subscribe-button');
+    script.setAttribute('data-language', 'en');
+    script.setAttribute('data-size', 'medium');
+    script.setAttribute('data-json-data', dataKey);
+    script.setAttribute('data-color', color);
+    script.setAttribute('data-format', format || 'rectangle');
+    script.setAttribute('data-style', variant || 'filled');
+
+    spanRef.current.appendChild(script);
+  }, []);
+
+  return (
+    <span ref={spanRef}>
+      <noscript>
+        <Link href={feedUrl} passHref>
+          <Button component="a" variant="contained" color="primary">
+            Subscribe to feed
+          </Button>
+        </Link>
+      </noscript>
+    </span>
+  );
+};

--- a/components/SubscribeButton/index.ts
+++ b/components/SubscribeButton/index.ts
@@ -1,0 +1,1 @@
+export * from './SubscribeButton';

--- a/lib/parse/menu/parseMenu.ts
+++ b/lib/parse/menu/parseMenu.ts
@@ -16,7 +16,12 @@ export const parseMenu = (data: ILink[]): IButton[] => {
       id,
       name,
       url,
-      attributes: { class: className, title, ...otherAttributes },
+      attributes: {
+        class: className,
+        title,
+        referrerpolicy,
+        ...otherAttributes
+      },
       children
     }) => ({
       key: id,
@@ -46,7 +51,10 @@ export const parseMenu = (data: ILink[]): IButton[] => {
               ({ id: childId, ...attributes } as ILink)
           )
         ),
-      attributes: otherAttributes
+      attributes: {
+        ...otherAttributes,
+        ...(referrerpolicy && { referrerPolicy: referrerpolicy })
+      }
     })
   );
 };


### PR DESCRIPTION
Closes #120

- Adds subscribe modal (PodLove) to app header nav.
- Fixes parsing of `referrerpolicy` menu item attribute so it is applied to react anchor camelcased.
- Fixes theme override of newsletter CTA form labels.
- Various prettier formatting changes.

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Ensure subscribe button is shown in header nav.
- [ ] Evaluate subscribe modal functionality.
- [ ] Ensure console doesn't show any errors when applying `referrerPolicy` attribute to donate link in footer.
- [ ] Ensure console doesn't show any warning in regard to them over ride of outlined inputs.
