### PR TITLE
#259 update to styles (QAs, Sidebar CTAs)

### DIFF
--- a/components/Sidebar/SidebarCta/SidebarCta.styles.ts
+++ b/components/Sidebar/SidebarCta/SidebarCta.styles.ts
@@ -4,7 +4,9 @@
  */
 
 import { createMuiTheme, Theme } from '@material-ui/core/styles';
-import { blue } from '@theme/colors';
+import { BlockRounded } from '@material-ui/icons';
+import { blue, grey } from '@theme/colors';
+import { NONAME } from 'dns';
 
 export const sidebarCtaTheme = (theme: Theme) =>
   createMuiTheme(theme, {
@@ -37,6 +39,28 @@ export const sidebarCtaTheme = (theme: Theme) =>
           },
           '& p + p': {
             marginTop: '1rem'
+          },
+          '& a:link, & a:visited': {
+            color: theme.palette.primary.main,
+            fontWeight: 'bold',
+            textDecoration: 'none'
+          },
+          '& ul': {
+            margin: '1em 0 0 16px',
+            padding: 0
+          },
+          '& li': {
+            padding: 0,
+            margin: 0,
+            color: grey[500]
+          },
+          '& li a:link, & li a:visited': {
+            padding: '3px 0',
+            width: '100%'
+          },
+          '& li a:hover': {
+            color: theme.palette.primary.dark,
+            textDecoration: 'underline'
           }
         }
       },

--- a/components/pages/Story/layouts/default/styles/body/Story.body.qa.ts
+++ b/components/pages/Story/layouts/default/styles/body/Story.body.qa.ts
@@ -19,8 +19,9 @@ export const storyBodyQAStyles = (theme: Theme) =>
         theme.palette.primary.main
       }`,
 
-      '& h3': {
+      '& .qa-question': {
         margin: '1rem 0 1rem',
+        fontWeight: 'bold',
         paddingBottom: '1.25rem',
         borderBottom: `${theme.typography.pxToRem(2)} solid ${
           theme.palette.grey[200]

--- a/components/pages/Story/layouts/feature/styles/body/Story.body.qa.ts
+++ b/components/pages/Story/layouts/feature/styles/body/Story.body.qa.ts
@@ -19,8 +19,9 @@ export const storyBodyQAStyles = (theme: Theme) =>
         theme.palette.primary.main
       }`,
 
-      '& h3': {
+      '& .qa-question': {
         margin: '1rem 0 1rem',
+        fontWeight: 'bold',
         paddingBottom: '1.25rem',
         borderBottom: `${theme.typography.pxToRem(2)} solid ${
           theme.palette.grey[200]


### PR DESCRIPTION
Closes #259 
Closes #261

- Looks like the QA question used to be an `<h3>`, but was changed to a `<p>`,  updated the styles to use the class `.qa-question`.
- Adds list styling to the sidebar CTA

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Go to this story http://localhost:3000/stories/2021-11-04/professional-tree-planting-its-combination-between-industrial-labor-and-high and confirm that the QAs are bold text and have the stylized border below them.
- [ ] Go to homepage and ensure the Follow the World CTA has decent enough list styling. 
