### PR TITLE
#228 robots.txt, ads.txt, opensearch.xml

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+placeholder.example.com, placeholder, DIRECT, placeholder

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -3,5 +3,6 @@
   <ShortName>theworld.org</ShortName>
   <Description>Search theworld.org</Description>
   <InputEncoding>UTF-8</InputEncoding>
-  <Url method="get" type="text/html" template="http://admin.theworld.org/search/node/{searchTerms}" />
+  <Url method="get" type="text/html"
+      template="http://www.pri.org/search/node/{searchTerms}"/>
 </OpenSearchDescription>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns:moz="http://www.mozilla.org/2006/browser/search/" xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <ShortName>pri.org</ShortName>
-  <Description>Search pri.org</Description>
+  <ShortName>theworld.org</ShortName>
+  <Description>Search theworld.org</Description>
   <InputEncoding>UTF-8</InputEncoding>
-  <Url method="get" type="text/html" 
-      template="http://www.pri.org/search/node/{searchTerms}"/>
+  <Url method="get" type="text/html" template="http://admin.theworld.org/search/node/{searchTerms}" />
 </OpenSearchDescription>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
-Sitemap: https://www.pri.org/sitemap.xml
+Sitemap: https://sitemap.theworld.org/sitemap.xml
 
 User-agent: *
 Disallow:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+Sitemap: https://www.pri.org/sitemap.xml
+User-agent:*
+Disallow:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
-Sitemap: https://admin.theworld.org/sitemap.xml
+Sitemap: https://pri.org/sitemap.xml
 
 User-agent: *
 Disallow:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
-Sitemap: https://pri.org/sitemap.xml
+Sitemap: https://www.pri.org/sitemap.xml
 
 User-agent: *
 Disallow:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 Sitemap: https://www.pri.org/sitemap.xml
-User-agent:*
+
+User-agent: *
 Disallow:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
-Sitemap: https://www.pri.org/sitemap.xml
+Sitemap: https://admin.theworld.org/sitemap.xml
 
 User-agent: *
 Disallow:


### PR DESCRIPTION
Closes #228 

- Adds robots.txt file pointing to an external sitemap with other suggested default settings, letting search engines know this domain is open for business.
- Creates ads.txt file, with the recommended line of code for bots to know we are not open for business. [See Page 7 of this IAB PDF](https://iabtechlab.com/wp-content/uploads/2021/03/ads.txt-1.0.3.pdf)
- updates opensearch.xml file

## To Review

- [ ] Code Review
