### PR TITLE
#156: Nextjs image optimization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "editor.formatOnSave": true,
   "eslint.packageManager": "yarn",
   "npm.packageManager": "yarn",
-  "prettier.packageManager": "yarn",
   "prettier.prettierPath": "./node_modules/prettier",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[html]": {
@@ -11,5 +10,6 @@
   "editor.codeActionsOnSave": {
     // For ESLint
     "source.fixAll.eslint": false
-  }
+  },
+  "editor.formatOnPaste": true
 }

--- a/components/AppFooter/AppFooter.tsx
+++ b/components/AppFooter/AppFooter.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import Image from 'next/image';
 import { useStore } from 'react-redux';
 import classNames from 'classnames/bind';
 import { Box, Breadcrumbs, Container, Divider, Link } from '@material-ui/core';
@@ -65,7 +66,7 @@ export const AppFooter = () => {
               href="https://www.carnegie.org/"
               aria-label="Carnegie Corporation of New York"
             >
-              <img
+              <Image
                 className={classes.logo}
                 alt="Carnegie Corporation of New York"
                 title="Carnegie Corporation of New York"
@@ -79,7 +80,7 @@ export const AppFooter = () => {
               href="https://www.macfound.org/"
               aria-label="MacArthur Foundation"
             >
-              <img
+              <Image
                 className={classes.logo}
                 alt="MacArthur Foundation"
                 title="MacArthur Foundation"
@@ -93,7 +94,7 @@ export const AppFooter = () => {
               href="https://www.fordfoundation.org/"
               aria-label="Ford Foundation"
             >
-              <img
+              <Image
                 className={classes.logo}
                 alt="Ford Foundation"
                 title="Ford Foundation"
@@ -107,7 +108,7 @@ export const AppFooter = () => {
               href="https://cpb.org/"
               aria-label="Corporation for Public Broadcasting"
             >
-              <img
+              <Image
                 className={classes.logo}
                 alt="Corporation for Public Broadcasting"
                 title="Corporation for Public Broadcasting"

--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -9,6 +9,7 @@ import ReactHtmlParser, { Transform } from 'react-html-parser';
 import {
   anchorToLink,
   audioDescendant,
+  enhanceImage,
   facebookPost,
   facebookVideo,
   fbRootRemove,
@@ -38,6 +39,7 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
     return [
       anchorToLink,
       audioDescendant,
+      enhanceImage,
       facebookPost,
       facebookVideo,
       fbRootRemove,

--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -9,7 +9,6 @@ import ReactHtmlParser, { Transform } from 'react-html-parser';
 import {
   anchorToLink,
   audioDescendant,
-  enhanceImage,
   facebookPost,
   facebookVideo,
   fbRootRemove,
@@ -39,7 +38,6 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
     return [
       anchorToLink,
       audioDescendant,
-      enhanceImage,
       facebookPost,
       facebookVideo,
       fbRootRemove,

--- a/components/HtmlContent/transforms/enhanceImage.tsx
+++ b/components/HtmlContent/transforms/enhanceImage.tsx
@@ -6,10 +6,44 @@ import React from 'react';
 import { DomElement } from 'htmlparser2';
 import Image from 'next/image';
 
-export const enhanceImage = (node: DomElement) => {
+export type ImageWidth = [string, string];
+
+export interface IImageWidthsFunc {
+  (node: DomElement): ImageWidth[];
+}
+
+export const enhanceImage = (getImageWidths: IImageWidthsFunc) => (
+  node: DomElement
+) => {
   if (node.type === 'tag' && node.name === 'img') {
+    const imageWidths = getImageWidths(node);
+    const sizes = imageWidths
+      .map(([q, w]) => (q ? `(${q}) ${w}` : w))
+      .join(', ');
     const { attribs } = node;
-    return <Image {...attribs} />;
+    const { class: className } = attribs;
+    let wrapperClass: string;
+
+    switch (true) {
+      case /\bfile-full-width\b/.test(className):
+        wrapperClass = 'file-full-width-wrapper';
+        break;
+
+      case /\bfile-browser-width\b/.test(className):
+        wrapperClass = 'file-browser-width-wrapper';
+        break;
+
+      default:
+        break;
+    }
+
+    return wrapperClass ? (
+      <div className={wrapperClass}>
+        <Image {...attribs} layout="responsive" sizes={sizes} />
+      </div>
+    ) : (
+      <Image {...attribs} layout="responsive" sizes={sizes} />
+    );
   }
 
   return undefined;

--- a/components/HtmlContent/transforms/enhanceImage.tsx
+++ b/components/HtmlContent/transforms/enhanceImage.tsx
@@ -1,0 +1,16 @@
+/**
+ * @file enhanceImage.ts
+ * Converts img tags to Image components.
+ */
+import React from 'react';
+import { DomElement } from 'htmlparser2';
+import Image from 'next/image';
+
+export const enhanceImage = (node: DomElement) => {
+  if (node.type === 'tag' && node.name === 'img') {
+    const { attribs } = node;
+    return <Image {...attribs} />;
+  }
+
+  return undefined;
+};

--- a/components/HtmlContent/transforms/index.ts
+++ b/components/HtmlContent/transforms/index.ts
@@ -1,5 +1,6 @@
 export * from './anchorToLink';
 export * from './audioDescendant';
+export * from './enhanceImage';
 export * from './facebookPost';
 export * from './facebookVideo';
 export * from './fbRootRemove';

--- a/components/LandingPageHeader/LandingPageHeader.styles.ts
+++ b/components/LandingPageHeader/LandingPageHeader.styles.ts
@@ -94,6 +94,7 @@ export const landingPageHeaderStyles = makeStyles((theme: Theme) =>
       gridRow: '1 / -1',
       display: 'flex',
       flexDirection: 'column',
+      gap: theme.typography.pxToRem(theme.spacing(2)),
       alignItems: 'center',
       zIndex: 1,
       [theme.breakpoints.up('sm')]: {

--- a/components/LandingPageHeader/LandingPageHeader.tsx
+++ b/components/LandingPageHeader/LandingPageHeader.tsx
@@ -45,6 +45,7 @@ export const LandingPageHeader = ({
                 src={image.url}
                 layout="fill"
                 objectFit="cover"
+                priority
               />
             </Hidden>
             <Hidden smDown>
@@ -55,6 +56,7 @@ export const LandingPageHeader = ({
                 width={image.metadata.width}
                 height={image.metadata.height}
                 objectFit="cover"
+                priority
               />
             </Hidden>
           </Box>

--- a/components/LandingPageHeader/LandingPageHeader.tsx
+++ b/components/LandingPageHeader/LandingPageHeader.tsx
@@ -4,10 +4,16 @@
  */
 
 import React from 'react';
+import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
-import { Box, Container, Typography, ThemeProvider } from '@material-ui/core';
-import { Image } from '@components/Image';
+import {
+  Box,
+  Container,
+  Typography,
+  ThemeProvider,
+  Hidden
+} from '@material-ui/core';
 import {
   landingPageHeaderStyles,
   landingPageHeaderTheme
@@ -32,20 +38,36 @@ export const LandingPageHeader = ({
     <ThemeProvider theme={landingPageHeaderTheme}>
       <Box className={cx('root', { withImage: !!image })}>
         {image && (
-          <Image
-            className={cx('image')}
-            wrapperClassName={cx('imageWrapper')}
-            data={image}
-            width={{ xl: '100vw' }}
-          />
+          <Box className={cx('imageWrapper')}>
+            <Hidden mdUp>
+              <Image
+                className={cx('image')}
+                src={image.url}
+                layout="fill"
+                objectFit="cover"
+              />
+            </Hidden>
+            <Hidden smDown>
+              <Image
+                className={cx('image')}
+                src={image.url}
+                layout="responsive"
+                width={image.metadata.width}
+                height={image.metadata.height}
+                objectFit="cover"
+              />
+            </Hidden>
+          </Box>
         )}
         <Box className={cx('content')}>
           <Container fixed className={cx('header')}>
             {logo && (
               <Image
-                data={logo}
+                src={logo.url}
+                layout="fixed"
                 width={220}
                 height={220}
+                objectFit="cover"
                 className={cx('logo')}
               />
             )}

--- a/components/LedeImage/LedeImage.tsx
+++ b/components/LedeImage/LedeImage.tsx
@@ -20,10 +20,23 @@ export const LedeImage = ({ data }: ILedeImageProps) => {
   const hasCaption = caption && !!caption.length;
   const hasCredit = credit && !!credit.length;
   const hasFooter = hasCaption || hasCredit;
+  const imageWidth = [
+    ['max-width: 600px', '100vw'],
+    ['max-width: 960px', '560px'],
+    ['max-width: 1280px', '600px'],
+    [null, '920px']
+  ];
+  const sizes = imageWidth.map(([q, w]) => (q ? `(${q}) ${w}` : w)).join(', ');
 
   return (
     <figure className={classes.root}>
-      <Image src={url} width={width} height={height} layout="responsive" />
+      <Image
+        src={url}
+        width={width}
+        height={height}
+        layout="responsive"
+        sizes={sizes}
+      />
       {hasFooter && (
         <Typography
           variant="caption"

--- a/components/LedeImage/LedeImage.tsx
+++ b/components/LedeImage/LedeImage.tsx
@@ -4,29 +4,26 @@
  */
 
 import React from 'react';
-import ReactMarkdown from 'react-markdown/with-html';
-import { Typography } from '@material-ui/core';
-import { Image, IResponsiveConfig } from '@components/Image';
+import Image from 'next/image';
+import { Box, Typography } from '@material-ui/core';
+import { HtmlContent } from '@components/HtmlContent';
 import { ledeImageStyles } from './LedeImage.styles';
 
 export interface ILedeImageProps {
   data: any;
-  widths: IResponsiveConfig;
 }
 
-export const LedeImage = ({ data, widths = null }: ILedeImageProps) => {
-  const { caption, credit } = data;
+export const LedeImage = ({ data }: ILedeImageProps) => {
+  const { caption, credit, url, metadata } = data;
+  const { width, height } = metadata || {};
   const classes = ledeImageStyles({});
   const hasCaption = caption && !!caption.length;
   const hasCredit = credit && !!credit.length;
   const hasFooter = hasCaption || hasCredit;
-  const mdProps = {
-    escapeHtml: false
-  };
 
   return (
     <figure className={classes.root}>
-      <Image className={classes.image} data={data} width={widths} />
+      <Image src={url} width={width} height={height} layout="responsive" />
       {hasFooter && (
         <Typography
           variant="caption"
@@ -34,18 +31,14 @@ export const LedeImage = ({ data, widths = null }: ILedeImageProps) => {
           className={classes.footer}
         >
           {hasCaption && (
-            <ReactMarkdown
-              {...mdProps}
-              className={classes.caption}
-              source={caption}
-            />
+            <Box className={classes.caption}>
+              <HtmlContent html={caption} />
+            </Box>
           )}
           {hasCredit && (
-            <ReactMarkdown
-              {...mdProps}
-              className={classes.credit}
-              source={credit}
-            />
+            <Box className={classes.credit}>
+              <HtmlContent html={credit} />
+            </Box>
           )}
         </Typography>
       )}

--- a/components/LedeImage/LedeImage.tsx
+++ b/components/LedeImage/LedeImage.tsx
@@ -36,6 +36,7 @@ export const LedeImage = ({ data }: ILedeImageProps) => {
         height={height}
         layout="responsive"
         sizes={sizes}
+        priority
       />
       {hasFooter && (
         <Typography

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
@@ -90,8 +90,6 @@ export const sidebarEpisodeTheme = (theme: Theme) =>
         root: {
           position: 'relative',
           width: '100%',
-          height: 0,
-          paddingTop: `${(9 / 16) * 100}%`,
           '& > :only-child': {
             position: 'absolute',
             top: 0,

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
@@ -90,13 +90,7 @@ export const sidebarEpisodeTheme = (theme: Theme) =>
         root: {
           position: 'relative',
           width: '100%',
-          '& > :only-child': {
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-          }
+          paddingTop: `${100 / (16 / 9)}%`
         }
       },
       MuiList: {

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
@@ -19,7 +20,6 @@ import { ThemeProvider } from '@material-ui/core/styles';
 import { ContentButton } from '@components/ContentButton';
 import { ContentLink } from '@components/ContentLink';
 import { HtmlContent } from '@components/HtmlContent';
-import { Image } from '@components/Image';
 import {
   sidebarEpisodeStyles,
   sidebarEpisodeTheme
@@ -38,11 +38,13 @@ export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
   const { segments } = audio || {};
   const classes = sidebarEpisodeStyles({});
   const cx = classNames.bind(classes);
-  const imageWidth = {
-    xs: '100vw',
-    md: '320px',
-    xl: '400px'
-  };
+  const imageWidth = [
+    ['max-width: 600px', '100vw'],
+    ['max-width: 960px', '552px'],
+    ['max-width: 1280px', '300px'],
+    [null, '400px']
+  ];
+  const sizes = imageWidth.map(([q, w]) => (q ? `(${q}) ${w}` : w)).join(', ');
 
   return (
     <ThemeProvider theme={sidebarEpisodeTheme}>
@@ -51,9 +53,13 @@ export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
           {image && (
             <CardMedia>
               <Image
-                data={image}
-                width={imageWidth}
-                wrapperClassName={classes.imageWrapper}
+                src={image.url}
+                alt={image.alt}
+                layout="responsive"
+                width={image.metadata.width}
+                height={image.metadata.width * (9 / 16)}
+                objectFit="cover"
+                sizes={sizes}
               />
             </CardMedia>
           )}

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -58,6 +58,7 @@ export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
                 layout="fill"
                 objectFit="cover"
                 sizes={sizes}
+                priority
               />
             </CardMedia>
           )}

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -55,9 +55,7 @@ export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
               <Image
                 src={image.url}
                 alt={image.alt}
-                layout="responsive"
-                width={image.metadata.width}
-                height={image.metadata.width * (9 / 16)}
+                layout="fill"
                 objectFit="cover"
                 sizes={sizes}
               />

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -88,11 +88,7 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
     },
     MuiCardMediaRoot: {
       [theme.breakpoints.down('xs')]: {
-        alignSelf: 'start',
-        paddingTop: '100%',
-        '$feature &': {
-          paddingTop: `${(9 / 16) * 100}%`
-        }
+        alignSelf: 'start'
       }
     },
     feature: {},

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -87,6 +87,7 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
       }
     },
     MuiCardMediaRoot: {
+      paddingTop: `${100 / (16 / 9)}%`,
       [theme.breakpoints.down('xs')]: {
         alignSelf: 'start'
       }

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -145,9 +145,7 @@ export const storyCardTheme = (theme: Theme) =>
         root: {
           position: 'relative',
           overflow: 'hidden',
-          width: '100%',
-          height: 0,
-          paddingTop: `${(9 / 16) * 100}%`
+          width: '100%'
         }
       },
       MuiList: {

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -103,9 +103,7 @@ export const StoryCard = ({ data, feature }: StoryCardProps) => {
               <Image
                 src={image.url}
                 alt={image.alt}
-                layout="responsive"
-                width={image.metadata.width}
-                height={image.metadata.width * (9 / 16)}
+                layout="fill"
                 objectFit="cover"
                 sizes={sizes}
               />

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { parse } from 'url';
 import classNames from 'classnames/bind';
@@ -23,7 +24,6 @@ import {
 } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { ContentLink } from '@components/ContentLink';
-import { Image } from '@components/Image';
 import { ILink } from '@interfaces/link';
 import { generateLinkHrefForContent } from '@lib/routing';
 import { storyCardStyles, storyCardTheme } from './StoryCard.styles';
@@ -40,11 +40,13 @@ export const StoryCard = ({ data, feature }: StoryCardProps) => {
   const { pathname } = generateLinkHrefForContent(data);
   const classes = storyCardStyles({ isLoading });
   const cx = classNames.bind(classes);
-  const imageWidth = {
-    xs: '100vw',
-    md: '568px',
-    xl: '808px'
-  };
+  const imageWidth = [
+    ['max-width: 600px', '100vw'],
+    ['max-width: 960px', '552px'],
+    ['max-width: 1280px', '600px'],
+    [null, '820px']
+  ];
+  const sizes = imageWidth.map(([q, w]) => (q ? `(${q}) ${w}` : w)).join(', ');
 
   const renderLink = ({ title: linkTitle, url }: ILink) => {
     const oUrl = parse(url, true, true);
@@ -99,9 +101,13 @@ export const StoryCard = ({ data, feature }: StoryCardProps) => {
           {image && (
             <CardMedia classes={{ root: classes.MuiCardMediaRoot }}>
               <Image
-                data={image}
-                width={imageWidth}
-                wrapperClassName={classes.imageWrapper}
+                src={image.url}
+                alt={image.alt}
+                layout="responsive"
+                width={image.metadata.width}
+                height={image.metadata.width * (9 / 16)}
+                objectFit="cover"
+                sizes={sizes}
               />
               <LinearProgress
                 className={classes.loadingBar}

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -31,9 +31,10 @@ import { storyCardStyles, storyCardTheme } from './StoryCard.styles';
 export interface StoryCardProps {
   data: IPriApiResource;
   feature?: boolean;
+  priority?: boolean;
 }
 
-export const StoryCard = ({ data, feature }: StoryCardProps) => {
+export const StoryCard = ({ data, feature, priority }: StoryCardProps) => {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const { teaser, title, image, primaryCategory, crossLinks } = data;
@@ -106,6 +107,7 @@ export const StoryCard = ({ data, feature }: StoryCardProps) => {
                 layout="fill"
                 objectFit="cover"
                 sizes={sizes}
+                priority={priority}
               />
               <LinearProgress
                 className={classes.loadingBar}

--- a/components/StoryCardGrid/StoryCardGrid.styles.ts
+++ b/components/StoryCardGrid/StoryCardGrid.styles.ts
@@ -71,9 +71,8 @@ export const storyCardGridTheme = (theme: Theme) =>
       },
       MuiCardMedia: {
         root: {
-          [theme.breakpoints.down('xs')]: {
-            paddingTop: '100%'
-          }
+          height: 'auto',
+          paddingTop: 'initial'
         }
       }
     }

--- a/components/StoryCardGrid/StoryCardGrid.styles.ts
+++ b/components/StoryCardGrid/StoryCardGrid.styles.ts
@@ -72,7 +72,7 @@ export const storyCardGridTheme = (theme: Theme) =>
       MuiCardMedia: {
         root: {
           height: 'auto',
-          paddingTop: 'initial'
+          paddingTop: `${100 / (16 / 9)}%`
         }
       }
     }

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { parse } from 'url';
 import classNames from 'classnames/bind';
@@ -25,7 +26,6 @@ import {
 } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { ContentLink } from '@components/ContentLink';
-import { Image } from '@components/Image';
 import { ILink } from '@interfaces/link';
 import {
   storyCardStyles,
@@ -48,12 +48,13 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
   const cardClasses = storyCardStyles({});
   const cx = classNames.bind(classes);
   const cxCard = classNames.bind(cardClasses);
-  const imageWidth = {
-    xs: '100px',
-    sm: '50vw',
-    md: '568px',
-    xl: '808px'
-  };
+  const imageWidth = [
+    ['max-width: 600px', '100px'],
+    ['max-width: 960px', '50vw'],
+    ['max-width: 1280px', '300px'],
+    [null, '400px']
+  ];
+  const sizes = imageWidth.map(([q, w]) => (q ? `(${q}) ${w}` : w)).join(', ');
 
   const renderLink = ({ title: linkTitle, url }: ILink) => {
     const oUrl = parse(url, true, true);
@@ -108,9 +109,13 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                   {image && (
                     <CardMedia>
                       <Image
-                        data={image}
-                        width={imageWidth}
-                        wrapperClassName={cxCard('imageWrapper')}
+                        src={image.url}
+                        alt={image.alt}
+                        layout="responsive"
+                        width={image.metadata.width}
+                        height={image.metadata.width * (9 / 16)}
+                        objectFit="cover"
+                        sizes={sizes}
                       />
                       <LinearProgress
                         className={cx(classes.loadingBar, {

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -99,7 +99,7 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
     <ThemeProvider theme={storyCardTheme}>
       <ThemeProvider theme={storyCardGridTheme}>
         <Box className={cx('root')} {...other}>
-          {data.map(item => {
+          {data.map((item, index) => {
             const { id, title, image, primaryCategory, crossLinks } = item;
             const { pathname } = generateLinkHrefForContent(item);
             const isLoading = pathname === loadingUrl;
@@ -114,6 +114,7 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                         layout="fill"
                         objectFit="cover"
                         sizes={sizes}
+                        priority={index <= 1}
                       />
                       <LinearProgress
                         className={cx(classes.loadingBar, {

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -111,9 +111,7 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                       <Image
                         src={image.url}
                         alt={image.alt}
-                        layout="responsive"
-                        width={image.metadata.width}
-                        height={image.metadata.width * (9 / 16)}
+                        layout="fill"
                         objectFit="cover"
                         sizes={sizes}
                       />

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -162,21 +162,25 @@ export const Bio = () => {
     {
       key: 'main top',
       children: bio && (
-        <Box mt={3}>
-          <Box className={cx('body')}>
-            <HtmlContent html={bio} />
+        <>
+          <Box mt={3}>
+            <Box className={cx('body')}>
+              <HtmlContent html={bio} />
+            </Box>
           </Box>
-        </Box>
+          <Box mt={bio ? 6 : 3}>
+            {featuredStory && <StoryCard data={featuredStory} feature />}
+            {featuredStories && (
+              <StoryCardGrid data={featuredStories[1]} mt={2} />
+            )}
+          </Box>
+        </>
       )
     },
     {
       key: 'main bottom',
       children: stories && (
-        <Box mt={bio ? 6 : 3}>
-          {featuredStory && <StoryCard data={featuredStory} feature />}
-          {featuredStories && (
-            <StoryCardGrid data={featuredStories[1]} mt={2} />
-          )}
+        <>
           {stories
             .reduce((a, p) => [...a, ...p], [])
             .map((item: IPriApiResource, index: number) => (
@@ -205,7 +209,7 @@ export const Bio = () => {
               </Button>
             </Box>
           )}
-        </Box>
+        </>
       )
     }
   ];

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -169,7 +169,9 @@ export const Bio = () => {
             </Box>
           </Box>
           <Box mt={bio ? 6 : 3}>
-            {featuredStory && <StoryCard data={featuredStory} feature />}
+            {featuredStory && (
+              <StoryCard data={featuredStory} feature priority />
+            )}
             {featuredStories && (
               <StoryCardGrid data={featuredStories[1]} mt={2} />
             )}

--- a/components/pages/Bio/components/BioHeader/BioHeader.styles.ts
+++ b/components/pages/Bio/components/BioHeader/BioHeader.styles.ts
@@ -84,7 +84,7 @@ export const bioHeaderStyles = makeStyles((theme: Theme) =>
       gridRow: '1 / -1',
       display: 'flex',
       flexDirection: 'column',
-      columnGap: theme.typography.pxToRem(theme.spacing(2)),
+      gap: theme.typography.pxToRem(theme.spacing(2)),
       alignItems: 'center',
       zIndex: 1,
       [theme.breakpoints.up('sm')]: {

--- a/components/pages/Bio/components/BioHeader/BioHeader.styles.ts
+++ b/components/pages/Bio/components/BioHeader/BioHeader.styles.ts
@@ -84,6 +84,7 @@ export const bioHeaderStyles = makeStyles((theme: Theme) =>
       gridRow: '1 / -1',
       display: 'flex',
       flexDirection: 'column',
+      columnGap: theme.typography.pxToRem(theme.spacing(2)),
       alignItems: 'center',
       zIndex: 1,
       [theme.breakpoints.up('sm')]: {

--- a/components/pages/Bio/components/BioHeader/BioHeader.tsx
+++ b/components/pages/Bio/components/BioHeader/BioHeader.tsx
@@ -4,11 +4,11 @@
  */
 
 import React from 'react';
+import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
 import { Box, Container, Typography, ThemeProvider } from '@material-ui/core';
 import { ContentLink } from '@components/ContentLink';
-import { Image } from '@components/Image';
 import { bioHeaderStyles, bioHeaderTheme } from './BioHeader.styles';
 
 export interface IBioHeaderProps {
@@ -35,10 +35,12 @@ export const BioHeader = ({
           <Container fixed className={cx('header')}>
             {image && (
               <Image
-                data={image}
+                src={image.url}
+                layout="fixed"
                 width={220}
                 height={220}
                 className={cx('image')}
+                objectFit="cover"
               />
             )}
             <Box className={cx('text')}>

--- a/components/pages/Category/Category.tsx
+++ b/components/pages/Category/Category.tsx
@@ -149,7 +149,7 @@ export const Category = () => {
       key: 'main top',
       children: (
         <Box mt={3}>
-          {featuredStory && <StoryCard data={featuredStory} feature />}
+          {featuredStory && <StoryCard data={featuredStory} feature priority />}
           {featuredStories && (
             <StoryCardGrid data={featuredStories[1]} mt={2} />
           )}

--- a/components/pages/Episode/components/EpisodeLede/EpisodeLede.tsx
+++ b/components/pages/Episode/components/EpisodeLede/EpisodeLede.tsx
@@ -17,18 +17,7 @@ export const EpisodeLede = ({ data }: Props) => {
 
   return image || video ? (
     <>
-      {(video && <LedeVideo data={video[0]} />) || (
-        <LedeImage
-          data={image}
-          widths={{
-            xs: '90vw',
-            sm: 552,
-            md: 580,
-            lg: 900,
-            xl: 900
-          }}
-        />
-      )}
+      {(video && <LedeVideo data={video[0]} />) || <LedeImage data={image} />}
     </>
   ) : null;
 };

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -96,7 +96,7 @@ export const Homepage = () => {
       key: 'main top',
       children: (
         <Box mt={3}>
-          <StoryCard data={featuredStory} feature />
+          <StoryCard data={featuredStory} feature priority />
           <StoryCardGrid data={featuredStories[1]} mt={2} />
           {inlineTop && (
             <Box mt={3}>

--- a/components/pages/Program/Program.tsx
+++ b/components/pages/Program/Program.tsx
@@ -201,7 +201,9 @@ export const Program = () => {
           )}
           {!isEpisodesView && (
             <>
-              {featuredStory && <StoryCard data={featuredStory} feature />}
+              {featuredStory && (
+                <StoryCard data={featuredStory} feature priority />
+              )}
               {featuredStories && (
                 <StoryCardGrid data={featuredStories[1]} mt={2} />
               )}

--- a/components/pages/Story/layouts/default/Story.default.tsx
+++ b/components/pages/Story/layouts/default/Story.default.tsx
@@ -13,6 +13,7 @@ import { Box, Container, Grid, Hidden } from '@material-ui/core';
 import { Sidebar, SidebarLatestStories } from '@components/Sidebar';
 import { IAudioPlayerProps } from '@components/AudioPlayer/AudioPlayer.interfaces';
 import { HtmlContent } from '@components/HtmlContent';
+import { enhanceImage } from '@components/HtmlContent/transforms';
 import { ITagsProps } from '@components/Tags';
 import { IContentComponentProps } from '@interfaces/content';
 import { ICtaRegionProps } from '@interfaces/cta';
@@ -185,6 +186,26 @@ export const StoryDefault = ({ data }: Props) => {
     return undefined;
   };
 
+  const enhanceImages = enhanceImage(node => {
+    switch (true) {
+      case /\bfile-on-the-side\b/.test(node.attribs.class):
+        return [
+          ['max-width: 600px', '100vw'],
+          ['max-width: 960px', '560px'],
+          ['max-width: 1280px', '300px'],
+          [null, '400px']
+        ];
+
+      default:
+        return [
+          ['max-width: 600px', '100vw'],
+          ['max-width: 960px', '560px'],
+          ['max-width: 1280px', '600px'],
+          [null, '920px']
+        ];
+    }
+  });
+
   return (
     <ThemeProvider theme={storyTheme}>
       <Container fixed>
@@ -207,7 +228,11 @@ export const StoryDefault = ({ data }: Props) => {
                 <Box className={classes.body} my={2}>
                   <HtmlContent
                     html={body}
-                    transforms={[insertCtaMobile01, insertCtaMobile02]}
+                    transforms={[
+                      insertCtaMobile01,
+                      insertCtaMobile02,
+                      enhanceImages
+                    ]}
                   />
                 </Box>
                 {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />}

--- a/components/pages/Story/layouts/default/components/StoryLede/StoryLede.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryLede/StoryLede.default.tsx
@@ -26,18 +26,7 @@ export const StoryLede = ({ data }: Props) => {
 
   return image || video ? (
     <>
-      {(video && <LedeVideo data={video[0]} />) || (
-        <LedeImage
-          data={image}
-          widths={{
-            xs: '90vw',
-            sm: 552,
-            md: 580,
-            lg: 900,
-            xl: 900
-          }}
-        />
-      )}
+      {(video && <LedeVideo data={video[0]} />) || <LedeImage data={image} />}
     </>
   ) : null;
 };

--- a/components/pages/Story/layouts/default/components/StoryRelatedLinks/StoryRelatedLinks.default.styles.ts
+++ b/components/pages/Story/layouts/default/components/StoryRelatedLinks/StoryRelatedLinks.default.styles.ts
@@ -55,7 +55,8 @@ export const storyRelatedLinksTheme = (theme: Theme) =>
       },
       MuiCardMedia: {
         root: {
-          height: theme.typography.pxToRem(130)
+          position: 'relative',
+          paddingTop: `${100 / (16 / 9)}%`
         }
       }
     }

--- a/components/pages/Story/layouts/default/components/StoryRelatedLinks/StoryRelatedLinks.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryRelatedLinks/StoryRelatedLinks.default.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import Image from 'next/image';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
   Card,
@@ -28,27 +29,31 @@ export const StoryRelatedLinks = ({
   data: related
 }: IStoryRelatedLinksProps) => {
   const classes = storyRelatedLinksStyles({});
+  const imageWidth = [
+    ['max-width: 600px', '100vw'],
+    [null, '300px']
+  ];
+  const sizes = imageWidth.map(([q, w]) => (q ? `(${q}) ${w}` : w)).join(', ');
 
   return (
     <ThemeProvider theme={storyRelatedLinksTheme}>
       <Grid container spacing={2} classes={{ root: classes.root }}>
         {related.map(story => {
-          const {
-            id: storyId,
-            title,
-            image: {
-              title: imageTitle,
-              styles: {
-                card_small: { src }
-              }
-            }
-          } = story;
+          const { id: storyId, title, image } = story;
           return (
-            <Grid item lg={3} xs={6} key={storyId}>
+            <Grid item lg={3} sm={6} xs={12} key={storyId}>
               <ContentLink data={story}>
                 <Card square elevation={1}>
                   <CardActionArea>
-                    <CardMedia image={src} title={imageTitle} />
+                    <CardMedia>
+                      <Image
+                        src={image.url}
+                        alt={image.alt}
+                        layout="fill"
+                        objectFit="cover"
+                        sizes={sizes}
+                      />
+                    </CardMedia>
                     <CardContent>
                       <Typography variant="h5" component="h2">
                         {title}

--- a/components/pages/Story/layouts/feature/Story.feature.tsx
+++ b/components/pages/Story/layouts/feature/Story.feature.tsx
@@ -6,12 +6,12 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { useStore } from 'react-redux';
-import { convertNodeToElement } from 'react-html-parser';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { Box, Container, Grid } from '@material-ui/core';
 import { IAudioPlayerProps } from '@components/AudioPlayer/AudioPlayer.interfaces';
 import { CtaRegion } from '@components/CtaRegion';
 import { HtmlContent } from '@components/HtmlContent';
+import { enhanceImage } from '@components/HtmlContent/transforms';
 import { ITagsProps } from '@components/Tags';
 import { IContentComponentProps } from '@interfaces/content';
 import { RootState } from '@interfaces/state';
@@ -90,37 +90,26 @@ export const StoryDefault = ({ data }: Props) => {
   ];
   const hasTags = !!allTags.length;
 
-  const wrapBrowserWidthImg = (node, transform, index: number) => {
-    if (
-      node.type === 'tag' &&
-      node.name === 'img' &&
-      'class' in node.attribs &&
-      /file-browser-width/.test(node.attribs.class)
-    ) {
-      return (
-        <div className="file-browser-width-wrapper">
-          {convertNodeToElement(node, index, transform)}
-        </div>
-      );
-    }
-    return undefined;
-  };
+  const enhanceImages = enhanceImage(node => {
+    switch (true) {
+      case /\bfile-on-the-side\b/.test(node.attribs.class):
+        return [
+          ['max-width: 600px', '100vw'],
+          ['max-width: 960px', '560px'],
+          ['max-width: 1280px', '400px'],
+          [null, '400px']
+        ];
 
-  const wrapFullWidthImg = (node, transform, index: number) => {
-    if (
-      node.type === 'tag' &&
-      node.name === 'img' &&
-      'class' in node.attribs &&
-      /file-full-width/.test(node.attribs.class)
-    ) {
-      return (
-        <div className="file-full-width-wrapper">
-          {convertNodeToElement(node, index, transform)}
-        </div>
-      );
+      case /\bfile-browser-width\b/.test(node.attribs.class):
+        return [[null, '100vw']];
+
+      default:
+        return [
+          ['max-width: 600px', '100vw'],
+          [null, '1200px']
+        ];
     }
-    return undefined;
-  };
+  });
 
   return (
     <ThemeProvider theme={storyTheme}>
@@ -137,10 +126,7 @@ export const StoryDefault = ({ data }: Props) => {
               />
             )}
             <Box className={classes.body} my={2}>
-              <HtmlContent
-                html={body}
-                transforms={[wrapBrowserWidthImg, wrapFullWidthImg]}
-              />
+              <HtmlContent html={body} transforms={[enhanceImages]} />
             </Box>
             {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />}
             {hasRelated && (

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -4,15 +4,21 @@
  */
 
 import React from 'react';
+import Image from 'next/image';
 import dynamic from 'next/dynamic';
 import 'moment-timezone';
 import ReactMarkdown from 'react-markdown';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
-import { Box, Container, Typography, ThemeProvider } from '@material-ui/core';
+import {
+  Box,
+  Container,
+  Typography,
+  ThemeProvider,
+  Hidden
+} from '@material-ui/core';
 import { IContentLinkProps } from '@components/ContentLink';
 import { HtmlContent } from '@components/HtmlContent';
-import { Image } from '@components/Image';
 import {
   storyHeaderStyles,
   storyHeaderTheme
@@ -52,14 +58,26 @@ export const StoryHeader = ({ data }: Props) => {
     <ThemeProvider theme={storyHeaderTheme}>
       <Box className={cx('root', { withImage: !!image })}>
         {image && (
-          <>
-            <Image
-              className={cx('image')}
-              wrapperClassName={cx('imageWrapper')}
-              data={image}
-              width={{ xl: '100vw' }}
-            />
-          </>
+          <Box className={cx('imageWrapper')}>
+            <Hidden mdUp>
+              <Image
+                className={cx('image')}
+                src={image.url}
+                layout="fill"
+                objectFit="cover"
+              />
+            </Hidden>
+            <Hidden smDown>
+              <Image
+                className={cx('image')}
+                src={image.url}
+                layout="responsive"
+                width={image.metadata.width}
+                height={image.metadata.height}
+                objectFit="cover"
+              />
+            </Hidden>
+          </Box>
         )}
         <Box className={cx('content')}>
           <Container fixed className={cx('header')}>

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -65,6 +65,7 @@ export const StoryHeader = ({ data }: Props) => {
                 src={image.url}
                 layout="fill"
                 objectFit="cover"
+                priority
               />
             </Hidden>
             <Hidden smDown>
@@ -75,6 +76,7 @@ export const StoryHeader = ({ data }: Props) => {
                 width={image.metadata.width}
                 height={image.metadata.height}
                 objectFit="cover"
+                priority
               />
             </Hidden>
           </Box>

--- a/components/pages/Story/layouts/feature/components/StoryLede/StoryLede.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryLede/StoryLede.feature.tsx
@@ -26,18 +26,7 @@ export const StoryLede = ({ data }: IStoryLedeProps) => {
 
   return (
     <>
-      {(video && <LedeVideo data={video[0]} />) || (
-        <LedeImage
-          data={image}
-          widths={{
-            xs: '90vw',
-            sm: 552,
-            md: 580,
-            lg: 900,
-            xl: 900
-          }}
-        />
-      )}
+      {(video && <LedeVideo data={video[0]} />) || <LedeImage data={image} />}
     </>
   );
 };

--- a/components/pages/Story/layouts/feature/components/StoryRelatedLinks/StoryRelatedLinks.feature.styles.ts
+++ b/components/pages/Story/layouts/feature/components/StoryRelatedLinks/StoryRelatedLinks.feature.styles.ts
@@ -55,7 +55,8 @@ export const storyRelatedLinksTheme = (theme: Theme) =>
       },
       MuiCardMedia: {
         root: {
-          height: theme.typography.pxToRem(130)
+          position: 'relative',
+          paddingTop: `${100 / (16 / 9)}%`
         }
       }
     }

--- a/components/pages/Story/layouts/feature/components/StoryRelatedLinks/StoryRelatedLinks.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryRelatedLinks/StoryRelatedLinks.feature.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import Image from 'next/image';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
   Card,
@@ -26,27 +27,31 @@ interface Props {
 
 export const StoryRelatedLinks = ({ data: related }: Props) => {
   const classes = storyRelatedLinksStyles({});
+  const imageWidth = [
+    ['max-width: 600px', '100vw'],
+    [null, '300px']
+  ];
+  const sizes = imageWidth.map(([q, w]) => (q ? `(${q}) ${w}` : w)).join(', ');
 
   return (
     <ThemeProvider theme={storyRelatedLinksTheme}>
       <Grid container spacing={2} classes={{ root: classes.root }}>
         {related.map(story => {
-          const {
-            id: storyId,
-            title,
-            image: {
-              title: imageTitle,
-              styles: {
-                card_small: { src }
-              }
-            }
-          } = story;
+          const { id: storyId, title, image } = story;
           return (
-            <Grid item lg={3} xs={6} key={storyId}>
+            <Grid item md={3} sm={6} xs={12} key={storyId}>
               <ContentLink data={story}>
                 <Card square elevation={1}>
                   <CardActionArea>
-                    <CardMedia image={src} title={imageTitle} />
+                    <CardMedia>
+                      <Image
+                        src={image.url}
+                        alt={image.alt}
+                        layout="fill"
+                        objectFit="cover"
+                        sizes={sizes}
+                      />
+                    </CardMedia>
                     <CardContent>
                       <Typography variant="h5" component="h2">
                         {title}

--- a/components/pages/Team/Team.styles.ts
+++ b/components/pages/Team/Team.styles.ts
@@ -39,7 +39,8 @@ export const teamTheme = (theme: Theme) =>
       MuiCardMedia: {
         root: {
           position: 'relative',
-          width: '100%'
+          width: '100%',
+          paddingTop: '100%'
         }
       },
       MuiCardContent: {

--- a/components/pages/Team/Team.tsx
+++ b/components/pages/Team/Team.tsx
@@ -81,7 +81,7 @@ export const Team = () => {
         <Grid container spacing={3}>
           {items
             .reduce((a, p) => [...a, ...p], [])
-            .map((item: IPriApiResource) => {
+            .map((item: IPriApiResource, index) => {
               const { pathname } = generateLinkHrefForContent(item);
               const isLoading = loadingUrl === pathname;
 
@@ -101,6 +101,7 @@ export const Team = () => {
                             layout="fill"
                             objectFit="cover"
                             sizes={sizes}
+                            priority={index <= 1}
                           />
                         </CardMedia>
                       )}

--- a/components/pages/Team/Team.tsx
+++ b/components/pages/Team/Team.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { AnyAction } from 'redux';
@@ -22,7 +23,6 @@ import {
   Typography
 } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
-import { Image } from '@components/Image';
 import { ContentLink } from '@components/ContentLink';
 import { AppContext } from '@contexts/AppContext';
 import { generateLinkHrefForContent } from '@lib/routing';
@@ -45,6 +45,11 @@ export const Team = () => {
   const cx = classNames.bind(classes);
   const title = "The World's Team";
   const { items } = getCollectionData(state, type, id, 'members');
+  const imageWidth = [
+    ['max-width: 600px', '100wv'],
+    [null, '300px']
+  ];
+  const sizes = imageWidth.map(([q, w]) => (q ? `(${q}) ${w}` : w)).join(', ');
 
   useEffect(() => {
     const handleRouteChangeStart = (url: string) => {
@@ -91,15 +96,11 @@ export const Team = () => {
                       {item.image && (
                         <CardMedia>
                           <Image
-                            data={item.image}
-                            width={{
-                              xl: 290,
-                              lg: 290,
-                              md: 288,
-                              sm: 264,
-                              xs: '100vw'
-                            }}
-                            wrapperClassName={classes.imageWrapper}
+                            alt={item.image.alt}
+                            src={item.image.url}
+                            layout="fill"
+                            objectFit="cover"
+                            sizes={sizes}
                           />
                         </CardMedia>
                       )}

--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -175,7 +175,9 @@ export const Term = () => {
         <Box mt={3}>
           {!isEpisodesView && (
             <>
-              {featuredStory && <StoryCard data={featuredStory} feature />}
+              {featuredStory && (
+                <StoryCard data={featuredStory} feature priority />
+              )}
               {featuredStories && (
                 <StoryCardGrid data={featuredStories[1]} mt={2} />
               )}

--- a/next.config.js
+++ b/next.config.js
@@ -88,6 +88,59 @@ module.exports = withPlugins([
             priority: 40,
             reuseExistingChunk: true,
             enforce: true
+          },
+          audioPlayer: {
+            chunks: 'all',
+            test: /[\\/]components[\\/]Audio[\\/]/,
+            name: 'material-ui',
+            priority: 40,
+            reuseExistingChunk: true,
+            enforce: true
+          },
+          sidebar: {
+            chunks: 'all',
+            test: /[\\/]components[\\/]sidebar[\\/]/,
+            name: (module, chunks, cacheGroupKey) => {
+              const moduleFileName = module
+                .identifier()
+                .split('/')
+                .reduceRight(item => item);
+              const allChunksNames = chunks.map(item => item.name).join('~');
+              return `${cacheGroupKey}-${allChunksNames}-${moduleFileName}`;
+            },
+            priority: 40,
+            reuseExistingChunk: true,
+            enforce: true
+          },
+          lib: {
+            chunks: 'all',
+            test: /[\\/]lib[\\/]/,
+            name: (module, chunks, cacheGroupKey) => {
+              const moduleFileName = module
+                .identifier()
+                .split('/')
+                .reduceRight(item => item);
+              const allChunksNames = chunks.map(item => item.name).join('~');
+              return `${cacheGroupKey}-${allChunksNames}-${moduleFileName}`;
+            },
+            priority: 40,
+            reuseExistingChunk: true,
+            enforce: true
+          },
+          store: {
+            chunks: 'all',
+            test: /[\\/]store[\\/]/,
+            name: (module, chunks, cacheGroupKey) => {
+              const moduleFileName = module
+                .identifier()
+                .split('/')
+                .reduceRight(item => item);
+              const allChunksNames = chunks.map(item => item.name).join('~');
+              return `${cacheGroupKey}-${allChunksNames}-${moduleFileName}`;
+            },
+            priority: 40,
+            reuseExistingChunk: true,
+            enforce: true
           }
         };
       }

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,16 @@ const withPlugins = require('next-compose-plugins');
 
 module.exports = withPlugins([
   {
+    images: {
+      domains: [
+        'media.pri.org',
+        'www.pri.org',
+        'pri9.lndo.site',
+        'media-pri-dev.s3.us-east-1.amazonaws.com'
+      ],
+      deviceSizes: [370, 600, 960, 1280, 1920],
+      imageSizes: [50, 100, 217, 290, 568, 808]
+    },
     future: {
       webpack5: true
     },

--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,7 @@ module.exports = withPlugins([
         'media-pri-dev.s3.us-east-1.amazonaws.com'
       ],
       deviceSizes: [370, 600, 960, 1280, 1920],
-      imageSizes: [50, 100, 217, 290, 568, 808]
+      imageSizes: [50, 100, 300, 400, 568, 808]
     },
     future: {
       webpack5: true

--- a/vercel.json
+++ b/vercel.json
@@ -50,7 +50,7 @@
   ],
   "rewrites": [
     {
-      "source": "/((?!_next/|__nextjs_original-stack-frame|api/|images/)(?:[^/.]+/?)+$)",
+      "source": "/((?!_next/|__nextjs_original-stack-frame|api/|(?:cache/)?images/)(?:[^/.]+/?)+$)",
       "destination": "/render/$1"
     }
   ]


### PR DESCRIPTION
Closes #156 

- Converts image usage to `next/image` and sets up image optimization config
- Preloads ATF images
- Added more webpack chunking rules

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Inspect image traffic an ensure images are delivered as `webp` at an intrinsic size close to the display size. Browsers that do not support `webp` should get `jpeg` or `png` images.
- [ ] Images should lazy load as they are scrolled into view.
- [ ] ATF images should load immediately, if not in parallel with page load.
