### PR TITLE
#170: Wrap link list button with `<li>`

### DIFF
--- a/components/Sidebar/SidebarList/SidebarList.tsx
+++ b/components/Sidebar/SidebarList/SidebarList.tsx
@@ -42,23 +42,27 @@ export const SidebarList = ({
       <List className={listClasses} {...other}>
         {data.map(item =>
           item.id ? (
-            <ListItem button component={ContentLink} data={item} key={item.id}>
-              {item.avatar && (
-                <ListItemAvatar>
-                  <Avatar
-                    alt={getTitle(item)}
-                    src={item.avatar.styles.w128.src}
-                  />
-                </ListItemAvatar>
-              )}
-              <ListItemText className={cx({ noBullet: !!item.avatar })}>
-                {getTitle(item)}
-              </ListItemText>
-            </ListItem>
+            <li key={item.id}>
+              <ListItem button component={ContentLink} data={item}>
+                {item.avatar && (
+                  <ListItemAvatar>
+                    <Avatar
+                      alt={getTitle(item)}
+                      src={item.avatar.styles.w128.src}
+                    />
+                  </ListItemAvatar>
+                )}
+                <ListItemText className={cx({ noBullet: !!item.avatar })}>
+                  {getTitle(item)}
+                </ListItemText>
+              </ListItem>
+            </li>
           ) : (
-            <ListItem button component="a" href={item.url} key={item.url}>
-              <ListItemText>{item.title}</ListItemText>
-            </ListItem>
+            <li key={item.id}>
+              <ListItem button component="a" href={item.url}>
+                <ListItemText>{item.title}</ListItemText>
+              </ListItem>
+            </li>
           )
         )}
       </List>

--- a/components/Tags/Tags.styles.ts
+++ b/components/Tags/Tags.styles.ts
@@ -1,6 +1,6 @@
 /**
- * @file Sidebar.style.ts
- * Styles for Sidebar.
+ * @file Tags.style.ts
+ * Styles for Tags.
  */
 
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';

--- a/components/Tags/Tags.tsx
+++ b/components/Tags/Tags.tsx
@@ -1,6 +1,6 @@
 /**
- * @file Sidebar.tsx
- * Component for sidebar elements.
+ * @file Tags.tsx
+ * Component for Tags elements.
  */
 
 import React, { HTMLAttributes } from 'react';

--- a/store/reducers/ctaData.ts
+++ b/store/reducers/ctaData.ts
@@ -25,7 +25,6 @@ export const ctaData = (state: State = {}, action: CtaAction) => {
 
     case 'SET_RESOURCE_CONTEXT':
       key = makeKey();
-      console.log(action.type, action.payload, key);
       return {
         ...state,
         [key]: {
@@ -37,7 +36,6 @@ export const ctaData = (state: State = {}, action: CtaAction) => {
 
     case 'FETCH_CTA_DATA_SUCCESS':
       key = makeKey();
-      console.log(action.type, action.payload, key);
       return {
         ...state,
         ...(state[key]


### PR DESCRIPTION
Closes #170 

- adds `<li>` wrappers to link list items
- some doc corrections
- remove console.log


## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Inspect link lists in sidebar to ensure each item is wrapped with and `<li>` tag as a direct child of the parent `<ul>`.