### PR TITLE
HOTFIX: custom headers update

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,23 +1,21 @@
 customHeaders:
-  - pattern: /_next/*
+  - pattern: '/_next/*'
     headers:
-      - key: x-control-type-options
-        value: nosniff
-      - key: x-frame-options
-        value: DENY
-      - key: x-xss-protection
-        value: 1; mode=block
-  - pattern: /api/*
+      - key: 'Cache-Control'
+        value: 'public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400'
+  - pattern: '**/*'
     headers:
-      - key: Cache-Control
-        value: 'public, max-age=0, s-maxage=1, stale-while-revalidate'
-  - pattern: /*
-    headers:
-      - key: Cache-Control
-        value: 'public, max-age=0, s-maxage=1, stale-while-revalidate'
-      - key: Permissions-Policy
-        value: interest-cohort=()
-      - key: x-frame-options
-        value: DENY
-      - key: x-xss-protection
-        value: 1; mode=block
+      - key: 'Cache-Control'
+        value: 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=600'
+      - key: 'Strict-Transport-Security'
+        value: 'max-age=31536000; includeSubDomains'
+      - key: 'X-Frame-Options'
+        value: 'SAMEORIGIN'
+      - key: 'X-XSS-Protection'
+        value: '1; mode=block'
+      - key: 'X-Content-Type-Options'
+        value: 'nosniff'
+      - key: 'Content-Security-Policy'
+        value: "default-src 'self'"
+      - key: 'Permissions-Policy'
+        value: 'interest-cohort=()'

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,8 +1,4 @@
 customHeaders:
-  - pattern: '/_next/*'
-    headers:
-      - key: 'Cache-Control'
-        value: 'public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400'
   - pattern: '**/*'
     headers:
       - key: 'Cache-Control'
@@ -17,3 +13,7 @@ customHeaders:
         value: 'nosniff'
       - key: 'Permissions-Policy'
         value: 'interest-cohort=()'
+  - pattern: '/_next/static/*'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400'

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -8,7 +8,7 @@ customHeaders:
       - key: 'Cache-Control'
         value: 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=600'
       - key: 'Strict-Transport-Security'
-        value: 'max-age=31536000; includeSubDomains'
+        value: 'max-age=63072000; includeSubDomains; preload'
       - key: 'X-Frame-Options'
         value: 'SAMEORIGIN'
       - key: 'X-XSS-Protection'

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -15,7 +15,5 @@ customHeaders:
         value: '1; mode=block'
       - key: 'X-Content-Type-Options'
         value: 'nosniff'
-      - key: 'Content-Security-Policy'
-        value: "default-src 'self'"
       - key: 'Permissions-Policy'
         value: 'interest-cohort=()'

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -13,19 +13,23 @@ customHeaders:
         value: 'nosniff'
       - key: 'Permissions-Policy'
         value: 'interest-cohort=()'
-  - pattern: '/_next/image?*'
+  - pattern: '/_next/image*'
     headers:
       - key: 'Cache-Control'
         value: 'public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400'
-  - pattern: '/static/image?*'
+  - pattern: '/static/**/*'
     headers:
       - key: 'Cache-Control'
         value: 'public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400'
-  - pattern: '/_next/static/chunks/*'
+  - pattern: '/_next/static/chunks/**/*'
     headers:
       - key: 'Cache-Control'
         value: 'public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400'
-  - pattern: '/_next/data/*'
+  - pattern: '/_next/data/**/*'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=600'
+  - pattern: '/api/**/*'
     headers:
       - key: 'Cache-Control'
         value: 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=600'

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -2,7 +2,7 @@ customHeaders:
   - pattern: '**/*'
     headers:
       - key: 'Cache-Control'
-        value: 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=600'
+        value: 'public, max-age=0, s-maxage=1, stale-while-revalidate'
       - key: 'Strict-Transport-Security'
         value: 'max-age=63072000; includeSubDomains; preload'
       - key: 'X-Frame-Options'
@@ -13,7 +13,23 @@ customHeaders:
         value: 'nosniff'
       - key: 'Permissions-Policy'
         value: 'interest-cohort=()'
-  - pattern: '/_next/static/*'
+  - pattern: '/_next/image?*'
     headers:
       - key: 'Cache-Control'
         value: 'public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400'
+  - pattern: '/static/image?*'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400'
+  - pattern: '/_next/static/chunks/*'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400'
+  - pattern: '/_next/data/*'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=600'
+  - pattern: '/api/*'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=600'


### PR DESCRIPTION
Related to PublicRadioInternational/pri.org#1574

- adds cache control headers for 1 hour

## To Review

- [x] Use the Preview link: https://fix-custom-headers-update-add-cache-times.d2mc541hyaqum0.amplifyapp.com/.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Navigate to the top story and refresh page.
- [x] Go back to homepage, then open the top store in a new incognito window.
- [x] Inspect page and got to Network tab.
- [x] Filter to JS requests.
- [x] Hard refresh page (Shift + Cmd + R).
- [x] Ensure many of the requests have `x-cache: Hit from cloudfront`.
- [x] Look at responses for Img, and fetch/XHR and ensure those also have hits on the cloudfront cache.
- [x] Do a standard refresh (Cmd + R).
- [x] Ensure `(memory cache)` or `(disk cache)` is shown in the requests' Size column.
