### PR TITLE
HOTFIX: Adds aria-label to progress bars

### DIFF
--- a/components/NewsletterForm/NewsletterForm.tsx
+++ b/components/NewsletterForm/NewsletterForm.tsx
@@ -50,7 +50,7 @@ export const NewsletterForm = ({
     !!error && !!error.message && !!error.message.match(/\bemail\b/i);
   const readyToSubmit = optedIn && validateEmailAddress(data.emailAddress);
   const icon = (submitted && (
-    <CircularProgress color="inherit" size={20} />
+    <CircularProgress color="inherit" size={20} aria-label="Progress Bar" />
   )) || <SendSharp />;
   const isAmp = useAmp();
   const classes = newsletterFormStyles({ compact });

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -121,6 +121,7 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                           isLoading
                         })}
                         color="secondary"
+                        aria-label="Progress Bar"
                       />
                     </CardMedia>
                   )}


### PR DESCRIPTION
- I noticed that image progress loading bars were missing an aria-label in story cards. Lighthouse caught it. `aria-label="Progress Bar"` is needed on all progress bars. 

## To Review

- [x] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Run Lighthouse on the homepage (a11y only) and confirm a 100% score
