### PR TITLE
HOTFIX: update newsletter button label

### DIFF
--- a/components/NewsletterForm/NewsletterForm.tsx
+++ b/components/NewsletterForm/NewsletterForm.tsx
@@ -142,9 +142,9 @@ export const NewsletterForm = ({
                 disableElevation={submitted}
                 endIcon={icon}
                 onClick={handleSubmit}
-                aria-label="Subscribe"
+                aria-label="Sign Up"
               >
-                {label || 'Subscribe'}
+                {label || 'Sign Up'}
               </Button>
             )}
           </Box>


### PR DESCRIPTION
- Subscribe now implies paid. Updates Newsletter form label to say "sign up"


## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] confirm newsletter sign up button says "sign up" instead of "subscribe"
