### PR TITLE
#148 adds noopener and noreferrer attributes to external links

### DIFF
--- a/components/AppHeader/DrawerSocialNav/DrawerSocialNav.tsx
+++ b/components/AppHeader/DrawerSocialNav/DrawerSocialNav.tsx
@@ -44,6 +44,7 @@ export const DrawerSocialNav = () => {
               color="inherit"
               href={url.href}
               target="_blank"
+              rel="noopener noreferrer"
               key={key}
               disableRipple
               {...attributes}

--- a/components/AudioPlayer/AudioPlayer.tsx
+++ b/components/AudioPlayer/AudioPlayer.tsx
@@ -238,6 +238,7 @@ export const AudioPlayer = ({
                 component="a"
                 href={popoutPlayerUrl}
                 target="_blank"
+                rel="noopener noreferrer"
                 aria-label="Open player in new window"
                 disableRipple
               >


### PR DESCRIPTION
Closes #148 

- Any links that have the `target=_blank` attribute need to have `rel="noopener noreferrer"` set as well

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Go to any story page with audio, and pop out the audio, ensure it works
- [ ] Ensure the story pages passes this lighthouse test
- [ ] Social links in header now have the attributes added.
