### PR TITLE
#189: App CTA banner data

### DIFF
--- a/components/AppCtaBanner/AppCtaBanner.tsx
+++ b/components/AppCtaBanner/AppCtaBanner.tsx
@@ -3,7 +3,7 @@
  * Component for CTA banner region.
  */
 
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useStore } from 'react-redux';
 import classNames from 'classnames/bind';
 import { getShownMessage, setCtaCookie } from '@lib/cta';
@@ -17,7 +17,10 @@ import { ctaTypeComponentMap } from './components';
 
 export const AppCtaBanner = () => {
   const store = useStore();
-  const state = store.getState();
+  const [state, setState] = useState(store.getState());
+  const unsub = store.subscribe(() => {
+    setState(store.getState());
+  });
   const {
     page: {
       resource: { type, id }
@@ -42,6 +45,12 @@ export const AppCtaBanner = () => {
     // Close prompt.
     setClosed(true);
   };
+
+  useEffect(() => {
+    return () => {
+      unsub();
+    };
+  }, []);
 
   return (
     CtaMessageComponent &&

--- a/components/AppCtaBanner/AppCtaBanner.tsx
+++ b/components/AppCtaBanner/AppCtaBanner.tsx
@@ -18,9 +18,6 @@ import { ctaTypeComponentMap } from './components';
 export const AppCtaBanner = () => {
   const store = useStore();
   const [state, setState] = useState(store.getState());
-  const unsub = store.subscribe(() => {
-    setState(store.getState());
-  });
   const {
     page: {
       resource: { type, id }
@@ -31,6 +28,10 @@ export const AppCtaBanner = () => {
   const { type: msgType } = shownMessage || {};
   const CtaMessageComponent = ctaTypeComponentMap[msgType] || null;
   const [closed, setClosed] = useState(false);
+  const unsub = store.subscribe(() => {
+    setClosed(false);
+    setState(store.getState());
+  });
   const classes = appCtaBannerStyles({});
   const cx = classNames.bind(classes);
 
@@ -41,7 +42,7 @@ export const AppCtaBanner = () => {
 
     const { name, hash, cookieLifespan } = shownMessage;
     // Set cookie for region message.
-    setCtaCookie(name, hash, +cookieLifespan);
+    setCtaCookie(name, hash, cookieLifespan);
     // Close prompt.
     setClosed(true);
   };

--- a/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
+++ b/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
@@ -3,7 +3,7 @@
  * Component for CTA load-under region.
  */
 
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useStore } from 'react-redux';
 import classNames from 'classnames/bind';
 import { getShownMessage, setCtaCookie } from '@lib/cta';
@@ -20,7 +20,10 @@ import { ctaTypeComponentMap } from './components';
 
 export const AppCtaLoadUnder = () => {
   const store = useStore();
-  const state = store.getState();
+  const [state, setState] = useState(store.getState());
+  const unsub = store.subscribe(() => {
+    setState(store.getState());
+  });
   const {
     page: {
       resource: { type, id }
@@ -40,16 +43,18 @@ export const AppCtaLoadUnder = () => {
   const cx = classNames.bind(classes);
 
   const handleClose = () => {
-    // Check if cookies allowed.
-
-    // Prompt if saving cookie is ok.
-
     const { name, hash, cookieLifespan } = shownMessage;
     // Set cookie for region message.
     setCtaCookie(name, hash, +cookieLifespan);
     // Close prompt.
     setClosed(true);
   };
+
+  useEffect(() => {
+    return () => {
+      unsub();
+    };
+  }, []);
 
   return (
     CtaMessageComponent &&

--- a/components/pages/Audio/Audio.tsx
+++ b/components/pages/Audio/Audio.tsx
@@ -104,7 +104,7 @@ export const Audio = () => {
     const context = [`file:${data.id}`, `node:${data.program.id}`];
     (async () => {
       await store.dispatch<any>(
-        fetchCtaData('tw_cta_regions_content', type, id, context)
+        fetchCtaData(type, id, 'tw_cta_regions_content', context)
       );
     })();
 

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -134,7 +134,7 @@ export const Bio = () => {
       // Get CTA message data.
       const context = [`node:${id}`];
       await store.dispatch<any>(
-        fetchCtaData('tw_cta_regions_landing', type, id, context)
+        fetchCtaData(type, id, 'tw_cta_regions_landing', context)
       );
     })();
   }, [id]);

--- a/components/pages/Category/Category.tsx
+++ b/components/pages/Category/Category.tsx
@@ -135,7 +135,7 @@ export const Category = () => {
       // Get CTA message data.
       const context = [`term:${id}`];
       await store.dispatch<any>(
-        fetchCtaData('tw_cta_regions_landing', type, id, context)
+        fetchCtaData(type, id, 'tw_cta_regions_landing', context)
       );
     })();
   }, [id]);

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -167,7 +167,7 @@ export const Episode = () => {
     const context = [`node:${data.id}`, `node:${data.program.id}`];
     (async () => {
       await store.dispatch<any>(
-        fetchCtaData('tw_cta_regions_content', type, id, context)
+        fetchCtaData(type, id, 'tw_cta_regions_content', context)
       );
     })();
 

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -188,7 +188,7 @@ export const Homepage = () => {
     const context = ['node:3704'];
     (async () => {
       await store.dispatch<any>(
-        fetchCtaData('tw_cta_regions_landing', 'homepage', undefined, context)
+        fetchCtaData('homepage', undefined, 'tw_cta_regions_landing', context)
       );
     })();
 

--- a/components/pages/Program/Program.tsx
+++ b/components/pages/Program/Program.tsx
@@ -158,7 +158,7 @@ export const Program = () => {
       // Get CTA message data.
       const context = [`node:${id}`];
       await store.dispatch<any>(
-        fetchCtaData('tw_cta_regions_landing', type, id, context)
+        fetchCtaData(type, id, 'tw_cta_regions_landing', context)
       );
     })();
   }, [id]);

--- a/components/pages/Story/Story.tsx
+++ b/components/pages/Story/Story.tsx
@@ -13,7 +13,7 @@ import { Plausible, PlausibleEventArgs } from '@components/Plausible';
 import { RootState } from '@interfaces/state';
 import { fetchApiCategoryStories } from '@lib/fetch';
 import { appendResourceCollection } from '@store/actions/appendResourceCollection';
-import { fetchCtaData } from '@store/actions/fetchCtaData';
+// import { fetchCtaData } from '@store/actions/fetchCtaData';
 import { fetchStoryData } from '@store/actions/fetchStoryData';
 import { getDataByResource, getCollectionData } from '@store/reducers';
 import { layoutComponentMap } from './layouts';
@@ -128,25 +128,25 @@ export const Story = () => {
       })();
     }
 
-    // Get CTA message data.
-    const context = [
-      `node:${data.id}`,
-      `node:${data.program?.id}`,
-      `term:${data.primaryCategory?.id}`,
-      ...((data.categories &&
-        !!data.categories.length &&
-        data.categories.filter(v => !!v).map(({ id: tid }) => `term:${tid}`)) ||
-        []),
-      ...((data.vertical &&
-        !!data.vertical.length &&
-        data.vertical.filter(v => !!v).map(({ tid }) => `term:${tid}`)) ||
-        [])
-    ];
-    (async () => {
-      await store.dispatch<any>(
-        fetchCtaData(type, id, 'tw_cta_regions_content', context)
-      );
-    })();
+    // // Get CTA message data.
+    // const context = [
+    //   `node:${data.id}`,
+    //   `node:${data.program?.id}`,
+    //   `term:${data.primaryCategory?.id}`,
+    //   ...((data.categories &&
+    //     !!data.categories.length &&
+    //     data.categories.filter(v => !!v).map(({ id: tid }) => `term:${tid}`)) ||
+    //     []),
+    //   ...((data.vertical &&
+    //     !!data.vertical.length &&
+    //     data.vertical.filter(v => !!v).map(({ tid }) => `term:${tid}`)) ||
+    //     [])
+    // ];
+    // (async () => {
+    //   await store.dispatch<any>(
+    //     fetchCtaData(type, id, 'tw_cta_regions_content', context)
+    //   );
+    // })();
 
     return () => {
       unsub();

--- a/components/pages/Story/Story.tsx
+++ b/components/pages/Story/Story.tsx
@@ -144,7 +144,7 @@ export const Story = () => {
     ];
     (async () => {
       await store.dispatch<any>(
-        fetchCtaData('tw_cta_regions_content', type, id, context)
+        fetchCtaData(type, id, 'tw_cta_regions_content', context)
       );
     })();
 

--- a/components/pages/Story/layouts/default/Story.default.tsx
+++ b/components/pages/Story/layouts/default/Story.default.tsx
@@ -3,7 +3,7 @@
  * Component for default Story layout.
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { convertNodeToElement, Transform } from 'react-html-parser';
 import { DomElement } from 'htmlparser2';
@@ -69,7 +69,10 @@ export const StoryDefault = ({ data }: Props) => {
     opencalaisPerson
   } = data;
   const store = useStore();
-  const state = store.getState();
+  const [state, updateForce] = useState(store.getState());
+  const unsub = store.subscribe(() => {
+    updateForce(store.getState());
+  });
   const relatedState =
     primaryCategory &&
     getCollectionData(
@@ -205,6 +208,12 @@ export const StoryDefault = ({ data }: Props) => {
         ];
     }
   });
+
+  useEffect(() => {
+    return () => {
+      unsub();
+    };
+  }, []);
 
   return (
     <ThemeProvider theme={storyTheme}>

--- a/interfaces/state/ctaData.interface.ts
+++ b/interfaces/state/ctaData.interface.ts
@@ -4,18 +4,39 @@
  * Define interfaces for ctaData.
  */
 
+import { AnyAction } from 'redux';
 import { ICtaMessage } from '@interfaces/cta';
 
 export interface CtaDataState {
   // Key: Resource signature.
   [k: string]: {
+    pageType: string;
     context: string[];
-    groups: {
+    groups?: {
       // Key: CTA region group.
       // Value: array of CTA region keys.
       [k: string]: string[];
     };
-    data: {
+    data?: {
+      // Key: CTA region.
+      [k: string]: ICtaMessage[];
+    };
+  };
+}
+
+export interface CtaAction extends AnyAction {
+  payload: {
+    ctaData?: CtaDataState;
+    type: string;
+    id: string;
+    pageType: string;
+    context: string[];
+    groups?: {
+      // Key: CTA region group.
+      // Value: array of CTA region keys.
+      [k: string]: string[];
+    };
+    data?: {
       // Key: CTA region.
       [k: string]: ICtaMessage[];
     };

--- a/interfaces/state/ctaData.interface.ts
+++ b/interfaces/state/ctaData.interface.ts
@@ -10,8 +10,8 @@ import { ICtaMessage } from '@interfaces/cta';
 export interface CtaDataState {
   // Key: Resource signature.
   [k: string]: {
-    pageType: string;
-    context: string[];
+    pageType?: string;
+    context?: string[];
     groups?: {
       // Key: CTA region group.
       // Value: array of CTA region keys.

--- a/interfaces/state/pageState.interface.ts
+++ b/interfaces/state/pageState.interface.ts
@@ -1,0 +1,22 @@
+/**
+ * @file pageState.interface.ts
+ *
+ * Define interfaces for page state.
+ */
+
+import { AnyAction } from 'redux';
+
+export interface PageResourceState {
+  type: string;
+  id: string;
+}
+
+export interface PageState {
+  resource?: PageResourceState;
+}
+
+export interface PageAction extends AnyAction {
+  payload: {
+    resource?: PageResourceState;
+  };
+}

--- a/interfaces/state/ui.interface.ts
+++ b/interfaces/state/ui.interface.ts
@@ -1,7 +1,7 @@
 /**
- * @file loading.interface.ts
+ * @file ui.interface.ts
  *
- * Define interfaces for loading state.
+ * Define interfaces for ui state.
  */
 
 import { AnyAction } from 'redux';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,6 +22,10 @@ import { fetchCtaData } from '@store/actions/fetchCtaData';
 
 const TwApp: FC<AppProps> = ({ Component, pageProps }: AppProps) => {
   const store = useStore();
+  const [, setState] = useState(store.getState());
+  const unsub = store.subscribe(() => {
+    setState(store.getState());
+  });
   const [plausibleDomain, setPlausibleDomain] = useState(null);
   const { type, id } = pageProps;
   const contextValue = {
@@ -42,6 +46,10 @@ const TwApp: FC<AppProps> = ({ Component, pageProps }: AppProps) => {
     if (jssStyles) {
       jssStyles.parentElement.removeChild(jssStyles);
     }
+
+    return () => {
+      unsub();
+    };
   }, []);
 
   useEffect(() => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,12 +4,13 @@
  */
 
 import React, { FC, useEffect, useState } from 'react';
+import { useStore } from 'react-redux';
 import { AppProps } from 'next/app';
 import PlausibleProvider from 'next-plausible';
 import { ThemeProvider, Box, CssBaseline } from '@material-ui/core';
 import { analytics } from '@config';
-// import { AppCtaBanner } from '@components/AppCtaBanner';
-// import { AppCtaLoadUnder } from '@components/AppCtaLoadUnder';
+import { AppCtaBanner } from '@components/AppCtaBanner';
+import { AppCtaLoadUnder } from '@components/AppCtaLoadUnder';
 import { AppFooter } from '@components/AppFooter';
 import { AppHeader } from '@components/AppHeader';
 import { AppLoadingBar } from '@components/AppLoadingBar';
@@ -17,8 +18,10 @@ import { AppSearch } from '@components/AppSearch';
 import { AppContext } from '@contexts/AppContext';
 import { baseMuiTheme, appTheme } from '@theme/App.theme';
 import { wrapper } from '@store';
+import { fetchCtaData } from '@store/actions/fetchCtaData';
 
 const TwApp: FC<AppProps> = ({ Component, pageProps }: AppProps) => {
+  const store = useStore();
   const [plausibleDomain, setPlausibleDomain] = useState(null);
   const { type, id } = pageProps;
   const contextValue = {
@@ -43,6 +46,10 @@ const TwApp: FC<AppProps> = ({ Component, pageProps }: AppProps) => {
 
   useEffect(() => {
     window.scrollTo({ top: 0, left: 0 });
+    // Fetch CTA messages for this resource.
+    (async () => {
+      await store.dispatch<any>(fetchCtaData(type, id, 'tw_cta_regions_site'));
+    })();
   }, [type, id]);
 
   return (
@@ -51,7 +58,7 @@ const TwApp: FC<AppProps> = ({ Component, pageProps }: AppProps) => {
         <AppContext.Provider value={contextValue}>
           <Box minHeight="100vh" display="flex" flexDirection="column">
             <AppLoadingBar />
-            {/* <AppCtaBanner /> */}
+            <AppCtaBanner />
             <AppHeader />
             <Box flexGrow={1}>
               <PlausibleProvider
@@ -65,7 +72,7 @@ const TwApp: FC<AppProps> = ({ Component, pageProps }: AppProps) => {
             </Box>
             <AppFooter />
             <AppSearch />
-            {/* <AppCtaLoadUnder /> */}
+            <AppCtaLoadUnder />
           </Box>
         </AppContext.Provider>
         <CssBaseline />
@@ -73,79 +80,5 @@ const TwApp: FC<AppProps> = ({ Component, pageProps }: AppProps) => {
     </ThemeProvider>
   );
 };
-
-// TwApp.getInitialProps = wrapper.getInitialAppProps(
-//   store => async ({ Component, ctx }) => {
-//     const { req } = ctx;
-
-//     store.dispatch({ type: 'LOADING_APP_DATA' });
-
-//     // Fetch App Data
-//     await store.dispatch<any>(fetchAppData(req));
-
-//     return {
-//       pageProps: {
-//         // Call page-level getInitialProps
-//         // DON'T FORGET TO PROVIDE STORE TO PAGE
-//         ...(Component.getInitialProps
-//           ? await Component.getInitialProps({ ...ctx, store })
-//           : {})
-//       }
-//     };
-//   }
-// );
-
-// class MyApp extends App<AppInitialProps> {
-//   public static getInitialProps = wrapper.getInitialAppProps(
-//     store => async ({ Component, ctx }) => {
-//       store.dispatch({ type: 'TOE', payload: 'was set in _app' });
-
-//       return {
-//         pageProps: {
-//           // Call page-level getInitialProps
-//           // DON'T FORGET TO PROVIDE STORE TO PAGE
-//           ...(Component.getInitialProps
-//             ? await Component.getInitialProps({ ...ctx, store })
-//             : {}),
-//           // Some custom thing for all pages
-//           pathname: ctx.pathname
-//         }
-//       };
-//     }
-//   );
-
-//   public render() {
-//     const { Component, pageProps } = this.props;
-//     const { type, id } = pageProps;
-//     const contextValue = {
-//       page: {
-//         resource: {
-//           type,
-//           id
-//         }
-//       }
-//     };
-
-//     return (
-//       <ThemeProvider theme={baseMuiTheme}>
-//         <ThemeProvider theme={appTheme}>
-//           <AppContext.Provider value={contextValue}>
-//             <Box minHeight="100vh" display="flex" flexDirection="column">
-//               <AppLoadingBar />
-//               <AppCtaBanner />
-//               <AppHeader />
-//               <Box flexGrow={1}>
-//                 <Component {...pageProps} />
-//               </Box>
-//               <AppFooter />
-//               <AppCtaLoadUnder />
-//             </Box>
-//           </AppContext.Provider>
-//           <CssBaseline />
-//         </ThemeProvider>
-//       </ThemeProvider>
-//     );
-//   }
-// }
 
 export default wrapper.withRedux(TwApp); // eslint-disable-line import/no-default-export

--- a/pages/render/[...alias].tsx
+++ b/pages/render/[...alias].tsx
@@ -116,16 +116,15 @@ export const getStaticProps = wrapper.getStaticProps(
       };
     }
 
-    // Preload content component.
+    // Fetch resource data.
     if (resourceType) {
       const fetchData = getResourceFetchData(resourceType);
 
-      // Use content component to fetch its data.
       if (fetchData) {
         await Promise.all([
           // Fetch App data (latest stories, menus, etc.)
           store.dispatch<any>(fetchAppData()),
-          // Use content component to fetch its data.
+          // Use resources fetch func to fetch its data.
           store.dispatch(fetchData(resourceId))
         ]);
 

--- a/pages/render/[...alias].tsx
+++ b/pages/render/[...alias].tsx
@@ -3,7 +3,8 @@
  * Exports the Home component.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useStore } from 'react-redux';
 import { GetStaticPropsResult } from 'next';
 import dynamic from 'next/dynamic';
 import { Url } from 'url';
@@ -20,6 +21,7 @@ import { wrapper } from '@store';
 import { fetchApp, fetchHomepage, fetchTeam } from '@lib/fetch';
 import { generateLinkHrefForContent } from '@lib/routing';
 import { getResourceFetchData } from '@lib/import/fetchData';
+import { fetchCtaData } from '@store/actions/fetchCtaData';
 
 // Define dynamic component imports.
 const DynamicAudio = dynamic(() => import('@components/pages/Audio'));
@@ -37,7 +39,16 @@ interface StateProps extends RootState {}
 
 type Props = StateProps & IContentComponentProxyProps;
 
-const ContentProxy = ({ type }: Props) => {
+const ContentProxy = ({ type, id }: Props) => {
+  const store = useStore();
+
+  useEffect(() => {
+    // Fetch CTA messages for this resource.
+    (async () => {
+      await store.dispatch<any>(fetchCtaData(type, id));
+    })();
+  }, [type, id]);
+
   switch (type) {
     case 'file--audio':
       return <DynamicAudio />;

--- a/store/actions/fetchHomepageData.ts
+++ b/store/actions/fetchHomepageData.ts
@@ -41,6 +41,16 @@ export const fetchHomepageData = (): ThunkAction<
       episodes
     } = apiResp;
 
+    dispatch({
+      type: 'SET_RESOURCE_CONTEXT',
+      payload: {
+        type,
+        id,
+        pageType: 'landing',
+        context: ['node:3704']
+      }
+    });
+
     dispatch(
       appendResourceCollection(
         { data: [featuredStory], meta: { count: 1 } },

--- a/store/actions/fetchStoryData.ts
+++ b/store/actions/fetchStoryData.ts
@@ -35,6 +35,30 @@ export const fetchStoryData = (
     ).then((resp: IPriApiResourceResponse) => resp && resp.data);
 
     dispatch({
+      type: 'SET_RESOURCE_CONTEXT',
+      payload: {
+        type,
+        id,
+        pageType: 'content',
+        context: [
+          `node:${data.id}`,
+          `node:${data.program?.id}`,
+          `term:${data.primaryCategory?.id}`,
+          ...((data.categories &&
+            !!data.categories.length &&
+            data.categories
+              .filter(v => !!v)
+              .map(({ id: tid }) => `term:${tid}`)) ||
+            []),
+          ...((data.vertical &&
+            !!data.vertical.length &&
+            data.vertical.filter(v => !!v).map(({ tid }) => `term:${tid}`)) ||
+            [])
+        ]
+      }
+    });
+
+    dispatch({
       type: 'FETCH_CONTENT_DATA_SUCCESS',
       payload: {
         ...data,

--- a/store/reducers/ctaData.ts
+++ b/store/reducers/ctaData.ts
@@ -25,6 +25,7 @@ export const ctaData = (state: State = {}, action: CtaAction) => {
 
     case 'SET_RESOURCE_CONTEXT':
       key = makeKey();
+      console.log(action.type, action.payload, key);
       return {
         ...state,
         [key]: {
@@ -36,6 +37,7 @@ export const ctaData = (state: State = {}, action: CtaAction) => {
 
     case 'FETCH_CTA_DATA_SUCCESS':
       key = makeKey();
+      console.log(action.type, action.payload, key);
       return {
         ...state,
         ...(state[key]

--- a/store/reducers/ctaData.ts
+++ b/store/reducers/ctaData.ts
@@ -4,25 +4,38 @@
  * Reducers for handling data by resource signature.
  */
 
-import { AnyAction } from 'redux';
 import { HYDRATE } from 'next-redux-wrapper';
 import { IPriApiResource } from 'pri-api-library/types';
-import { CtaDataState } from '@interfaces/state';
+import { CtaAction, CtaDataState } from '@interfaces/state';
 import { makeResourceSignature } from '@lib/parse/state';
 
 type State = CtaDataState;
 
-export const ctaData = (state: State = {}, action: AnyAction) => {
+export const ctaData = (state: State = {}, action: CtaAction) => {
   let key: string;
+  const makeKey = () =>
+    makeResourceSignature({
+      type: action.payload.type,
+      id: action.payload.id
+    } as IPriApiResource);
 
   switch (action.type) {
     case HYDRATE:
       return { ...state, ...action.payload.ctaData };
+
+    case 'SET_RESOURCE_CONTEXT':
+      key = makeKey();
+      return {
+        ...state,
+        [key]: {
+          ...(state[key] || {}),
+          pageType: action.payload.pageType,
+          context: action.payload.context
+        }
+      };
+
     case 'FETCH_CTA_DATA_SUCCESS':
-      key = makeResourceSignature({
-        type: action.payload.type,
-        id: action.payload.id
-      } as IPriApiResource);
+      key = makeKey();
       return {
         ...state,
         ...(state[key]
@@ -30,11 +43,11 @@ export const ctaData = (state: State = {}, action: AnyAction) => {
               [key]: {
                 ...state[key],
                 groups: {
-                  ...state[key].groups,
+                  ...(state[key].groups || {}),
                   ...action.payload.groups
                 },
                 data: {
-                  ...state[key].data,
+                  ...(state[key].data || {}),
                   ...action.payload.data
                 }
               }
@@ -58,6 +71,12 @@ export const getCtaData = (
   type: string,
   id: string
 ) => state[makeResourceSignature({ type, id } as IPriApiResource)];
+
+export const getCtaPageType = (
+  state: CtaDataState = {},
+  type: string,
+  id: string
+) => (getCtaData(state, type, id) || {}).pageType;
 
 export const getCtaContext = (
   state: CtaDataState = {},

--- a/store/reducers/index.ts
+++ b/store/reducers/index.ts
@@ -74,6 +74,9 @@ export const getCollectionData = (
 export const getCtaData = (state: RootState, type: string, id: string) =>
   fromCtaData.getCtaData(state.ctaData, type, id);
 
+export const getCtaPageType = (state: RootState, type: string, id: string) =>
+  fromCtaData.getCtaPageType(state.ctaData, type, id);
+
 export const getCtaContext = (state: RootState, type: string, id: string) =>
   fromCtaData.getCtaContext(state.ctaData, type, id);
 


### PR DESCRIPTION
Closes #189 

- Re-adds app banner and load under CTA messaging

## To Review

- [x] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] On the live site, ensure the subqueues in the **Call To Action Regions - Site Messaging** entity queue have multiple CTA messages, including some targeted to a program and a story (choose one from the homepage).
- [x] Clear cookies for `localhost:3000`
- [x] Refresh app
- [x] Ensure banner and load under CTA messages are shown (Don't close them yet.)
- [x] Navigate to the targeted story
- [x] Ensure banner and load under messages update to targeted message
- [x] Navigate to targeted program
- [x] Ensure banner and load under messages update to targeted message
- [x] Go to homepage
- [ ] Close banner and load under messages
- [ ] Visit a non-targeted story
- [ ] Ensure either banner and load under remain closed, or reopens to an applicable message
