### PR TITLE
#232: Add search icon button

### DIFF
--- a/components/AppFooter/AppFooter.styles.ts
+++ b/components/AppFooter/AppFooter.styles.ts
@@ -24,7 +24,8 @@ export const appFooterStyles = makeStyles((theme: Theme) =>
       }
     },
     twLogo: {
-      width: theme.typography.pxToRem(250),
+      width: '100%',
+      maxWidth: theme.typography.pxToRem(250),
       height: 'auto',
       fill: theme.palette.grey.A200
     },

--- a/components/AppHeader/AppHeader.styles.ts
+++ b/components/AppHeader/AppHeader.styles.ts
@@ -16,9 +16,13 @@ export const appHeaderStyles = makeStyles((theme: Theme) =>
       marginRight: theme.spacing(0.5)
     },
     twLogo: {
+      display: 'block',
       width: 'auto',
       height: theme.typography.pxToRem(28),
-      fill: theme.palette.primary.contrastText
+      fill: theme.palette.primary.contrastText,
+      [theme.breakpoints.down('xs')]: {
+        height: theme.typography.pxToRem(22)
+      }
     },
     menuButton: {},
     grow: {

--- a/components/AppHeader/AppHeader.tsx
+++ b/components/AppHeader/AppHeader.tsx
@@ -18,6 +18,7 @@ import {
 } from '@material-ui/core';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import MenuIcon from '@material-ui/icons/Menu';
+import SearchIcon from '@material-ui/icons/Search';
 import classNames from 'classnames/bind';
 import { ReactComponent as Logo } from '@svg/tw-white.svg';
 import { getUiDrawerOpen } from '@store/reducers';
@@ -61,6 +62,10 @@ export const AppHeader = () => {
     store.dispatch({ type: 'UI_DRAWER_CLOSE' });
   };
 
+  const handleSearchOpen = () => () => {
+    store.dispatch({ type: 'SEARCH_OPEN' });
+  };
+
   return (
     <>
       <AppBar className={cx({ root: true })} position="static">
@@ -80,7 +85,7 @@ export const AppHeader = () => {
 
           <Link href="/">
             <a href="/" aria-label="The World">
-              <Logo className={cx({ twLogo: true })} />
+              <Logo className={cx('twLogo')} />
             </a>
           </Link>
 
@@ -90,6 +95,20 @@ export const AppHeader = () => {
 
           {/* Header Nav */}
           <AppHeaderNav />
+
+          {/* Search Button */}
+          <NoSsr>
+            <IconButton
+              edge="end"
+              className={cx('searchButton')}
+              disableRipple
+              color="inherit"
+              aria-label="site search"
+              onClick={handleSearchOpen()}
+            >
+              <SearchIcon />
+            </IconButton>
+          </NoSsr>
         </Toolbar>
       </AppBar>
       <Drawer open={open} onClose={handleDrawerClose()}>

--- a/components/AppHeader/AppHeaderNav/AppHeaderNav.tsx
+++ b/components/AppHeader/AppHeaderNav/AppHeaderNav.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { useStore } from 'react-redux';
 import Button from '@material-ui/core/Button';
 import Hidden from '@material-ui/core/Hidden';
+import IconButton from '@material-ui/core/IconButton';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { FavoriteSharp } from '@material-ui/icons';
 import { handleButtonClick } from '@lib/routing';
@@ -51,24 +52,36 @@ export const AppHeaderNav = () => {
                 </Button>
               </Hidden>
               <Hidden smUp>
-                <Button
-                  component="a"
-                  href={url.href}
-                  onClick={handleButtonClick(url)}
-                  variant={
-                    /\bbtn-(text|link)\b/.test(itemLinkClass)
-                      ? 'text'
-                      : 'contained'
-                  }
-                  color={color || 'default'}
-                  size="small"
-                  disableRipple
-                  disableElevation
-                  {...(icon && { startIcon: renderIcon(icon) })}
-                  {...attributes}
-                >
-                  {name}
-                </Button>
+                {icon ? (
+                  <IconButton
+                    component="a"
+                    href={url.href}
+                    onClick={handleButtonClick(url)}
+                    color={color || 'default'}
+                    size="small"
+                    disableRipple
+                    {...attributes}
+                  >
+                    {renderIcon(icon)}
+                  </IconButton>
+                ) : (
+                  <Button
+                    component="a"
+                    href={url.href}
+                    onClick={handleButtonClick(url)}
+                    variant="text"
+                    color={color || 'default'}
+                    size="small"
+                    disableRipple
+                    disableElevation
+                    {...attributes}
+                    {...(icon && {
+                      startIcon: renderIcon(icon)
+                    })}
+                  >
+                    {name}
+                  </Button>
+                )}
               </Hidden>
             </React.Fragment>
           )


### PR DESCRIPTION
Closes #232 

- add search icon button to site header
- adjust header nav mobile styles
- adjust footer logo mobile styles

## To Review

- [ ] Use the Preview link located at https://feat-232-site-header-search-icon.dtaq9a3yfwk0i.amplifyapp.com/.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Ensure search icon is shown in header and functions to open the search dialog.
- [ ] Resize window and ensure header nav buttons adjust to fit in a presentable manner.
- [ ] Resize window to a small mobile size and ensure footer logo doesn't overflow body, causing edge gaps in other sections.
