### PR TITLE
HOTFIX: Add revalidate to alias page builds

### DIFF
--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -139,7 +139,10 @@ export const getStaticProps = wrapper.getStaticProps(
           store.dispatch(fetchData(resourceId))
         ]);
 
-        return { props: { type: resourceType, id: resourceId } };
+        return {
+          props: { type: resourceType, id: resourceId },
+          revalidate: 10
+        };
       }
     }
 


### PR DESCRIPTION
Closes #[ISSUE_ID]

- Alias pages are currently being cache with no expire time. This will allow the system to revalidate page data every 10 sec. (Same as the homepage.)

## To Review
- [ ] Go to preview linkL https://fix-add-static-page-revalidate.d2mc541hyaqum0.amplifyapp.com/

> ...then...

- [ ] Visit a story.
- [ ] Find the story in the CMS and make a change.
- [ ] Go back to the story and hard refresh. Wait ten seconds. Hard refresh again.
- [ ] Ensure your changes are now shown on the page.
