### PR TITLE
190: Convert data fetch for static SSR

### DIFF
--- a/components/pages/Newsletter/Newsletter.tsx
+++ b/components/pages/Newsletter/Newsletter.tsx
@@ -4,7 +4,6 @@
  */
 import React, { useContext, useState, useEffect } from 'react';
 import { useStore } from 'react-redux';
-import { IncomingMessage } from 'http';
 import classNames from 'classnames/bind';
 import Head from 'next/head';
 import { AnyAction } from 'redux';
@@ -150,8 +149,7 @@ export const Newsletter = () => {
 };
 
 export const fetchData = (
-  id: string,
-  req: IncomingMessage
+  id: string
 ): ThunkAction<void, {}, {}, AnyAction> => async (
   dispatch: ThunkDispatch<{}, {}, AnyAction>,
   getState: () => RootState
@@ -161,6 +159,6 @@ export const fetchData = (
 
   if (!data) {
     // Get content data.
-    await dispatch<any>(fetchNewsletterData(id, req));
+    await dispatch<any>(fetchNewsletterData(id));
   }
 };

--- a/lib/fetch/index.ts
+++ b/lib/fetch/index.ts
@@ -4,6 +4,7 @@ export * from './audio';
 export * from './category';
 export * from './episode';
 export * from './homepage';
+export * from './newsletter';
 export * from './page';
 export * from './person';
 export * from './program';

--- a/lib/fetch/newsletter/fetchNewsletter.ts
+++ b/lib/fetch/newsletter/fetchNewsletter.ts
@@ -1,0 +1,14 @@
+/**
+ * Fetch Newsletter data from CMS API.
+ */
+
+import { PriApiResourceResponse } from 'pri-api-library/types';
+import { fetchPriApiItem } from '../api/fetchPriApi';
+
+export const fetchNewsletter = async (
+  id: string
+): Promise<PriApiResourceResponse> => {
+  return fetchPriApiItem('node--newsletter_sign_ups', id, {
+    include: ['image']
+  });
+};

--- a/lib/fetch/newsletter/index.ts
+++ b/lib/fetch/newsletter/index.ts
@@ -1,0 +1,1 @@
+export * from './fetchNewsletter';

--- a/store/actions/fetchNewsletterData.ts
+++ b/store/actions/fetchNewsletterData.ts
@@ -3,16 +3,15 @@
  *
  * Actions to fetch data for a story resource.
  */
-import { IncomingMessage } from 'http';
 import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { RootState } from '@interfaces/state';
-import { fetchApiNewsletter } from '@lib/fetch/api';
 import { getDataByResource } from '@store/reducers';
+import { fetchNewsletter } from '@lib/fetch';
+import { IPriApiResourceResponse } from 'pri-api-library/types';
 
 export const fetchNewsletterData = (
-  id: string,
-  req?: IncomingMessage
+  id: string
 ): ThunkAction<void, {}, {}, AnyAction> => async (
   dispatch: ThunkDispatch<{}, {}, AnyAction>,
   getState: () => RootState
@@ -30,7 +29,9 @@ export const fetchNewsletterData = (
       }
     });
 
-    data = await fetchApiNewsletter(id, req);
+    data = await fetchNewsletter(id).then(
+      (resp: IPriApiResourceResponse) => resp && resp.data
+    );
 
     dispatch({
       type: 'FETCH_CONTENT_DATA_SUCCESS',


### PR DESCRIPTION
Closes #190 

- Converts data fetch action to use static SSR friendly function.

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Ensure newsletter pages load.
