### PR TITLE
HOTFIX: Apply bug fixes from #166 PR

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/components/AppFooter/AppFooter.tsx
+++ b/components/AppFooter/AppFooter.tsx
@@ -60,7 +60,11 @@ export const AppFooter = () => {
               separator: classes.fundedByMuiSeparator
             }}
           >
-            <a className={classes.logoLink} href="https://www.carnegie.org/" aria-label="Carnegie Corporation of New York">
+            <a
+              className={classes.logoLink}
+              href="https://www.carnegie.org/"
+              aria-label="Carnegie Corporation of New York"
+            >
               <img
                 className={classes.logo}
                 alt="Carnegie Corporation of New York"
@@ -70,7 +74,11 @@ export const AppFooter = () => {
                 height="131"
               />
             </a>
-            <a className={classes.logoLink} href="https://www.macfound.org/" aria-label="MacArthur Foundation">
+            <a
+              className={classes.logoLink}
+              href="https://www.macfound.org/"
+              aria-label="MacArthur Foundation"
+            >
               <img
                 className={classes.logo}
                 alt="MacArthur Foundation"
@@ -94,7 +102,11 @@ export const AppFooter = () => {
                 height="52"
               />
             </a>
-            <a className={classes.logoLink} href="https://cpb.org/" aria-label="Corporation for Public Broadcasting">
+            <a
+              className={classes.logoLink}
+              href="https://cpb.org/"
+              aria-label="Corporation for Public Broadcasting"
+            >
               <img
                 className={classes.logo}
                 alt="Corporation for Public Broadcasting"

--- a/components/CtaRegion/components/CtaMessageNewsletter/CtaMessageNewsletter.styles.ts
+++ b/components/CtaRegion/components/CtaMessageNewsletter/CtaMessageNewsletter.styles.ts
@@ -24,7 +24,7 @@ export const ctaMessageNewsletterTheme = (theme: Theme) => {
         }
       },
       MuiInputLabel: {
-        outlinedPrimary: {
+        outlined: {
           color: theme.palette.grey[700]
         }
       },

--- a/lib/parse/menu/parseMenu.ts
+++ b/lib/parse/menu/parseMenu.ts
@@ -16,7 +16,12 @@ export const parseMenu = (data: ILink[]): IButton[] => {
       id,
       name,
       url,
-      attributes: { class: className, title, ...otherAttributes },
+      attributes: {
+        class: className,
+        title,
+        referrerpolicy,
+        ...otherAttributes
+      },
       children
     }) => ({
       key: id,
@@ -46,7 +51,10 @@ export const parseMenu = (data: ILink[]): IButton[] => {
               ({ id: childId, ...attributes } as ILink)
           )
         ),
-      attributes: otherAttributes
+      attributes: {
+        ...otherAttributes,
+        ...(referrerpolicy && { referrerPolicy: referrerpolicy })
+      }
     })
   );
 };


### PR DESCRIPTION
This is a PR that applies fixes from #166 to get them in use while the modal work is on hold.

- Fixes parsing of `referrerpolicy` menu item attribute so it is applied to react anchor camelcased.
- Fixes theme override of newsletter CTA form labels.
- Adds `.editorconfig` file.
- Various prettier formatting changes.

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Ensure console doesn't show any errors when applying `referrerPolicy` attribute to donate link in footer.
- [ ] Ensure console doesn't show any warning in regard to them over ride of outlined inputs.
- [ ] Ensure editing a new file in your repo uses UTF-8, has indent spacing set to 2 spaces, and saving appends newline at the end of file and removes all trailing whitespace character.
