### PR TITLE
#146: Page metadata

### DIFF
--- a/components/HtmlContent/transforms/enhanceImage.tsx
+++ b/components/HtmlContent/transforms/enhanceImage.tsx
@@ -38,11 +38,11 @@ export const enhanceImage = (getImageWidths: IImageWidthsFunc) => (
     }
 
     return wrapperClass ? (
-      <div className={wrapperClass}>
+      <div className={wrapperClass} key={attribs.src}>
         <Image {...attribs} layout="responsive" sizes={sizes} />
       </div>
     ) : (
-      <Image {...attribs} layout="responsive" sizes={sizes} />
+      <Image {...attribs} layout="responsive" sizes={sizes} key={attribs.src} />
     );
   }
 

--- a/components/Image/Image.spec.ts
+++ b/components/Image/Image.spec.ts
@@ -12,23 +12,23 @@ describe('Image', () => {
   const mockImageStyles: IImageStyle[] = [
     {
       src: '/images/foo-100px.jpg',
-      info: { width: 100 }
+      width: 100
     },
     {
       src: '/images/foo-200px.jpg',
-      info: { width: 200 }
+      width: 200
     },
     {
       src: '/images/foo-300px.jpg',
-      info: { width: 300 }
+      width: 300
     },
     {
       src: '/images/foo-400px.jpg',
-      info: { width: 400 }
+      width: 400
     },
     {
       src: '/images/foo-500px.jpg',
-      info: { width: 500 }
+      width: 500
     }
   ];
 
@@ -44,7 +44,7 @@ describe('Image', () => {
 
   describe('findBestStyle', () => {
     test('should return image style with width 400', () => {
-      expect(findBestStyle(350, mockImageStyles).info.width).toEqual(400);
+      expect(findBestStyle(350, mockImageStyles).width).toEqual(400);
     });
   });
 

--- a/components/Image/Image.tsx
+++ b/components/Image/Image.tsx
@@ -29,10 +29,9 @@ export interface IImageComponentProps {
 
 export interface IImageStyle {
   src: string;
-  info: {
-    width: number;
-    height?: number;
-  };
+  type?: string;
+  width?: number;
+  height?: number;
 }
 
 /**
@@ -68,7 +67,7 @@ export const findBestStyle = (width: number, styles: IImageStyle[]) =>
   _reduceRight(
     styles,
     (best: IImageStyle, style: IImageStyle) =>
-      style.info.width >= width ? style : best,
+      style.width >= width ? style : best,
     _last(styles)
   );
 
@@ -122,7 +121,7 @@ export const generateResponsiveAttributes = (
   theme: Theme
 ) => {
   const srcSet = imageSrcs
-    .map(({ src, info: { width } }) => `${src} ${width}w`)
+    .map(({ src, width }) => `${src} ${width}w`)
     .toString();
   const sizes = ['xs', 'sm', 'md', 'lg', 'xl']
     .map((breakpoint, index, all) => {
@@ -185,13 +184,11 @@ export const Image = ({
     .map(([key, style]) => {
       return {
         ...style,
-        info: style.info || {
-          width: parseInt(key.replace(/^w/, ''), 10)
-        }
+        width: style.width || parseInt(key.replace(/^w/, ''), 10)
       };
     })
-    .filter(({ info }) => !!info)
-    .sort(({ info: { width: wa } }, { info: { width: wb } }) =>
+    .filter(({ width: w }) => !!w)
+    .sort(({ width: wa }, { width: wb }) =>
       wa < wb ? -1 : 1
     ) as IImageStyle[];
 

--- a/components/LandingPage/LandingPage.tsx
+++ b/components/LandingPage/LandingPage.tsx
@@ -41,14 +41,14 @@ export const LandingPage = ({ main, sidebar }: ILandingPageProps) => {
               children && <Fragment key={key}>{children}</Fragment>
           )}
         </Grid>
-        <Hidden smDown>
-          <Grid item xs md={4}>
+        <Grid item xs md={4}>
+          <Hidden smDown implementation="css">
             {sidebar.map(
               ({ key, children }: ILandingPageItem) =>
                 children && <Fragment key={key}>{children}</Fragment>
             )}
-          </Grid>
-        </Hidden>
+          </Hidden>
+        </Grid>
       </Grid>
     </Container>
   );

--- a/components/LandingPageHeader/LandingPageHeader.styles.ts
+++ b/components/LandingPageHeader/LandingPageHeader.styles.ts
@@ -97,6 +97,9 @@ export const landingPageHeaderStyles = makeStyles((theme: Theme) =>
       gap: theme.typography.pxToRem(theme.spacing(2)),
       alignItems: 'center',
       zIndex: 1,
+      '& > :first-child': {
+        flexShrink: 0
+      },
       [theme.breakpoints.up('sm')]: {
         alignItems: 'flex-start'
       },

--- a/components/LandingPageHeader/LandingPageHeader.tsx
+++ b/components/LandingPageHeader/LandingPageHeader.tsx
@@ -43,6 +43,7 @@ export const LandingPageHeader = ({
               <Image
                 className={cx('image')}
                 src={image.url}
+                alt={image.alt}
                 layout="fill"
                 objectFit="cover"
                 priority
@@ -52,6 +53,7 @@ export const LandingPageHeader = ({
               <Image
                 className={cx('image')}
                 src={image.url}
+                alt={image.alt}
                 layout="responsive"
                 width={image.metadata.width}
                 height={image.metadata.height}
@@ -66,6 +68,7 @@ export const LandingPageHeader = ({
             {logo && (
               <Image
                 src={logo.url}
+                alt={logo.alt}
                 layout="fixed"
                 width={220}
                 height={220}

--- a/components/LedeImage/LedeImage.tsx
+++ b/components/LedeImage/LedeImage.tsx
@@ -14,7 +14,7 @@ export interface ILedeImageProps {
 }
 
 export const LedeImage = ({ data }: ILedeImageProps) => {
-  const { caption, credit, url, metadata } = data;
+  const { alt, caption, credit, url, metadata } = data;
   const { width, height } = metadata || {};
   const classes = ledeImageStyles({});
   const hasCaption = caption && !!caption.length;
@@ -37,6 +37,7 @@ export const LedeImage = ({ data }: ILedeImageProps) => {
         layout="responsive"
         sizes={sizes}
         priority
+        alt={alt}
       />
       {hasFooter && (
         <Typography

--- a/components/MetaTags/MetaTags.tsx
+++ b/components/MetaTags/MetaTags.tsx
@@ -36,10 +36,12 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
     ...metaOther
   } = data;
   const urlCanonical = parse(canonical);
+  const hostname = process.env.NEXT_PUBLIC_VERCEL_URL || 'theworld.org';
+  const pageUrl = `https://${hostname}${urlCanonical.pathname}`;
   const ogProps = {
     title: ogTitle,
     description: ogDescription,
-    url: urlCanonical.pathname,
+    url: pageUrl,
     type: ogType,
     image: {
       src: ogImage,
@@ -50,7 +52,7 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
   const twProps = {
     title: twTitle,
     description: twDescription,
-    url: urlCanonical.pathname,
+    url: pageUrl,
     type: twCard,
     image: { src: twImage }
   };
@@ -78,7 +80,7 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
     <Head>
       <title>{title}</title>
       <meta name="description" content={description} />
-      <link rel="canonical" href={urlCanonical.pathname} />
+      <link rel="canonical" href={pageUrl} />
       <OpenGraph {...ogProps} />
       <TwitterCard {...twProps} />
       {renderMetaOther()}

--- a/components/MetaTags/MetaTags.tsx
+++ b/components/MetaTags/MetaTags.tsx
@@ -45,8 +45,8 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
     type: ogType,
     image: {
       src: ogImage,
-      width: parseInt(ogImageWidth, 10),
-      height: parseInt(ogImageHeight, 10)
+      ...(ogImageWidth && { width: parseInt(ogImageWidth, 10) }),
+      ...(ogImageHeight && { height: parseInt(ogImageHeight, 10) })
     }
   };
   const twProps = {

--- a/components/MetaTags/MetaTags.tsx
+++ b/components/MetaTags/MetaTags.tsx
@@ -38,23 +38,31 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
   const urlCanonical = parse(canonical);
   const hostname = process.env.NEXT_PUBLIC_VERCEL_URL || 'theworld.org';
   const pageUrl = `https://${hostname}${urlCanonical.pathname}`;
+  const defaultImage = {
+    src:
+      'https://media.pri.org/s3fs-public/images/2020/04/tw-globe-bg-3000.jpg',
+    width: 3000,
+    height: 3000
+  };
   const ogProps = {
     title: ogTitle,
     description: ogDescription,
     url: pageUrl,
     type: ogType,
-    image: {
-      src: ogImage,
-      ...(ogImageWidth && { width: parseInt(ogImageWidth, 10) }),
-      ...(ogImageHeight && { height: parseInt(ogImageHeight, 10) })
-    }
+    image: ogImage
+      ? {
+          src: ogImage,
+          ...(ogImageWidth && { width: parseInt(ogImageWidth, 10) }),
+          ...(ogImageHeight && { height: parseInt(ogImageHeight, 10) })
+        }
+      : defaultImage
   };
   const twProps = {
     title: twTitle,
     description: twDescription,
     url: pageUrl,
     type: twCard,
-    image: { src: twImage }
+    image: twImage ? { src: twImage } : defaultImage
   };
   const keyGen = (k: string, v: string) =>
     // eslint-disable-next-line no-control-regex

--- a/components/MetaTags/MetaTags.tsx
+++ b/components/MetaTags/MetaTags.tsx
@@ -18,6 +18,8 @@ export interface IMetaTagsProps {
   data: IMetaTags;
 }
 
+const sanitizeContent = (content: string) => content.replace(/<[^>]+>/g, '');
+
 export const MetaTags = ({ data }: IMetaTagsProps) => {
   const {
     title,
@@ -46,7 +48,7 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
   };
   const ogProps = {
     title: ogTitle,
-    description: ogDescription,
+    description: sanitizeContent(ogDescription),
     url: pageUrl,
     type: ogType,
     image: ogImage
@@ -59,7 +61,7 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
   };
   const twProps = {
     title: twTitle,
-    description: twDescription,
+    description: sanitizeContent(twDescription),
     url: pageUrl,
     type: twCard,
     image: twImage ? { src: twImage } : defaultImage
@@ -80,16 +82,16 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
           'shortlink'
         ].indexOf(k) === -1 &&
         (/^(og|fb):/.test(k) ? (
-          <meta property={k} content={v} key={keyGen(k, v)} />
+          <meta property={k} content={sanitizeContent(v)} key={keyGen(k, v)} />
         ) : (
-          <meta name={k} content={v} key={keyGen(k, v)} />
+          <meta name={k} content={sanitizeContent(v)} key={keyGen(k, v)} />
         ))
     );
 
   return (
     <Head>
       <title>{title}</title>
-      <meta name="description" content={description} />
+      <meta name="description" content={sanitizeContent(description)} />
       <link rel="canonical" href={pageUrl} />
       <OpenGraph {...ogProps} />
       <TwitterCard {...twProps} />

--- a/components/MetaTags/MetaTags.tsx
+++ b/components/MetaTags/MetaTags.tsx
@@ -54,7 +54,9 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
     type: twCard,
     image: { src: twImage }
   };
-  const keyGen = (k: string, v: string) => `${k}:${encode(v.slice(0, 16))}`;
+  const keyGen = (k: string, v: string) =>
+    // eslint-disable-next-line no-control-regex
+    `${k}:${encode(v.replace(/[^\x00-\x7F]/g, ''))}`;
   const renderMetaOther = () =>
     Object.entries(metaOther).map(
       ([k, v]) =>

--- a/components/MetaTags/MetaTags.tsx
+++ b/components/MetaTags/MetaTags.tsx
@@ -71,9 +71,11 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
     Object.entries(metaOther).map(
       ([k, v]) =>
         [
+          'fb:admins',
+          'fb:app_id',
           'og:site_name',
-          'twitter:account_id',
           'og:url',
+          'twitter:account_id',
           'twitter:url',
           'shortlink'
         ].indexOf(k) === -1 &&

--- a/components/MetaTags/MetaTags.tsx
+++ b/components/MetaTags/MetaTags.tsx
@@ -1,0 +1,85 @@
+/**
+ * @file MetaTags.tsx
+ * Component for generating meta tags.
+ */
+
+import React from 'react';
+import { parse } from 'url';
+import Head from 'next/head';
+import { encode } from 'base-64';
+import { OpenGraph } from '@components/OpenGraph';
+import { TwitterCard } from '@components/TwitterCard';
+
+export interface IMetaTags {
+  [k: string]: string;
+}
+
+export interface IMetaTagsProps {
+  data: IMetaTags;
+}
+
+export const MetaTags = ({ data }: IMetaTagsProps) => {
+  const {
+    title,
+    description,
+    canonical,
+    'og:title': ogTitle,
+    'og:description': ogDescription,
+    'og:type': ogType,
+    'og:image': ogImage,
+    'og:image:width': ogImageWidth,
+    'og:image:height': ogImageHeight,
+    'twitter:title': twTitle,
+    'twitter:description': twDescription,
+    'twitter:card': twCard,
+    'twitter:image': twImage,
+    ...metaOther
+  } = data;
+  const urlCanonical = parse(canonical);
+  const ogProps = {
+    title: ogTitle,
+    description: ogDescription,
+    url: urlCanonical.pathname,
+    type: ogType,
+    image: {
+      src: ogImage,
+      width: parseInt(ogImageWidth, 10),
+      height: parseInt(ogImageHeight, 10)
+    }
+  };
+  const twProps = {
+    title: twTitle,
+    description: twDescription,
+    url: urlCanonical.pathname,
+    type: twCard,
+    image: { src: twImage }
+  };
+  const keyGen = (k: string, v: string) => `${k}:${encode(v.slice(0, 16))}`;
+  const renderMetaOther = () =>
+    Object.entries(metaOther).map(
+      ([k, v]) =>
+        [
+          'og:site_name',
+          'twitter:account_id',
+          'og:url',
+          'twitter:url',
+          'shortlink'
+        ].indexOf(k) === -1 &&
+        (/^og:/.test(k) ? (
+          <meta property={k} content={v} key={keyGen(k, v)} />
+        ) : (
+          <meta name={k} content={v} key={keyGen(k, v)} />
+        ))
+    );
+
+  return (
+    <Head>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={urlCanonical.pathname} />
+      <OpenGraph {...ogProps} />
+      <TwitterCard {...twProps} />
+      {renderMetaOther()}
+    </Head>
+  );
+};

--- a/components/MetaTags/MetaTags.tsx
+++ b/components/MetaTags/MetaTags.tsx
@@ -69,7 +69,7 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
           'twitter:url',
           'shortlink'
         ].indexOf(k) === -1 &&
-        (/^og:/.test(k) ? (
+        (/^(og|fb):/.test(k) ? (
           <meta property={k} content={v} key={keyGen(k, v)} />
         ) : (
           <meta name={k} content={v} key={keyGen(k, v)} />

--- a/components/MetaTags/index.ts
+++ b/components/MetaTags/index.ts
@@ -1,0 +1,1 @@
+export * from './MetaTags';

--- a/components/OpenGraph/OpenGraph.tsx
+++ b/components/OpenGraph/OpenGraph.tsx
@@ -1,0 +1,47 @@
+/**
+ * @file Duration.tsx
+ * Component for displaying formatted time.
+ */
+
+import React from 'react';
+import { encode } from 'base-64';
+import { IImageStyle } from '@interfaces/content';
+
+export interface IOpenGraphProps {
+  type: 'webiste' | 'article' | 'profile';
+  title: string;
+  url: string;
+  description?: string;
+  image?: IImageStyle | IImageStyle[];
+  children?: React.ReactNode;
+}
+
+export const OpenGraph = ({
+  type,
+  title,
+  url,
+  description,
+  image,
+  children
+}: IOpenGraphProps) => (
+  <>
+    <meta property="og:type" content={type} />
+    <meta property="og:title" content={title} />
+    <meta property="og:url" content={url} />
+    {description && <meta property="og:description" content={description} />}
+    {image &&
+      (Array.isArray(image) ? image : [image]).map(
+        ({ src, type: imageType, width, height }) => (
+          <>
+            <meta property="og:image" content={src} key={`i:${encode(src)}`} />
+            {imageType && <meta property="og:image:type" content={imageType} />}
+            {width && <meta property="og:image:width" content={`${width}`} />}
+            {height && (
+              <meta property="og:image:height" content={`${height}`} />
+            )}
+          </>
+        )
+      )}
+    {children}
+  </>
+);

--- a/components/OpenGraph/OpenGraph.tsx
+++ b/components/OpenGraph/OpenGraph.tsx
@@ -8,7 +8,7 @@ import { encode } from 'base-64';
 import { IImageStyle } from '@interfaces/content';
 
 export interface IOpenGraphProps {
-  type: 'webiste' | 'article' | 'profile';
+  type: string;
   title: string;
   url: string;
   description?: string;

--- a/components/OpenGraph/OpenGraph.tsx
+++ b/components/OpenGraph/OpenGraph.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import { encode } from 'base-64';
+import { fb } from '@config';
 import { IImageStyle } from '@interfaces/content';
 
 export interface IOpenGraphProps {
@@ -25,6 +26,8 @@ export const OpenGraph = ({
   children
 }: IOpenGraphProps) => (
   <>
+    <meta property="fb:admins" content={fb.admins} />
+    <meta property="fb:app_id" content={fb.appId} />
     <meta property="og:site_name" content="The World from PRX" />
     <meta property="og:type" content={type} />
     <meta property="og:title" content={title} />

--- a/components/OpenGraph/OpenGraph.tsx
+++ b/components/OpenGraph/OpenGraph.tsx
@@ -25,6 +25,7 @@ export const OpenGraph = ({
   children
 }: IOpenGraphProps) => (
   <>
+    <meta property="og:site_name" content="The World from PRX" />
     <meta property="og:type" content={type} />
     <meta property="og:title" content={title} />
     <meta property="og:url" content={url} />

--- a/components/OpenGraph/OpenGraph.tsx
+++ b/components/OpenGraph/OpenGraph.tsx
@@ -32,14 +32,14 @@ export const OpenGraph = ({
     {image &&
       (Array.isArray(image) ? image : [image]).map(
         ({ src, type: imageType, width, height }) => (
-          <>
-            <meta property="og:image" content={src} key={`i:${encode(src)}`} />
+          <React.Fragment key={`i:${encode(src)}`}>
+            <meta property="og:image" content={src} />
             {imageType && <meta property="og:image:type" content={imageType} />}
             {width && <meta property="og:image:width" content={`${width}`} />}
             {height && (
               <meta property="og:image:height" content={`${height}`} />
             )}
-          </>
+          </React.Fragment>
         )
       )}
     {children}

--- a/components/OpenGraph/index.ts
+++ b/components/OpenGraph/index.ts
@@ -1,0 +1,1 @@
+export * from './OpenGraph';

--- a/components/TwitterCard/TwitterCard.tsx
+++ b/components/TwitterCard/TwitterCard.tsx
@@ -24,6 +24,7 @@ export const TwitterCard = ({
   children
 }: ITwitterCardProps) => (
   <>
+    <meta property="twitter:account_id" content="24953039" />
     <meta property="twitter:card" content={type} />
     <meta property="twitter:title" content={title} />
     <meta property="twitter:url" content={url} />

--- a/components/TwitterCard/TwitterCard.tsx
+++ b/components/TwitterCard/TwitterCard.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { twitter } from '@config';
 import { IImageStyle } from '@interfaces/content';
 
 export interface ITwitterCardProps {
@@ -24,7 +25,7 @@ export const TwitterCard = ({
   children
 }: ITwitterCardProps) => (
   <>
-    <meta name="twitter:account_id" content="24953039" />
+    <meta name="twitter:account_id" content={twitter.accountId} />
     <meta name="twitter:card" content={type} />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:url" content={url} />

--- a/components/TwitterCard/TwitterCard.tsx
+++ b/components/TwitterCard/TwitterCard.tsx
@@ -1,0 +1,36 @@
+/**
+ * @file TwitterCard.tsx
+ * Component for displaying formatted time.
+ */
+
+import React from 'react';
+import { IImageStyle } from '@interfaces/content';
+
+export interface ITwitterCardProps {
+  type: 'summary' | 'summary_large_image' | 'app' | 'player';
+  title: string;
+  url: string;
+  description?: string;
+  image?: IImageStyle;
+  children?: React.ReactNode;
+}
+
+export const TwitterCard = ({
+  type,
+  title,
+  url,
+  description,
+  image,
+  children
+}: ITwitterCardProps) => (
+  <>
+    <meta property="twitter:card" content={type} />
+    <meta property="twitter:title" content={title} />
+    <meta property="twitter:url" content={url} />
+    {description && (
+      <meta property="twitter:description" content={description} />
+    )}
+    {image && <meta property="twitter:image" content={image.src} />}
+    {children}
+  </>
+);

--- a/components/TwitterCard/TwitterCard.tsx
+++ b/components/TwitterCard/TwitterCard.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { IImageStyle } from '@interfaces/content';
 
 export interface ITwitterCardProps {
-  type: 'summary' | 'summary_large_image' | 'app' | 'player';
+  type: string;
   title: string;
   url: string;
   description?: string;
@@ -24,14 +24,12 @@ export const TwitterCard = ({
   children
 }: ITwitterCardProps) => (
   <>
-    <meta property="twitter:account_id" content="24953039" />
-    <meta property="twitter:card" content={type} />
-    <meta property="twitter:title" content={title} />
-    <meta property="twitter:url" content={url} />
-    {description && (
-      <meta property="twitter:description" content={description} />
-    )}
-    {image && <meta property="twitter:image" content={image.src} />}
+    <meta name="twitter:account_id" content="24953039" />
+    <meta name="twitter:card" content={type} />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:url" content={url} />
+    {description && <meta name="twitter:description" content={description} />}
+    {image && <meta name="twitter:image" content={image.src} />}
     {children}
   </>
 );

--- a/components/TwitterCard/index.ts
+++ b/components/TwitterCard/index.ts
@@ -1,0 +1,1 @@
+export * from './TwitterCard';

--- a/components/pages/Audio/Audio.tsx
+++ b/components/pages/Audio/Audio.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useContext, useEffect } from 'react';
-import Head from 'next/head';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
@@ -14,6 +13,7 @@ import { AudioPlayer } from '@components/AudioPlayer';
 import { CtaRegion } from '@components/CtaRegion';
 import { AppContext } from '@contexts/AppContext';
 import { HtmlContent } from '@components/HtmlContent';
+import { MetaTags } from '@components/MetaTags';
 import { RootState } from '@interfaces/state';
 import { fetchCtaData, fetchAudioData } from '@store/actions';
 import { getDataByResource, getCtaRegionData } from '@store/reducers';
@@ -35,7 +35,7 @@ export const Audio = () => {
     return null;
   }
 
-  const { audioTitle, description } = data;
+  const { metatags, description } = data;
 
   const ctaInlineEnd = getCtaRegionData(
     state,
@@ -64,10 +64,9 @@ export const Audio = () => {
 
   return (
     <ThemeProvider theme={audioTheme}>
-      <Head>
-        <title>{audioTitle}</title>
-        {/* TODO: WIRE UP ANALYTICS */}
-      </Head>
+      <MetaTags
+        data={{ ...metatags, description: metatags.description || description }}
+      />
       <Container fixed>
         <Grid container>
           <Grid item xs={12}>

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -5,7 +5,6 @@
 
 import React, { useContext, useEffect, useState } from 'react';
 import classNames from 'classnames/bind';
-import Head from 'next/head';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
@@ -16,6 +15,7 @@ import Pagination from '@material-ui/lab/Pagination';
 import { LandingPage } from '@components/LandingPage';
 import { CtaRegion } from '@components/CtaRegion';
 import { HtmlContent } from '@components/HtmlContent';
+import { MetaTags } from '@components/MetaTags';
 import {
   Sidebar,
   SidebarAudioList,
@@ -82,7 +82,16 @@ export const Bio = () => {
   const { items: segments, count: segmentsCount, size: segmentsSize } =
     segmentsState || {};
   const segmentsPageCount = Math.ceil(segmentsCount / segmentsSize);
-  const { title, teaser, image, bio, program, position, socialLinks } = data;
+  const {
+    metatags,
+    title,
+    teaser,
+    image,
+    bio,
+    program,
+    position,
+    socialLinks
+  } = data;
   const { twitter, tumblr, podcast, blog, website, rss, contact } =
     socialLinks || {};
   const followLinks = [
@@ -287,9 +296,7 @@ export const Bio = () => {
 
   return (
     <>
-      <Head>
-        <title>{title}</title>
-      </Head>
+      <MetaTags data={metatags} />
       <BioHeader
         title={title}
         position={position}

--- a/components/pages/Category/Category.tsx
+++ b/components/pages/Category/Category.tsx
@@ -3,7 +3,6 @@
  * Component for Category.
  */
 import React, { useContext, useEffect, useState } from 'react';
-import Head from 'next/head';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
@@ -30,6 +29,7 @@ import { StoryCardGrid } from '@components/StoryCardGrid';
 import { fetchApiCategoryStories } from '@lib/fetch';
 import { HtmlContent } from '@components/HtmlContent';
 import { LandingPageHeader } from '@components/LandingPageHeader';
+import { MetaTags } from '@components/MetaTags';
 import { SidebarContent } from '@components/Sidebar/SidebarContent';
 import { AppContext } from '@contexts/AppContext';
 import { RootState } from '@interfaces/state';
@@ -96,6 +96,7 @@ export const Category = () => {
   const storiesState = getCollectionData(state, type, id, 'stories');
   const { items: stories, page, next } = storiesState;
   const {
+    metatags,
     title,
     teaser,
     bannerImage,
@@ -291,9 +292,7 @@ export const Category = () => {
 
   return (
     <>
-      <Head>
-        <title>{title}</title>
-      </Head>
+      <MetaTags data={metatags} />
       <LandingPageHeader
         title={title}
         subhead={teaser}

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
-import Head from 'next/head';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
@@ -22,6 +21,7 @@ import { ThemeProvider } from '@material-ui/core/styles';
 import { EqualizerRounded } from '@material-ui/icons';
 import { AudioPlayer } from '@components/AudioPlayer';
 import { HtmlContent } from '@components/HtmlContent';
+import { MetaTags } from '@components/MetaTags';
 import {
   Sidebar,
   SidebarAudioList,
@@ -69,7 +69,7 @@ export const Episode = () => {
   }
 
   const {
-    title,
+    metatags,
     body,
     audio,
     embeddedPlayerUrl,
@@ -127,10 +127,7 @@ export const Episode = () => {
 
   return (
     <ThemeProvider theme={episodeTheme}>
-      <Head>
-        <title>{title}</title>
-        {/* TODO: WIRE UP ANALYTICS */}
-      </Head>
+      <MetaTags data={metatags} />
       <Container fixed>
         <Grid container>
           <Grid item xs={12}>

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -4,14 +4,12 @@
  */
 import React, { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
-import Head from 'next/head';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import { Box, Hidden } from '@material-ui/core';
 import { LandingPage } from '@components/LandingPage';
-import { OpenGraph } from '@components/OpenGraph';
 import { SidebarLatestStories } from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
@@ -19,7 +17,7 @@ import { SidebarEpisode } from '@components/Sidebar/SidebarEpisode';
 import { ICtaRegionProps } from '@interfaces/cta';
 import { fetchCtaData, fetchHomepageData } from '@store/actions';
 import { getCollectionData, getCtaRegionData } from '@store/reducers';
-import { TwitterCard } from '@components/TwitterCard';
+import { MetaTags } from '@components/MetaTags';
 
 const CtaRegion = dynamic(
   () => import('@components/CtaRegion').then(mod => mod.CtaRegion) as any
@@ -200,26 +198,31 @@ export const Homepage = () => {
   const title = 'The World';
   const description =
     'The World is a public radio program that crosses borders and time zones to bring home the stories that matter. From PRX.';
-  const url = 'https://theworld.org/';
-  const image = {
-    src: 'https://media.pri.org/s3fs-public/images/2020/04/tw-globe-bg-3000.jpg'
-  };
-  const baseProps = {
+  const url = '/';
+  const image =
+    'https://media.pri.org/s3fs-public/images/2020/04/tw-globe-bg-3000.jpg';
+  const metatags = {
     title,
     description,
-    url,
-    image
+    canonical: url,
+    'og:type': 'website',
+    'og:title': title,
+    'og:description': description,
+    'og:url': url,
+    'og:image': image,
+    'og:image:width': '3000',
+    'og:image:height': '3000',
+    'og:local': 'en_US',
+    'twitter:card': 'summary',
+    'twitter:title': title,
+    'twitter:description': description,
+    'twitter:url': url,
+    'twitter:image': image
   };
 
   return (
     <>
-      <Head>
-        <title>{title}</title>
-        <meta name="description" content={description} />
-        <link rel="canonical" href={url} />
-        <OpenGraph {...baseProps} type="webiste" />
-        <TwitterCard {...baseProps} type="summary" />
-      </Head>
+      <MetaTags data={metatags} />
       <LandingPage main={mainElements} sidebar={sidebarElements} />
     </>
   );

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -216,6 +216,7 @@ export const Homepage = () => {
       <Head>
         <title>{title}</title>
         <meta name="description" content={description} />
+        <link rel="canonical" href={url} />
         <OpenGraph {...baseProps} type="webiste" />
         <TwitterCard {...baseProps} type="summary" />
       </Head>

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -19,6 +19,7 @@ import { SidebarEpisode } from '@components/Sidebar/SidebarEpisode';
 import { ICtaRegionProps } from '@interfaces/cta';
 import { fetchCtaData, fetchHomepageData } from '@store/actions';
 import { getCollectionData, getCtaRegionData } from '@store/reducers';
+import { TwitterCard } from '@components/TwitterCard';
 
 const CtaRegion = dynamic(
   () => import('@components/CtaRegion').then(mod => mod.CtaRegion) as any
@@ -197,37 +198,26 @@ export const Homepage = () => {
   }, []);
 
   const title = 'The World';
+  const description =
+    'The World is a public radio program that crosses borders and time zones to bring home the stories that matter. From PRX.';
+  const url = 'https://theworld.org/';
+  const image = {
+    src: 'https://media.pri.org/s3fs-public/images/2020/04/tw-globe-bg-3000.jpg'
+  };
   const baseProps = {
     title,
-    description:
-      'The World is a public radio program that crosses borders and time zones to bring home the stories that matter. From PRX.',
-    url: 'https://theworld.org/'
+    description,
+    url,
+    image
   };
 
   return (
     <>
       <Head>
         <title>{title}</title>
-        {/* Open Graph */}
-        <OpenGraph
-          {...baseProps}
-          type="webiste"
-          image={{
-            src:
-              'https://media.pri.org/s3fs-public/images/2020/04/tw-globe-bg-3000.jpg'
-          }}
-        >
-          <meta property="prx:test" content="foo" />
-        </OpenGraph>
-        {/* Twitter */}
-        {/* <meta property="twitter:card" content="summary" />
-        <meta property="twitter:title" content={metaTitle} />
-        <meta property="twitter:description" content={metaDescription} />
-        <meta property="twitter:url" content={metaUrl} />
-        <meta
-          property="twitter:image"
-          content="https://media.pri.org/s3fs-public/pri_og-default.jpg"
-        /> */}
+        <meta name="description" content={description} />
+        <OpenGraph {...baseProps} type="webiste" />
+        <TwitterCard {...baseProps} type="summary" />
       </Head>
       <LandingPage main={mainElements} sidebar={sidebarElements} />
     </>

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -11,6 +11,7 @@ import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import { Box, Hidden } from '@material-ui/core';
 import { LandingPage } from '@components/LandingPage';
+import { OpenGraph } from '@components/OpenGraph';
 import { SidebarLatestStories } from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
@@ -195,10 +196,38 @@ export const Homepage = () => {
     };
   }, []);
 
+  const title = 'The World';
+  const baseProps = {
+    title,
+    description:
+      'The World is a public radio program that crosses borders and time zones to bring home the stories that matter. From PRX.',
+    url: 'https://theworld.org/'
+  };
+
   return (
     <>
       <Head>
-        <title>The World</title>
+        <title>{title}</title>
+        {/* Open Graph */}
+        <OpenGraph
+          {...baseProps}
+          type="webiste"
+          image={{
+            src:
+              'https://media.pri.org/s3fs-public/images/2020/04/tw-globe-bg-3000.jpg'
+          }}
+        >
+          <meta property="prx:test" content="foo" />
+        </OpenGraph>
+        {/* Twitter */}
+        {/* <meta property="twitter:card" content="summary" />
+        <meta property="twitter:title" content={metaTitle} />
+        <meta property="twitter:description" content={metaDescription} />
+        <meta property="twitter:url" content={metaUrl} />
+        <meta
+          property="twitter:image"
+          content="https://media.pri.org/s3fs-public/pri_og-default.jpg"
+        /> */}
       </Head>
       <LandingPage main={mainElements} sidebar={sidebarElements} />
     </>

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -195,7 +195,7 @@ export const Homepage = () => {
     };
   }, []);
 
-  const title = 'The World';
+  const title = 'The World from PRX';
   const description =
     'The World is a public radio program that crosses borders and time zones to bring home the stories that matter. From PRX.';
   const url = '/';

--- a/components/pages/Newsletter/Newsletter.tsx
+++ b/components/pages/Newsletter/Newsletter.tsx
@@ -5,7 +5,6 @@
 import React, { useContext, useState, useEffect } from 'react';
 import { useStore } from 'react-redux';
 import classNames from 'classnames/bind';
-import Head from 'next/head';
 import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import {
@@ -19,6 +18,7 @@ import { CheckCircleOutlineSharp } from '@material-ui/icons';
 import { AppContext } from '@contexts/AppContext';
 import { HtmlContent } from '@components/HtmlContent';
 import { Image } from '@components/Image';
+import { MetaTags } from '@components/MetaTags';
 import { NewsletterForm } from '@components/NewsletterForm';
 import { IPriApiNewsletter } from '@interfaces/newsletter';
 import { RootState } from '@interfaces/state';
@@ -42,7 +42,7 @@ export const Newsletter = () => {
   }
 
   const [subscribed, setSubscribed] = useState(false);
-  const { title, body, buttonLabel, summary, image } = data;
+  const { metatags, title, body, buttonLabel, summary, image } = data;
   const options = parseNewsletterOptions(
     data as IPriApiNewsletter,
     'newsletter-page'
@@ -66,9 +66,7 @@ export const Newsletter = () => {
 
   return (
     <>
-      <Head>
-        <title>{title}</title>
-      </Head>
+      <MetaTags data={metatags} />
       <ThemeProvider theme={newsletterTheme}>
         <Container disableGutters={!!image} maxWidth={false}>
           <Grid container justify="center">

--- a/components/pages/Page/Page.tsx
+++ b/components/pages/Page/Page.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useContext, useEffect } from 'react';
-import Head from 'next/head';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
@@ -12,6 +11,7 @@ import { Box, Container, Grid } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { AppContext } from '@contexts/AppContext';
 import { HtmlContent } from '@components/HtmlContent';
+import { MetaTags } from '@components/MetaTags';
 import { RootState } from '@interfaces/state';
 import { fetchPageData } from '@store/actions';
 import { getDataByResource } from '@store/reducers';
@@ -33,7 +33,7 @@ export const Page = () => {
     return null;
   }
 
-  const { title, body } = data;
+  const { metatags, body } = data;
 
   useEffect(() => {
     if (!data.complete) {
@@ -47,10 +47,7 @@ export const Page = () => {
 
   return (
     <ThemeProvider theme={pageTheme}>
-      <Head>
-        <title>{title}</title>
-        {/* TODO: WIRE UP ANALYTICS */}
-      </Head>
+      <MetaTags data={metatags} />
       <Container fixed>
         <Grid container>
           <Grid item xs={12}>

--- a/components/pages/Program/Program.tsx
+++ b/components/pages/Program/Program.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
@@ -24,6 +23,7 @@ import { ThemeProvider } from '@material-ui/core/styles';
 import { CtaRegion } from '@components/CtaRegion';
 import { HtmlContent } from '@components/HtmlContent';
 import { LandingPage } from '@components/LandingPage';
+import { MetaTags } from '@components/MetaTags';
 import {
   Sidebar,
   SidebarContent,
@@ -120,6 +120,7 @@ export const Program = () => {
   const latestEpisode = episodes && episodes[1].shift();
   const hasContentLinks = hasStories || hasEpisodes;
   const {
+    metatags,
     title,
     teaser,
     bannerImage,
@@ -374,11 +375,14 @@ export const Program = () => {
 
   return (
     <ThemeProvider theme={programTheme}>
-      <Head>
-        <title>
-          {title} | {!isEpisodesView ? 'Stories' : 'Episodes'}
-        </title>
-      </Head>
+      <MetaTags
+        data={{
+          ...metatags,
+          title: `${metatags.title} | ${
+            !isEpisodesView ? 'Stories' : 'Episodes'
+          }`
+        }}
+      />
       <LandingPageHeader
         title={title}
         subhead={teaser}

--- a/components/pages/Story/Story.tsx
+++ b/components/pages/Story/Story.tsx
@@ -3,11 +3,11 @@
  * Component for Story.
  */
 import React, { useContext, useEffect, useState } from 'react';
-import Head from 'next/head';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { AppContext } from '@contexts/AppContext';
+import { MetaTags } from '@components/MetaTags';
 import { RootState } from '@interfaces/state';
 import { fetchApiCategoryStories } from '@lib/fetch';
 import {
@@ -30,7 +30,7 @@ export const Story = () => {
     updateForce(store.getState());
   });
   let data = getDataByResource(state, type, id);
-  const { title, displayTemplate } = data;
+  const { metatags, displayTemplate } = data;
   const LayoutComponent =
     layoutComponentMap[displayTemplate] || layoutComponentMap.standard;
 
@@ -104,10 +104,7 @@ export const Story = () => {
 
   return (
     <>
-      <Head>
-        <title>{title}</title>
-        {/* TODO: WIRE UP ANALYTICS */}
-      </Head>
+      <MetaTags data={metatags} />
       <LayoutComponent data={data} />
     </>
   );

--- a/components/pages/Team/Team.tsx
+++ b/components/pages/Team/Team.tsx
@@ -51,7 +51,7 @@ export const Team = () => {
   const sizes = imageWidth.map(([q, w]) => (q ? `(${q}) ${w}` : w)).join(', ');
 
   const title = "The World's Team";
-  const description = 'Meet the team that makes The World.';
+  const description = 'Meet the team who brings you The World.';
   const metaUrl = '/programs/the-world/team';
   const image =
     'https://media.pri.org/s3fs-public/images/2020/04/tw-globe-bg-3000.jpg';

--- a/components/pages/Team/Team.tsx
+++ b/components/pages/Team/Team.tsx
@@ -6,7 +6,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import Head from 'next/head';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
@@ -24,6 +23,7 @@ import {
 } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { ContentLink } from '@components/ContentLink';
+import { MetaTags } from '@components/MetaTags';
 import { AppContext } from '@contexts/AppContext';
 import { generateLinkHrefForContent } from '@lib/routing';
 import { fetchTeamData } from '@store/actions';
@@ -43,13 +43,36 @@ export const Team = () => {
   const state = store.getState();
   const classes = teamStyles({});
   const cx = classNames.bind(classes);
-  const title = "The World's Team";
   const { items } = getCollectionData(state, type, id, 'members');
   const imageWidth = [
     ['max-width: 600px', '100wv'],
     [null, '300px']
   ];
   const sizes = imageWidth.map(([q, w]) => (q ? `(${q}) ${w}` : w)).join(', ');
+
+  const title = "The World's Team";
+  const description = 'Meet the team that makes The World.';
+  const metaUrl = '/programs/the-world/team';
+  const image =
+    'https://media.pri.org/s3fs-public/images/2020/04/tw-globe-bg-3000.jpg';
+  const metatags = {
+    title,
+    description,
+    canonical: metaUrl,
+    'og:type': 'website',
+    'og:title': title,
+    'og:description': description,
+    'og:url': metaUrl,
+    'og:image': image,
+    'og:image:width': '3000',
+    'og:image:height': '3000',
+    'og:local': 'en_US',
+    'twitter:card': 'summary',
+    'twitter:title': title,
+    'twitter:description': description,
+    'twitter:url': metaUrl,
+    'twitter:image': image
+  };
 
   useEffect(() => {
     const handleRouteChangeStart = (url: string) => {
@@ -72,10 +95,7 @@ export const Team = () => {
 
   return (
     <ThemeProvider theme={teamTheme}>
-      <Head>
-        <title>{title}</title>
-        {/* TODO: WIRE UP ANALYTICS */}
-      </Head>
+      <MetaTags data={metatags} />
       <Container fixed>
         <TeamHeader title={title} />
         <Grid container spacing={3}>

--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -3,7 +3,6 @@
  * Component for Term.
  */
 import React, { useContext, useEffect, useState } from 'react';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
@@ -24,7 +23,9 @@ import { SidebarCta, SidebarLatestStories } from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
 import { fetchApiTermEpisodes, fetchApiTermStories } from '@lib/fetch';
+import { EpisodeCard } from '@components/EpisodeCard';
 import { LandingPageHeader } from '@components/LandingPageHeader';
+import { MetaTags } from '@components/MetaTags';
 import { SidebarEpisode } from '@components/Sidebar/SidebarEpisode';
 import { AppContext } from '@contexts/AppContext';
 import { RootState } from '@interfaces/state';
@@ -39,7 +40,6 @@ import {
   getDataByResource
 } from '@store/reducers';
 import { generateLinkPropsForContent } from '@lib/routing';
-import { EpisodeCard } from '@components/EpisodeCard';
 
 export const Term = () => {
   const {
@@ -106,7 +106,7 @@ export const Term = () => {
   const isEpisodesView =
     (query.v === 'episodes' && hasEpisodes) || (hasEpisodes && !hasStories);
   const latestEpisode = episodes && episodes[1].shift();
-  const { title, description } = data;
+  const { metatags, title, description } = data;
   const [loadingStories, setLoadingStories] = useState(false);
   const [loadingEpisodes, setLoadingEpisodes] = useState(false);
   const [oldscrollY, setOldScrollY] = useState(0);
@@ -330,9 +330,7 @@ export const Term = () => {
 
   return (
     <>
-      <Head>
-        <title>{title}</title>
-      </Head>
+      <MetaTags data={metatags} />
       <LandingPageHeader title={title} subhead={description} />
       {hasStories && hasEpisodes && (
         <AppBar position="static" color="transparent">

--- a/config/development.js
+++ b/config/development.js
@@ -6,29 +6,13 @@ module.exports = {
     apiVersion: '1.0'
   },
   fb: {
+    admins: '16800048',
     appId: '142079625983010',
     clientToken: '987e1f53e945ba53f8fbd95d8c82c93e',
     clientAccessToken: '142079625983010|987e1f53e945ba53f8fbd95d8c82c93e'
   },
-  analytics: {
-    chartBeat: {
-      uid: 12345
-    },
-    comscore: {
-      c1: '0',
-      c2: '00000'
-    },
-    crazyEgg: {
-      accountId: '00000000'
-    },
-    facebook: {
-      id: 1234567890
-    },
-    google: {
-      uaid: 'UA-XXXXXXX-X'
-    },
-    twitter: {
-      pixelId: 'xxxxx'
-    }
-  }
+  twitter: {
+    accountId: '24953039'
+  },
+  analytics: {}
 };

--- a/config/production.js
+++ b/config/production.js
@@ -6,32 +6,13 @@ module.exports = {
     apiVersion: '1.0'
   },
   fb: {
+    admins: '16800048',
     appId: '142079625983010',
     clientToken: '987e1f53e945ba53f8fbd95d8c82c93e',
     clientAccessToken: '142079625983010|987e1f53e945ba53f8fbd95d8c82c93e'
   },
-  analytics: {
-    chartBeat: {
-      uid: 19027,
-      domain: 'pri.org',
-      useCanonical: true,
-      noCookies: true
-    },
-    comscore: {
-      c1: '2',
-      c2: '20076093'
-    },
-    crazyEgg: {
-      accountId: '00224394'
-    },
-    facebook: {
-      id: 813271415445416
-    },
-    google: {
-      uaid: 'UA-2145282-1'
-    },
-    twitter: {
-      pixelId: 'nwehg'
-    }
-  }
+  twitter: {
+    accountId: '24953039'
+  },
+  analytics: {}
 };

--- a/interfaces/content/image.interface.ts
+++ b/interfaces/content/image.interface.ts
@@ -1,0 +1,6 @@
+export interface IImageStyle {
+  src: string;
+  type?: string;
+  width?: number;
+  height?: number;
+}

--- a/interfaces/content/index.ts
+++ b/interfaces/content/index.ts
@@ -1,1 +1,2 @@
 export * from './content.interface';
+export * from './image.interface';

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,8 @@ module.exports = {
   snapshotSerializers: ['enzyme-to-json/serializer'],
   testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
+    '\\.tsx$': 'babel-jest',
+    '\\.tsx?$': 'ts-jest'
   },
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],

--- a/lib/fetch/api/params/audio.ts
+++ b/lib/fetch/api/params/audio.ts
@@ -11,6 +11,7 @@ export const basicAudioParams = {
 export const fullAudioParams = {
   include: ['audioAuthor', 'program'],
   fields: [
+    'metatags',
     'audioAuthor.title',
     'audioAuthor.metatags',
     'audioTitle',

--- a/lib/fetch/category/fetchCategory.ts
+++ b/lib/fetch/category/fetchCategory.ts
@@ -25,6 +25,7 @@ export const fetchCategory = async (
       )
     ],
     fields: [
+      'metatags',
       'title',
       'teaser',
       'bannerImage',

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -30,6 +30,10 @@ class TwDocument extends Document {
             href="/opensearch.xml"
           />
           <link rel="icon" href="/images/favicon.png" />
+          {/* Open Graph */}
+          <meta property="og:site_name" content="The World from PRX" />
+          {/* Twitter */}
+          <meta property="twitter:account_id" content="24953039" />
         </Head>
         <body>
           <Main />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -30,10 +30,6 @@ class TwDocument extends Document {
             href="/opensearch.xml"
           />
           <link rel="icon" href="/images/favicon.png" />
-          {/* Open Graph */}
-          <meta property="og:site_name" content="The World from PRX" />
-          {/* Twitter */}
-          <meta property="twitter:account_id" content="24953039" />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
Closes #146 

- Adds meta tags to all page types.

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Visit pages and review metatags found in the `<head>`. You may want to disable javascript to see all tags delivered with the page, since some may be removed as Nextjs initializes the page.
- [x] If you are using the deploy link, you can submit the URL to the Facebook and Twitter validators.
- [x] NOTE: Not all landing pages have complete metadata defined, ie. descriptions. Every tag returned in an API resources `metatags` object are being added to the page. If it's not in the data, the app can't make it up.
