### PR TITLE
HOTFIX: Feature story header should cover background

### DIFF
--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -10,13 +10,7 @@ import 'moment-timezone';
 import ReactMarkdown from 'react-markdown';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
-import {
-  Box,
-  Container,
-  Typography,
-  ThemeProvider,
-  Hidden
-} from '@material-ui/core';
+import { Box, Container, Typography, ThemeProvider } from '@material-ui/core';
 import { IContentLinkProps } from '@components/ContentLink';
 import { HtmlContent } from '@components/HtmlContent';
 import {
@@ -60,28 +54,14 @@ export const StoryHeader = ({ data }: Props) => {
       <Box component="header" className={cx('root', { withImage: !!image })}>
         {image && (
           <Box className={cx('imageWrapper')}>
-            <Hidden mdUp>
-              <Image
-                alt={alt}
-                className={cx('image')}
-                src={image.url}
-                layout="fill"
-                objectFit="cover"
-                priority
-              />
-            </Hidden>
-            <Hidden smDown>
-              <Image
-                alt={alt}
-                className={cx('image')}
-                src={image.url}
-                layout="responsive"
-                width={image.metadata.width}
-                height={image.metadata.height}
-                objectFit="cover"
-                priority
-              />
-            </Hidden>
+            <Image
+              alt={alt}
+              className={cx('image')}
+              src={image.url}
+              layout="fill"
+              objectFit="cover"
+              priority
+            />
           </Box>
         )}
         <Box className={cx('content')}>


### PR DESCRIPTION
## To Review

- [ ] Use the Preview link: https://fix-story-feature-header-image-cover.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Go to a feature story.
- [ ] Resize window.
- [ ] Ensure at no point do you see gaps below image revealing a blue background.
