### PR TITLE
#147: restyle story tags list

### DIFF
--- a/components/Tags/Tags.styles.ts
+++ b/components/Tags/Tags.styles.ts
@@ -3,9 +3,7 @@
  * Styles for Sidebar.
  */
 
-import { common } from '@material-ui/core/colors';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import { Block } from '@material-ui/icons';
 
 export const tagsStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/components/Tags/Tags.styles.ts
+++ b/components/Tags/Tags.styles.ts
@@ -3,13 +3,14 @@
  * Styles for Sidebar.
  */
 
+import { common } from '@material-ui/core/colors';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 export const tagsStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      marginTop: '1rem',
-      marginBottom: '1rem',
+      marginTop: '0.5rem',
+      marginBottom: '0.5rem',
       color: theme.palette.grey[700]
     },
     label: {
@@ -20,30 +21,20 @@ export const tagsStyles = makeStyles((theme: Theme) =>
       }
     },
     link: {
-      fontWeight: theme.typography.fontWeightBold
+      display: 'block',
+      background: common.white,
+      fontWeight: theme.typography.fontWeightBold,
+      padding: '1rem .5rem',
+      borderRadius: '5px',
+      '&:hover': {
+        background: theme.palette.primary.main,
+        color: common.white
+      }
     },
     tag: {
+      display: 'inline-block',
       textTransform: 'capitalize',
-      '&::after': {
-        content: '",\x20"'
-      },
-      '&:last-child:not(:only-of-type)': {
-        '&:before': {
-          content: '"and\x20"',
-          textTransform: 'none'
-        },
-        '&::after': {
-          content: 'none'
-        }
-      },
-      '&:only-of-type': {
-        '&::before': {
-          content: 'none'
-        },
-        '&::after': {
-          content: 'none'
-        }
-      }
+      margin: '.25rem'
     }
   })
 );

--- a/components/Tags/Tags.styles.ts
+++ b/components/Tags/Tags.styles.ts
@@ -11,12 +11,11 @@ export const tagsStyles = makeStyles((theme: Theme) =>
       display: 'flex',
       alignItems: 'center',
       flexWrap: 'wrap',
-      margin: '.5rem 0',
+      margin: `${theme.typography.pxToRem(theme.spacing(1))} 0`,
       color: theme.palette.grey[700]
     },
     label: {
       margin: '0',
-      padding: '0',
       fontWeight: theme.typography.fontWeightRegular,
       '&::after': {
         content: '":\x20"'
@@ -24,7 +23,7 @@ export const tagsStyles = makeStyles((theme: Theme) =>
     },
     link: {
       fontWeight: theme.typography.fontWeightBold,
-      margin: '0 2px',
+      gap: theme.typography.pxToRem(theme.spacing(1)),
       color: theme.palette.primary.main
     },
     tag: {

--- a/components/Tags/Tags.styles.ts
+++ b/components/Tags/Tags.styles.ts
@@ -5,36 +5,32 @@
 
 import { common } from '@material-ui/core/colors';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { Block } from '@material-ui/icons';
 
 export const tagsStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      marginTop: '0.5rem',
-      marginBottom: '0.5rem',
+      display: 'flex',
+      alignItems: 'center',
+      flexWrap: 'wrap',
+      margin: '.5rem 0',
       color: theme.palette.grey[700]
     },
     label: {
-      display: 'inline',
+      margin: '0',
+      padding: '0',
       fontWeight: theme.typography.fontWeightRegular,
       '&::after': {
         content: '":\x20"'
       }
     },
     link: {
-      display: 'block',
-      background: common.white,
       fontWeight: theme.typography.fontWeightBold,
-      padding: '1rem .5rem',
-      borderRadius: '5px',
-      '&:hover': {
-        background: theme.palette.primary.main,
-        color: common.white
-      }
+      margin: '0 2px',
+      color: theme.palette.primary.main
     },
     tag: {
-      display: 'inline-block',
-      textTransform: 'capitalize',
-      margin: '.25rem'
+      textTransform: 'capitalize'
     }
   })
 );

--- a/components/Tags/Tags.styles.ts
+++ b/components/Tags/Tags.styles.ts
@@ -12,6 +12,7 @@ export const tagsStyles = makeStyles((theme: Theme) =>
       alignItems: 'center',
       flexWrap: 'wrap',
       margin: `${theme.typography.pxToRem(theme.spacing(1))} 0`,
+      gap: theme.typography.pxToRem(theme.spacing(1)),
       color: theme.palette.grey[700]
     },
     label: {
@@ -23,7 +24,6 @@ export const tagsStyles = makeStyles((theme: Theme) =>
     },
     link: {
       fontWeight: theme.typography.fontWeightBold,
-      gap: theme.typography.pxToRem(theme.spacing(1)),
       color: theme.palette.primary.main
     },
     tag: {

--- a/components/Tags/Tags.tsx
+++ b/components/Tags/Tags.tsx
@@ -6,7 +6,7 @@
 import React, { HTMLAttributes } from 'react';
 import { Box } from '@material-ui/core';
 import { IPriApiResource } from 'pri-api-library/types';
-import { ContentLink } from '@components/ContentLink';
+import { ContentButton } from '@components/ContentButton';
 import { tagsStyles } from './Tags.styles';
 
 interface ITagsProps extends HTMLAttributes<{}> {
@@ -24,7 +24,7 @@ export const Tags = ({ data, label }: ITagsProps) => {
         item =>
           item && (
             <span className={classes.tag} key={item.id}>
-              <ContentLink className={classes.link} data={item} />
+              <ContentButton className={classes.link} data={item} />
             </span>
           )
       )}

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -46,7 +46,17 @@ export const StoryHeader = ({ data }: Props) => {
   return (
     <ThemeProvider theme={storyHeaderTheme}>
       <Box className={cx('root', { withImage: !!image })}>
-      <Box className={cx('content')}>
+        {image && (
+          <>
+            <Image
+              className={cx('image')}
+              wrapperClassName={cx('imageWrapper')}
+              data={image}
+              width={{ xl: '100vw' }}
+            />
+          </>
+        )}
+        <Box className={cx('content')}>
           <Container fixed className={cx('header')}>
             {primaryCategory && (
               <Box mb={2}>
@@ -94,16 +104,6 @@ export const StoryHeader = ({ data }: Props) => {
             </Box>
           </Container>
         </Box>
-        {image && (
-          <>
-            <Image
-              className={cx('image')}
-              wrapperClassName={cx('imageWrapper')}
-              data={image}
-              width={{ xl: '100vw' }}
-            />
-          </>
-        )}
       </Box>
       {hasFooter && (
         <Container fixed className={classes.footer}>

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -46,17 +46,7 @@ export const StoryHeader = ({ data }: Props) => {
   return (
     <ThemeProvider theme={storyHeaderTheme}>
       <Box className={cx('root', { withImage: !!image })}>
-        {image && (
-          <>
-            <Image
-              className={cx('image')}
-              wrapperClassName={cx('imageWrapper')}
-              data={image}
-              width={{ xl: '100vw' }}
-            />
-          </>
-        )}
-        <Box className={cx('content')}>
+      <Box className={cx('content')}>
           <Container fixed className={cx('header')}>
             {primaryCategory && (
               <Box mb={2}>
@@ -104,6 +94,16 @@ export const StoryHeader = ({ data }: Props) => {
             </Box>
           </Container>
         </Box>
+        {image && (
+          <>
+            <Image
+              className={cx('image')}
+              wrapperClassName={cx('imageWrapper')}
+              data={image}
+              width={{ xl: '100vw' }}
+            />
+          </>
+        )}
       </Box>
       {hasFooter && (
         <Container fixed className={classes.footer}>


### PR DESCRIPTION
Closes #147 

- The tags and categories list at the end of stories didn't have appropriate sizing (48x48) so I redesigned them a bit here. 

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Go to any story and view the category styling (desktop and mobile)
- [ ] Run Lighthouse on the story, ensure tap target size issues have all been resolved.
