### PR TITLE
#246: Update default header label of latest stories sidebar block

### DIFF
--- a/components/Sidebar/SidebarLatestStories/SidebarLatestStories.tsx
+++ b/components/Sidebar/SidebarLatestStories/SidebarLatestStories.tsx
@@ -33,7 +33,7 @@ export const SidebarLatestStories = ({
     <Sidebar item elevated>
       <SidebarHeader>
         <Typography variant="h2">
-          <MenuBookRounded /> {label || 'Latest from our partners'}
+          <MenuBookRounded /> {label || 'Latest Headlines'}
         </Typography>
       </SidebarHeader>
       <SidebarList disablePadding data={listItems} />

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -202,7 +202,10 @@ export const Homepage = () => {
       key: 'sidebar bottom',
       children: (
         <Box mt={3}>
-          <SidebarLatestStories data={latestStories[1]} />
+          <SidebarLatestStories
+            data={latestStories[1]}
+            label="Latest from our partners"
+          />
           {sidebarBottom && (
             <Box mt={3}>
               <Hidden only="sm">


### PR DESCRIPTION
Closes #246

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- Ensure the header label in the latest stories sidebar block on the homepage remains the same as before.
- Go to any other landing page and ensure the header label is shown as "Latest Headlines".
