### PR TITLE
#233: Add categories links to homepage

### DIFF
--- a/components/Sidebar/SidebarLatestStories/SidebarLatestStories.tsx
+++ b/components/Sidebar/SidebarLatestStories/SidebarLatestStories.tsx
@@ -33,7 +33,7 @@ export const SidebarLatestStories = ({
     <Sidebar item elevated>
       <SidebarHeader>
         <Typography variant="h2">
-          <MenuBookRounded /> {label || 'Latest world news headlines'}
+          <MenuBookRounded /> {label || 'Latest from our partners'}
         </Typography>
       </SidebarHeader>
       <SidebarList disablePadding data={listItems} />

--- a/components/StoryCardGrid/StoryCardGrid.styles.ts
+++ b/components/StoryCardGrid/StoryCardGrid.styles.ts
@@ -71,6 +71,7 @@ export const storyCardGridTheme = (theme: Theme) =>
       },
       MuiCardMedia: {
         root: {
+          alignSelf: 'start',
           height: 'auto',
           paddingTop: `${100 / (16 / 9)}%`
         }

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -10,6 +10,7 @@ import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import { Box, Hidden, Typography } from '@material-ui/core';
 import CategoryRounded from '@material-ui/icons/Category';
+import StyleRounded from '@material-ui/icons/Style';
 import { LandingPage } from '@components/LandingPage';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible } from '@components/Plausible';
@@ -189,7 +190,7 @@ export const Homepage = () => {
             <Sidebar item elevated>
               <SidebarHeader>
                 <Typography variant="h2">
-                  <CategoryRounded /> Categories
+                  <StyleRounded /> Categories
                 </Typography>
               </SidebarHeader>
               <SidebarList data={categoriesMenu} />

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -8,18 +8,29 @@ import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
-import { Box, Hidden } from '@material-ui/core';
+import { Box, Hidden, Typography } from '@material-ui/core';
+import CategoryRounded from '@material-ui/icons/Category';
 import { LandingPage } from '@components/LandingPage';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible } from '@components/Plausible';
-import { SidebarLatestStories } from '@components/Sidebar';
+import {
+  Sidebar,
+  SidebarHeader,
+  SidebarLatestStories,
+  SidebarList
+} from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
 import { SidebarEpisode } from '@components/Sidebar/SidebarEpisode';
 import { ICtaRegionProps } from '@interfaces/cta';
 import { fetchCtaData } from '@store/actions/fetchCtaData';
 import { fetchHomepageData } from '@store/actions/fetchHomepageData';
-import { getCollectionData, getCtaRegionData } from '@store/reducers';
+import {
+  getCollectionData,
+  getCtaRegionData,
+  getMenusData
+} from '@store/reducers';
+import { IButton } from '@interfaces';
 
 const CtaRegion = dynamic(
   () => import('@components/CtaRegion').then(mod => mod.CtaRegion) as any
@@ -74,6 +85,20 @@ export const Homepage = () => {
     undefined,
     'tw_cta_region_landing_inline_01'
   );
+  const drawerMainNav = getMenusData(store.getState(), 'drawerMainNav');
+  const categoriesMenu = drawerMainNav
+    ?.filter((item: IButton) => item.name === 'Categories')?.[0]
+    .children.map(
+      item =>
+        ({
+          id: item.key,
+          type: 'link',
+          title: item.name,
+          metatags: {
+            canonical: item.url.href
+          }
+        } as IPriApiResource)
+    );
   const inlineBottom = getCtaRegionData(
     state,
     'homepage',
@@ -160,6 +185,16 @@ export const Homepage = () => {
               </Hidden>
             </Box>
           )}
+          <Box mt={3}>
+            <Sidebar item elevated>
+              <SidebarHeader>
+                <Typography variant="h2">
+                  <CategoryRounded /> Categories
+                </Typography>
+              </SidebarHeader>
+              <SidebarList data={categoriesMenu} />
+            </Sidebar>
+          </Box>
         </Box>
       )
     },

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -9,7 +9,7 @@ import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import { Box, Hidden, Typography } from '@material-ui/core';
-import StyleRounded from '@material-ui/icons/Style';
+import StyleRounded from '@material-ui/icons/StyleRounded';
 import { LandingPage } from '@components/LandingPage';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible } from '@components/Plausible';

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -9,7 +9,6 @@ import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import { Box, Hidden, Typography } from '@material-ui/core';
-import CategoryRounded from '@material-ui/icons/Category';
 import StyleRounded from '@material-ui/icons/Style';
 import { LandingPage } from '@components/LandingPage';
 import { MetaTags } from '@components/MetaTags';


### PR DESCRIPTION
Closes #233 

- adds categories menu links to homepage
- fix image layout on small featured story cards

## To Review

- [ ] Use the Preview link located at https://feat-233-homepage-category-links.dtaq9a3yfwk0i.amplifyapp.com/.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Note that categories link list now in sidebar.
- [ ] Ensure small feature card images layout correctly on mobile.
