### PR TITLE
#154 fixes sequential headers and styling

### DIFF
--- a/components/Tags/Tags.styles.ts
+++ b/components/Tags/Tags.styles.ts
@@ -17,6 +17,7 @@ export const tagsStyles = makeStyles((theme: Theme) =>
     },
     label: {
       margin: '0',
+      fontSize: theme.typography.pxToRem(14),
       fontWeight: theme.typography.fontWeightRegular,
       '&::after': {
         content: '":\x20"'

--- a/components/Tags/Tags.tsx
+++ b/components/Tags/Tags.tsx
@@ -19,7 +19,7 @@ export const Tags = ({ data, label }: ITagsProps) => {
 
   return (
     <Box component="aside" className={classes.root}>
-      {label && <h4 className={classes.label}>{label}</h4>}
+      {label && <h2 className={classes.label}>{label}</h2>}
       {data.map(
         item =>
           item && (

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
@@ -110,7 +110,9 @@ export const storyHeaderStyles = makeStyles((theme: Theme) =>
       zIndex: 1
     },
     teaser: {
-      marginTop: theme.typography.pxToRem(theme.spacing(2))
+      marginTop: theme.typography.pxToRem(theme.spacing(2)),
+      fontSize: theme.typography.pxToRem(24),
+      lineHeight: theme.typography.pxToRem(30)
     },
     byline: {
       padding: 0,

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -69,7 +69,7 @@ export const StoryHeader = ({ data }: Props) => {
             <Box mb={3}>
               <Typography variant="h1">{title}</Typography>
               {teaser && (
-                <Typography variant="subtitle1" className={classes.teaser}>
+                <Typography className={classes.teaser}>
                   <HtmlContent html={teaser} />
                 </Typography>
               )}


### PR DESCRIPTION
Closes #154

- Updates the teaser on feature story pages to a `<p>` tag. I don't think the teaser works as an h2 of the page. 
- Updates the category/tags label to an H2.
- Restyles both

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Go to a story page with a featured layout
- [ ] Run Lighthouse, ensure headings are sequentially ordered
- [ ] Confirm style is at intended sizes.
