### PR TITLE
Remove starting / from alias paths

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,8 +4,9 @@ This project makes use of the [Gitflow](https://www.atlassian.com/git/tutorials/
 
 ### Branch naming conventions
 
-- `master` - The master branch is for code ready to be released to the production environment.
-- `{feat|fix|docs}/{issue-number}--{short-description}` - Work branches for issue specific work. Should branck off `master` and PR's merge back into `master`.
+- `productions` - The master branch is for code ready to be released to the production environment.
+- `preview` - The staging branch is for new, larger feature or changes introduced by one or more PR's that needs ongoing, external review at `preview.theworld.org`. If more than one major project is in progress, new "preview" domains and branches will need to be made for those projects.
+- `{feat|fix|docs}/{issue-number}--{short-description}` - Work branches for issue specific work. Bug fixes and minor new features branch off `master` and PR's merge back into `master`. Issues related to larger feature projects should branch of of `preview` (or the develop branch created for that project) and merge back into that branch.
 
 ### Pull requests
 

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -203,7 +203,9 @@ export const Episode = () => {
                 {spotifyPlaylist && !!spotifyPlaylist.length && (
                   <Box my={3}>
                     <Divider />
-                    <Typography variant="h4">Music heard on air</Typography>
+                    <Typography variant="h4" component="h2">
+                      Music heard on air
+                    </Typography>
                     <Grid container spacing={2}>
                       {spotifyPlaylist.map(({ uri }) => (
                         <Grid item xs={12} sm={6} lg={4} key={uri}>

--- a/components/pages/Episode/components/EpisodeHeader/EpisodeHeader.tsx
+++ b/components/pages/Episode/components/EpisodeHeader/EpisodeHeader.tsx
@@ -20,7 +20,7 @@ export const EpisodeHeader = ({ data }: Props) => {
   const classes = episodeHeaderStyles({});
 
   return (
-    <Box className={classes.root} mt={4} mb={2}>
+    <Box component="header" className={classes.root} mt={4} mb={2}>
       <Box mb={3}>
         <Typography variant="h1">{title}</Typography>
       </Box>

--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -25,6 +25,7 @@ export const StoryHeader = ({ data }: Props) => {
     byline,
     dateBroadcast,
     datePublished,
+    dateUpdated,
     primaryCategory,
     program,
     title
@@ -32,7 +33,7 @@ export const StoryHeader = ({ data }: Props) => {
   const classes = storyHeaderStyles({});
 
   return (
-    <Box className={classes.root} mt={4} mb={2}>
+    <Box component="header" className={classes.root} mt={4} mb={2}>
       {primaryCategory && (
         <Box mb={2}>
           <ContentLink
@@ -49,14 +50,32 @@ export const StoryHeader = ({ data }: Props) => {
           {program && (
             <ContentLink data={program} className={classes.programLink} />
           )}
-          <Moment
+          <Typography
+            variant="subtitle1"
+            component="div"
             className={classes.date}
-            format="MMM. D, YYYY · h:mm A z"
-            tz="America/New_York"
-            unix
           >
-            {dateBroadcast || datePublished}
-          </Moment>
+            <Moment format="MMMM D, YYYY · h:mm A z" tz="America/New_York" unix>
+              {dateBroadcast || datePublished}
+            </Moment>
+          </Typography>
+          {dateUpdated && (
+            <Typography
+              variant="subtitle2"
+              component="div"
+              className={classes.date}
+            >
+              {' '}
+              Updated on{' '}
+              <Moment
+                format="MMM. D, YYYY · h:mm A z"
+                tz="America/New_York"
+                unix
+              >
+                {dateUpdated}
+              </Moment>
+            </Typography>
+          )}
           {byline && (
             <ul className={classes.byline}>
               {byline.map(({ id, creditType, person }) => (

--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -61,7 +61,7 @@ export const StoryHeader = ({ data }: Props) => {
           </Typography>
           {dateUpdated && (
             <Typography
-              variant="subtitle2"
+              variant="subtitle1"
               component="div"
               className={classes.date}
             >

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
@@ -28,6 +28,14 @@ export const storyHeaderTheme = (theme: Theme) =>
           fontSize: theme.typography.pxToRem(24),
           lineHeight: theme.typography.pxToRem(30)
         }
+      },
+      subtitle2: {
+        fontSize: theme.typography.pxToRem(16),
+        lineHeight: theme.typography.pxToRem(24),
+        [theme.breakpoints.up('sm')]: {
+          fontSize: theme.typography.pxToRem(18),
+          lineHeight: theme.typography.pxToRem(30)
+        }
       }
     },
     overrides: {

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
@@ -28,14 +28,6 @@ export const storyHeaderTheme = (theme: Theme) =>
           fontSize: theme.typography.pxToRem(24),
           lineHeight: theme.typography.pxToRem(30)
         }
-      },
-      subtitle2: {
-        fontSize: theme.typography.pxToRem(16),
-        lineHeight: theme.typography.pxToRem(24),
-        [theme.breakpoints.up('sm')]: {
-          fontSize: theme.typography.pxToRem(18),
-          lineHeight: theme.typography.pxToRem(30)
-        }
       }
     },
     overrides: {

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -38,6 +38,7 @@ export const StoryHeader = ({ data }: Props) => {
     byline,
     dateBroadcast,
     datePublished,
+    dateUpdated,
     image,
     primaryCategory,
     program,
@@ -56,7 +57,7 @@ export const StoryHeader = ({ data }: Props) => {
 
   return (
     <ThemeProvider theme={storyHeaderTheme}>
-      <Box className={cx('root', { withImage: !!image })}>
+      <Box component="header" className={cx('root', { withImage: !!image })}>
         {image && (
           <Box className={cx('imageWrapper')}>
             <Hidden mdUp>
@@ -104,14 +105,36 @@ export const StoryHeader = ({ data }: Props) => {
                 {program && (
                   <ContentLink data={program} className={classes.programLink} />
                 )}
-                <Moment
+                <Typography
+                  variant="subtitle1"
+                  component="div"
                   className={classes.date}
-                  format="MMM. D, YYYY · h:mm A z"
-                  tz="America/New_York"
-                  unix
                 >
-                  {dateBroadcast || datePublished}
-                </Moment>
+                  <Moment
+                    format="MMMM D, YYYY · h:mm A z"
+                    tz="America/New_York"
+                    unix
+                  >
+                    {dateBroadcast || datePublished}
+                  </Moment>
+                </Typography>
+                {dateUpdated && (
+                  <Typography
+                    variant="subtitle2"
+                    component="div"
+                    className={classes.date}
+                  >
+                    {' '}
+                    Updated on{' '}
+                    <Moment
+                      format="MMM. D, YYYY · h:mm A z"
+                      tz="America/New_York"
+                      unix
+                    >
+                      {dateUpdated}
+                    </Moment>
+                  </Typography>
+                )}
                 {byline && (
                   <ul className={classes.byline}>
                     {byline.map(({ id, creditType, person }) => (

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -120,7 +120,7 @@ export const StoryHeader = ({ data }: Props) => {
                 </Typography>
                 {dateUpdated && (
                   <Typography
-                    variant="subtitle2"
+                    variant="subtitle1"
                     component="div"
                     className={classes.date}
                   >

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -44,7 +44,7 @@ export const StoryHeader = ({ data }: Props) => {
     title,
     teaser
   } = data;
-  const { caption, credit } = image || {};
+  const { alt, caption, credit } = image || {};
   const hasCaption = caption && !!caption.length;
   const hasCredit = credit && !!credit.length;
   const hasFooter = hasCaption || hasCredit;
@@ -61,6 +61,7 @@ export const StoryHeader = ({ data }: Props) => {
           <Box className={cx('imageWrapper')}>
             <Hidden mdUp>
               <Image
+                alt={alt}
                 className={cx('image')}
                 src={image.url}
                 layout="fill"
@@ -70,6 +71,7 @@ export const StoryHeader = ({ data }: Props) => {
             </Hidden>
             <Hidden smDown>
               <Image
+                alt={alt}
                 className={cx('image')}
                 src={image.url}
                 layout="responsive"

--- a/lib/routing/content.ts
+++ b/lib/routing/content.ts
@@ -40,10 +40,12 @@ export const generateLinkPropsForContent = (
     const href = {
       ...parse('/render/[...alias]'),
       query: {
-        alias: alias.pathname.split('/'),
+        alias: alias.pathname.substr(1).split('/'),
         ...query
       }
     };
+
+    console.log(url.pathname, href);
 
     return {
       href,


### PR DESCRIPTION
- Removes starting `/` from alias URL's to prevent double `//` in pre-built json file URL's.

## To Review

- [ ] Ensure links do not 404 in AWS Amplify deployment.
