### PR TITLE
#213: Add updated date to story headers

### DIFF
--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -203,7 +203,9 @@ export const Episode = () => {
                 {spotifyPlaylist && !!spotifyPlaylist.length && (
                   <Box my={3}>
                     <Divider />
-                    <Typography variant="h4">Music heard on air</Typography>
+                    <Typography variant="h4" component="h2">
+                      Music heard on air
+                    </Typography>
                     <Grid container spacing={2}>
                       {spotifyPlaylist.map(({ uri }) => (
                         <Grid item xs={12} sm={6} lg={4} key={uri}>

--- a/components/pages/Episode/components/EpisodeHeader/EpisodeHeader.tsx
+++ b/components/pages/Episode/components/EpisodeHeader/EpisodeHeader.tsx
@@ -20,7 +20,7 @@ export const EpisodeHeader = ({ data }: Props) => {
   const classes = episodeHeaderStyles({});
 
   return (
-    <Box className={classes.root} mt={4} mb={2}>
+    <Box component="header" className={classes.root} mt={4} mb={2}>
       <Box mb={3}>
         <Typography variant="h1">{title}</Typography>
       </Box>

--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -25,6 +25,7 @@ export const StoryHeader = ({ data }: Props) => {
     byline,
     dateBroadcast,
     datePublished,
+    dateUpdated,
     primaryCategory,
     program,
     title
@@ -32,7 +33,7 @@ export const StoryHeader = ({ data }: Props) => {
   const classes = storyHeaderStyles({});
 
   return (
-    <Box className={classes.root} mt={4} mb={2}>
+    <Box component="header" className={classes.root} mt={4} mb={2}>
       {primaryCategory && (
         <Box mb={2}>
           <ContentLink
@@ -49,14 +50,32 @@ export const StoryHeader = ({ data }: Props) => {
           {program && (
             <ContentLink data={program} className={classes.programLink} />
           )}
-          <Moment
+          <Typography
+            variant="subtitle1"
+            component="div"
             className={classes.date}
-            format="MMM. D, YYYY · h:mm A z"
-            tz="America/New_York"
-            unix
           >
-            {dateBroadcast || datePublished}
-          </Moment>
+            <Moment format="MMMM D, YYYY · h:mm A z" tz="America/New_York" unix>
+              {dateBroadcast || datePublished}
+            </Moment>
+          </Typography>
+          {dateUpdated && (
+            <Typography
+              variant="subtitle2"
+              component="div"
+              className={classes.date}
+            >
+              {' '}
+              Updated on{' '}
+              <Moment
+                format="MMM. D, YYYY · h:mm A z"
+                tz="America/New_York"
+                unix
+              >
+                {dateUpdated}
+              </Moment>
+            </Typography>
+          )}
           {byline && (
             <ul className={classes.byline}>
               {byline.map(({ id, creditType, person }) => (

--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -61,7 +61,7 @@ export const StoryHeader = ({ data }: Props) => {
           </Typography>
           {dateUpdated && (
             <Typography
-              variant="subtitle2"
+              variant="subtitle1"
               component="div"
               className={classes.date}
             >

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
@@ -28,6 +28,14 @@ export const storyHeaderTheme = (theme: Theme) =>
           fontSize: theme.typography.pxToRem(24),
           lineHeight: theme.typography.pxToRem(30)
         }
+      },
+      subtitle2: {
+        fontSize: theme.typography.pxToRem(16),
+        lineHeight: theme.typography.pxToRem(24),
+        [theme.breakpoints.up('sm')]: {
+          fontSize: theme.typography.pxToRem(18),
+          lineHeight: theme.typography.pxToRem(30)
+        }
       }
     },
     overrides: {

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
@@ -28,14 +28,6 @@ export const storyHeaderTheme = (theme: Theme) =>
           fontSize: theme.typography.pxToRem(24),
           lineHeight: theme.typography.pxToRem(30)
         }
-      },
-      subtitle2: {
-        fontSize: theme.typography.pxToRem(16),
-        lineHeight: theme.typography.pxToRem(24),
-        [theme.breakpoints.up('sm')]: {
-          fontSize: theme.typography.pxToRem(18),
-          lineHeight: theme.typography.pxToRem(30)
-        }
       }
     },
     overrides: {

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -38,6 +38,7 @@ export const StoryHeader = ({ data }: Props) => {
     byline,
     dateBroadcast,
     datePublished,
+    dateUpdated,
     image,
     primaryCategory,
     program,
@@ -56,7 +57,7 @@ export const StoryHeader = ({ data }: Props) => {
 
   return (
     <ThemeProvider theme={storyHeaderTheme}>
-      <Box className={cx('root', { withImage: !!image })}>
+      <Box component="header" className={cx('root', { withImage: !!image })}>
         {image && (
           <Box className={cx('imageWrapper')}>
             <Hidden mdUp>
@@ -104,14 +105,36 @@ export const StoryHeader = ({ data }: Props) => {
                 {program && (
                   <ContentLink data={program} className={classes.programLink} />
                 )}
-                <Moment
+                <Typography
+                  variant="subtitle1"
+                  component="div"
                   className={classes.date}
-                  format="MMM. D, YYYY · h:mm A z"
-                  tz="America/New_York"
-                  unix
                 >
-                  {dateBroadcast || datePublished}
-                </Moment>
+                  <Moment
+                    format="MMMM D, YYYY · h:mm A z"
+                    tz="America/New_York"
+                    unix
+                  >
+                    {dateBroadcast || datePublished}
+                  </Moment>
+                </Typography>
+                {dateUpdated && (
+                  <Typography
+                    variant="subtitle2"
+                    component="div"
+                    className={classes.date}
+                  >
+                    {' '}
+                    Updated on{' '}
+                    <Moment
+                      format="MMM. D, YYYY · h:mm A z"
+                      tz="America/New_York"
+                      unix
+                    >
+                      {dateUpdated}
+                    </Moment>
+                  </Typography>
+                )}
                 {byline && (
                   <ul className={classes.byline}>
                     {byline.map(({ id, creditType, person }) => (

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -120,7 +120,7 @@ export const StoryHeader = ({ data }: Props) => {
                 </Typography>
                 {dateUpdated && (
                   <Typography
-                    variant="subtitle2"
+                    variant="subtitle1"
                     component="div"
                     className={classes.date}
                   >


### PR DESCRIPTION
Closes #213 

- add updated date to story headers
- use `header` wrapper on content page headers

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Visit a story with and updated date and ensure that date is shown in header.
- [ ] Run lighthouse and ensure you don't get and error for _The page does not contain a heading, skip link, or landmark region_. Do this for both the default and feature layouts.
- [ ] Run lighthouse on episode page. Should get 💯  depending on body content.
