### PR TITLE
#198: Add `alt` attribute to lede image on feature stories

### DIFF
--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -44,7 +44,7 @@ export const StoryHeader = ({ data }: Props) => {
     title,
     teaser
   } = data;
-  const { caption, credit } = image || {};
+  const { alt, caption, credit } = image || {};
   const hasCaption = caption && !!caption.length;
   const hasCredit = credit && !!credit.length;
   const hasFooter = hasCaption || hasCredit;
@@ -61,6 +61,7 @@ export const StoryHeader = ({ data }: Props) => {
           <Box className={cx('imageWrapper')}>
             <Hidden mdUp>
               <Image
+                alt={alt}
                 className={cx('image')}
                 src={image.url}
                 layout="fill"
@@ -70,6 +71,7 @@ export const StoryHeader = ({ data }: Props) => {
             </Hidden>
             <Hidden smDown>
               <Image
+                alt={alt}
                 className={cx('image')}
                 src={image.url}
                 layout="responsive"


### PR DESCRIPTION
Closes #198 

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Visit a feature story and ensure lede image has alt text.
