### PR TITLE
#263: Make content update faster

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -36,11 +36,6 @@ const config = {
     ...(defaultConfig.fb || {}),
     ...(localConfig.fb || {})
   },
-  search: {
-    cseId: '8fae02a164443be00',
-    ...(defaultConfig.search || {}),
-    ...(localConfig.search || {})
-  },
   twitter: {
     ...(defaultConfig.twitter || {}),
     ...(localConfig.twitter || {})

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -525,7 +525,7 @@ export const fetchApiSearch = (
   fetch(
     format({
       protocol: 'https',
-      hostname: '7mll7u30kh.execute-api.us-east-1.amazonaws.com', // TODO: Update to `search.theworld.org` when DNS is ready.
+      hostname: 'search.theworld.org', // TODO: Update to `search.theworld.org` when DNS is ready.
       pathname: 'query',
       query: {
         ...(q && { q }),

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -6,7 +6,6 @@
 import fetch from 'isomorphic-unfetch';
 import {
   IPriApiCollectionResponse,
-  IPriApiResource,
   IPriApiResourceResponse
 } from 'pri-api-library/types';
 import { IncomingMessage } from 'http';
@@ -206,7 +205,7 @@ export const fetchApiEpisode = async (
 export const fetchApiFileAudio = async (
   id: string,
   req?: IncomingMessage
-): Promise<IPriApiResource> => fetchApi(`file/audio/${id}`, req);
+): Promise<IPriApiResourceResponse> => fetchApi(`file/audio/${id}`, req);
 
 /**
  * Method that simplifies GET queries for program data.
@@ -284,7 +283,7 @@ export const fetchApiProgramEpisodes = async (
 export const fetchApiCategory = async (
   id: string,
   req?: IncomingMessage
-): Promise<IPriApiResource> => fetchApi(`category/${id}`, req);
+): Promise<IPriApiResourceResponse> => fetchApi(`category/${id}`, req);
 
 /**
  * Method that simplifies GET queries for category stories data.
@@ -333,7 +332,7 @@ export const fetchApiCategoryStories = async (
 export const fetchApiTerm = async (
   id: string,
   req?: IncomingMessage
-): Promise<IPriApiResource> => fetchApi(`term/${id}`, req);
+): Promise<IPriApiResourceResponse> => fetchApi(`term/${id}`, req);
 
 /**
  * Method that simplifies GET queries for term stories data.
@@ -407,7 +406,7 @@ export const fetchApiTermEpisodes = async (
 export const fetchApiPage = async (
   id: string,
   req?: IncomingMessage
-): Promise<IPriApiResource> => fetchApi(`page/${id}`, req);
+): Promise<IPriApiResourceResponse> => fetchApi(`page/${id}`, req);
 
 /**
  * Method that simplifies GET queries for team data.
@@ -420,7 +419,7 @@ export const fetchApiPage = async (
  */
 export const fetchApiTeam = async (
   req?: IncomingMessage
-): Promise<IPriApiResource> => fetchApi('team', req);
+): Promise<IPriApiResourceResponse> => fetchApi('team', req);
 
 /**
  * Method that simplifies GET queries for person data.
@@ -436,7 +435,7 @@ export const fetchApiTeam = async (
 export const fetchApiPerson = async (
   id: string,
   req?: IncomingMessage
-): Promise<IPriApiResource> => fetchApi(`person/${id}`, req);
+): Promise<IPriApiResourceResponse> => fetchApi(`person/${id}`, req);
 
 /**
  * Method that simplifies GET queries for person stories data.

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -22,6 +22,7 @@ import { fetchApp, fetchHomepage, fetchTeam } from '@lib/fetch';
 import { generateLinkHrefForContent } from '@lib/routing';
 import { getResourceFetchData } from '@lib/import/fetchData';
 import { fetchCtaData } from '@store/actions/fetchCtaData';
+import { getDataByResource } from '@store/reducers';
 
 // Define dynamic component imports.
 const DynamicAudio = dynamic(() => import('@components/pages/Audio'));
@@ -139,8 +140,14 @@ export const getStaticProps = wrapper.getStaticProps(
           store.dispatch(fetchData(resourceId))
         ]);
 
+        const data = getDataByResource(
+          store.getState(),
+          resourceType,
+          resourceId
+        );
+
         return {
-          props: { type: resourceType, id: resourceId },
+          props: { ...data },
           revalidate: 10
         };
       }

--- a/pages/api/homepage.ts
+++ b/pages/api/homepage.ts
@@ -22,8 +22,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   })) as IPriApiCollectionResponse;
 
   const apiResp = {
-    ...program,
-    latestStories
+    data: {
+      ...program,
+      latestStories
+    }
   };
 
   return res.status(200).json(apiResp);

--- a/pages/api/query/search/[label]/[q].ts
+++ b/pages/api/query/search/[label]/[q].ts
@@ -3,37 +3,24 @@
  * Query Google Custom Search Engine JSON API.
  */
 
-import { google, customsearch_v1 } from 'googleapis';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { search } from '@config';
+import { fetchApiSearch } from '@lib/fetch/api';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  const gcs = google.customsearch({
-    version: 'v1',
-    auth: process.env.CSE_API_KEY
-  });
   const { label, q, start } = req.query;
-  const { cseId: cx } = search;
-  const listParams: customsearch_v1.Params$Resource$Cse$List = {
-    cx,
-    q:
-      !label || label !== 'all'
-        ? `${q as string} more:${label}`
-        : (q as string),
-    ...(start && { start: parseInt(start as string, 10) })
-  };
 
   if (q.length) {
-    const apiResp = await gcs.cse.siterestrict.list(listParams);
+    const apiResp = await fetchApiSearch(
+      q as string,
+      label as string,
+      start as string
+    );
 
-    switch (apiResp.status) {
-      case 200:
-        return res.status(200).json(apiResp.data);
-        break;
-
-      default:
-        return res.status(400).json(apiResp);
+    if (apiResp) {
+      return res.status(200).json(apiResp);
     }
+
+    return res.status(400).json(apiResp);
   }
 
   return res.status(400).end();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,23 +4,29 @@
  */
 
 import React from 'react';
-import { Homepage, fetchData } from '@components/pages/Homepage';
+import { Homepage } from '@components/pages/Homepage';
 import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
+import { fetchHomepageData } from '@store/actions/fetchHomepageData';
 
 const IndexPage = () => {
   return <Homepage />;
 };
 
 export const getStaticProps = wrapper.getStaticProps(store => async () => {
-  await Promise.all([
+  const [, data] = await Promise.all([
     // Fetch App data (latest stories, menus, etc.)
     store.dispatch<any>(fetchAppData()),
     // Use content component to fetch its data.
-    store.dispatch<any>(fetchData())
+    store.dispatch<any>(fetchHomepageData())
   ]);
 
-  return { props: {}, revalidate: 10 };
+  return {
+    props: {
+      ...data
+    },
+    revalidate: 10
+  };
 });
 
 export default IndexPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,4 +23,8 @@ export const getStaticProps = wrapper.getStaticProps(store => async () => {
   return { props: {}, revalidate: 10 };
 });
 
+export const getStaticPaths = async () => {
+  return { paths: [{ params: {} }], fallback: 'blocking' };
+};
+
 export default IndexPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,8 +23,4 @@ export const getStaticProps = wrapper.getStaticProps(store => async () => {
   return { props: {}, revalidate: 10 };
 });
 
-export const getStaticPaths = async () => {
-  return { paths: [{ params: {} }], fallback: 'blocking' };
-};
-
 export default IndexPage;

--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -20,6 +20,7 @@ import { fetchHomepage } from '@lib/fetch';
 import { generateLinkHrefForContent } from '@lib/routing';
 import { getResourceFetchData } from '@lib/import/fetchData';
 import { fetchCtaData } from '@store/actions/fetchCtaData';
+import { getDataByResource } from '@store/reducers';
 
 // Define dynamic component imports.
 const DynamicAudio = dynamic(() => import('@components/pages/Audio'));
@@ -98,8 +99,14 @@ export const getStaticProps = wrapper.getStaticProps(
           store.dispatch(fetchData(resourceId))
         ]);
 
+        const data = getDataByResource(
+          store.getState(),
+          resourceType,
+          resourceId
+        );
+
         return {
-          props: { type: resourceType, id: resourceId },
+          props: { ...data },
           revalidate: 10
         };
       }

--- a/store/actions/fetchAliasData.ts
+++ b/store/actions/fetchAliasData.ts
@@ -21,19 +21,18 @@ export const fetchAliasData = (
   getState: () => RootState
 ): Promise<IPriApiResource> => {
   const state = getState();
+  const isOnServer = typeof window === 'undefined';
   let data = getDataByAlias(state, alias);
 
-  if (!data) {
+  if (!data || isOnServer) {
     dispatch({
       type: 'FETCH_ALIAS_DATA_REQUEST',
       alias
     });
 
-    data = await (typeof window === 'undefined'
-      ? fetchQueryAlias
-      : fetchApiQueryAlias)(alias).then(
-      (resp: IPriApiResourceResponse) => resp && resp.data
-    );
+    data = await (isOnServer ? fetchQueryAlias : fetchApiQueryAlias)(
+      alias
+    ).then((resp: IPriApiResourceResponse) => resp && resp.data);
 
     dispatch({
       type: 'FETCH_ALIAS_DATA_SUCCESS',

--- a/store/actions/fetchAppData.ts
+++ b/store/actions/fetchAppData.ts
@@ -15,16 +15,15 @@ export const fetchAppData = (): ThunkAction<void, {}, {}, AnyAction> => async (
   getState: () => RootState
 ): Promise<void> => {
   const state = getState();
+  const isOnServer = typeof window === 'undefined';
   const latest = getCollectionData(state, 'app', undefined, 'latest');
 
-  if (!latest) {
+  if (!latest || isOnServer) {
     dispatch({
       type: 'FETCH_APP_DATA_REQUEST'
     });
 
-    const apiResp = await (typeof window === 'undefined'
-      ? fetchApp
-      : fetchApiApp)();
+    const apiResp = await (isOnServer ? fetchApp : fetchApiApp)();
     const { latestStories, menus } = apiResp;
 
     dispatch(

--- a/store/actions/fetchAudioData.ts
+++ b/store/actions/fetchAudioData.ts
@@ -7,7 +7,7 @@
 import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { RootState } from '@interfaces/state';
-import { fetchAudio } from '@lib/fetch';
+import { fetchApiFileAudio, fetchAudio } from '@lib/fetch';
 import { getDataByResource } from '@store/reducers';
 import { IPriApiResourceResponse } from 'pri-api-library/types';
 
@@ -19,9 +19,10 @@ export const fetchAudioData = (
 ): Promise<void> => {
   const state = getState();
   const type = 'file--audio';
+  const isOnServer = typeof window === 'undefined';
   let data = getDataByResource(state, type, id);
 
-  if (!data || !data.complete) {
+  if (!data || !data.complete || isOnServer) {
     dispatch({
       type: 'FETCH_CONTENT_DATA_REQUEST',
       payload: {
@@ -30,7 +31,7 @@ export const fetchAudioData = (
       }
     });
 
-    data = await fetchAudio(id).then(
+    data = await (isOnServer ? fetchAudio : fetchApiFileAudio)(id).then(
       (resp: IPriApiResourceResponse) => resp && resp.data
     );
 

--- a/store/actions/fetchCategoryData.ts
+++ b/store/actions/fetchCategoryData.ts
@@ -7,7 +7,7 @@ import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResourceResponse } from 'pri-api-library/types';
 import { RootState } from '@interfaces/state';
-import { fetchCategory } from '@lib/fetch';
+import { fetchApiCategory, fetchCategory } from '@lib/fetch';
 import { getDataByResource } from '@store/reducers';
 import { appendResourceCollection } from './appendResourceCollection';
 
@@ -19,9 +19,10 @@ export const fetchCategoryData = (
 ): Promise<void> => {
   const state = getState();
   const type = 'taxonomy_term--categories';
+  const isOnServer = typeof window === 'undefined';
   const data = getDataByResource(state, type, id);
 
-  if (!data) {
+  if (!data || isOnServer) {
     dispatch({
       type: 'FETCH_CONTENT_DATA_REQUEST',
       payload: {
@@ -35,7 +36,7 @@ export const fetchCategoryData = (
       featuredStories,
       stories,
       ...payload
-    } = await fetchCategory(id).then(
+    } = await (isOnServer ? fetchCategory : fetchApiCategory)(id).then(
       (resp: IPriApiResourceResponse) => resp && resp.data
     );
 

--- a/store/actions/fetchEpisodeData.ts
+++ b/store/actions/fetchEpisodeData.ts
@@ -19,9 +19,10 @@ export const fetchEpisodeData = (
 ): Promise<void> => {
   const state = getState();
   const type = 'node--episodes';
+  const isOnServer = typeof window === 'undefined';
   let data = getDataByResource(state, type, id);
 
-  if (!data || !data.complete) {
+  if (!data || !data.complete || isOnServer) {
     dispatch({
       type: 'FETCH_CONTENT_DATA_REQUEST',
       payload: {
@@ -30,9 +31,7 @@ export const fetchEpisodeData = (
       }
     });
 
-    data = await (typeof window === 'undefined'
-      ? fetchEpisode
-      : fetchApiEpisode)(id).then(
+    data = await (isOnServer ? fetchEpisode : fetchApiEpisode)(id).then(
       (resp: IPriApiResourceResponse) => resp && resp.data
     );
 

--- a/store/actions/fetchHomepageData.ts
+++ b/store/actions/fetchHomepageData.ts
@@ -7,8 +7,9 @@ import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResourceResponse } from 'pri-api-library/types';
 import { RootState } from '@interfaces/state';
+import { fetchApiHomepage } from '@lib/fetch/api';
 import { fetchHomepage } from '@lib/fetch/homepage/fetchHomepage';
-import { getCollectionData } from '@store/reducers';
+import { getHomepageData } from '@store/reducers';
 import { appendResourceCollection } from './appendResourceCollection';
 
 export const fetchHomepageData = (): ThunkAction<
@@ -19,18 +20,22 @@ export const fetchHomepageData = (): ThunkAction<
 > => async (
   dispatch: ThunkDispatch<{}, {}, AnyAction>,
   getState: () => RootState
-): Promise<void> => {
+): Promise<{ [k: string]: any }> => {
   const state = getState();
   const type = 'homepage';
   const id = undefined;
-  const dataCheck = getCollectionData(state, type, id, 'featured story');
+  const isOnServer = typeof window === 'undefined';
+  const data = getHomepageData(state);
+  const dataCheck = Object.values(data).filter(v => !!v).length > 0;
 
-  if (!dataCheck) {
+  if (!dataCheck || isOnServer) {
     dispatch({
       type: 'FETCH_HOMEPAGE_DATA_REQUEST'
     });
 
-    const apiResp = await fetchHomepage().then(
+    const apiResp = await (isOnServer
+      ? fetchHomepage
+      : fetchApiHomepage)().then(
       (resp: IPriApiResourceResponse) => resp && resp.data
     );
     const {
@@ -78,5 +83,9 @@ export const fetchHomepageData = (): ThunkAction<
     dispatch({
       type: 'FETCH_HOMEPAGE_DATA_SUCCESS'
     });
+
+    return { ...apiResp };
   }
+
+  return { ...data };
 };

--- a/store/actions/fetchNewsletterData.ts
+++ b/store/actions/fetchNewsletterData.ts
@@ -7,7 +7,7 @@ import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { RootState } from '@interfaces/state';
 import { getDataByResource } from '@store/reducers';
-import { fetchNewsletter } from '@lib/fetch';
+import { fetchApiNewsletter, fetchNewsletter } from '@lib/fetch';
 import { IPriApiResourceResponse } from 'pri-api-library/types';
 
 export const fetchNewsletterData = (
@@ -18,9 +18,10 @@ export const fetchNewsletterData = (
 ): Promise<void> => {
   const state = getState();
   const type = 'node--newsletter_sign_ups';
+  const isOnServer = typeof window === 'undefined';
   let data = getDataByResource(state, type, id);
 
-  if (!data || !data.complete) {
+  if (!data || !data.complete || isOnServer) {
     dispatch({
       type: 'FETCH_CONTENT_DATA_REQUEST',
       payload: {
@@ -29,7 +30,7 @@ export const fetchNewsletterData = (
       }
     });
 
-    data = await fetchNewsletter(id).then(
+    data = await (isOnServer ? fetchNewsletter : fetchApiNewsletter)(id).then(
       (resp: IPriApiResourceResponse) => resp && resp.data
     );
 

--- a/store/actions/fetchPageData.ts
+++ b/store/actions/fetchPageData.ts
@@ -7,7 +7,7 @@
 import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { RootState } from '@interfaces/state';
-import { fetchPage } from '@lib/fetch';
+import { fetchApiPage, fetchPage } from '@lib/fetch';
 import { getDataByResource } from '@store/reducers';
 import { IPriApiResourceResponse } from 'pri-api-library/types';
 
@@ -19,9 +19,10 @@ export const fetchPageData = (
 ): Promise<void> => {
   const state = getState();
   const type = 'node--pages';
+  const isOnServer = typeof window === 'undefined';
   let data = getDataByResource(state, type, id);
 
-  if (!data || !data.complete) {
+  if (!data || !data.complete || isOnServer) {
     dispatch({
       type: 'FETCH_CONTENT_DATA_REQUEST',
       payload: {
@@ -30,7 +31,7 @@ export const fetchPageData = (
       }
     });
 
-    data = await fetchPage(id).then(
+    data = await (isOnServer ? fetchPage : fetchApiPage)(id).then(
       (resp: IPriApiResourceResponse) => resp && resp.data
     );
 

--- a/store/actions/fetchPersonData.ts
+++ b/store/actions/fetchPersonData.ts
@@ -7,7 +7,7 @@ import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResourceResponse } from 'pri-api-library/types';
 import { RootState } from '@interfaces/state';
-import { fetchPerson } from '@lib/fetch';
+import { fetchApiPerson, fetchPerson } from '@lib/fetch';
 import { getDataByResource } from '@store/reducers';
 import { appendResourceCollection } from './appendResourceCollection';
 
@@ -19,9 +19,10 @@ export const fetchPersonData = (
 ): Promise<void> => {
   const state = getState();
   const type = 'node--people';
+  const isOnServer = typeof window === 'undefined';
   const data = getDataByResource(state, type, id);
 
-  if (!data) {
+  if (!data || isOnServer) {
     dispatch({
       type: 'FETCH_CONTENT_DATA_REQUEST',
       payload: {
@@ -30,7 +31,7 @@ export const fetchPersonData = (
       }
     });
 
-    const apiResp = await fetchPerson(id).then(
+    const apiResp = await (isOnServer ? fetchPerson : fetchApiPerson)(id).then(
       (resp: IPriApiResourceResponse) => resp && resp.data
     );
     const {

--- a/store/actions/fetchProgramData.ts
+++ b/store/actions/fetchProgramData.ts
@@ -19,9 +19,10 @@ export const fetchProgramData = (
 ): Promise<void> => {
   const state = getState();
   const type = 'node--programs';
+  const isOnServer = typeof window === 'undefined';
   const data = getDataByResource(state, type, id);
 
-  if (!data) {
+  if (!data || isOnServer) {
     dispatch({
       type: 'FETCH_CONTENT_DATA_REQUEST',
       payload: {
@@ -30,11 +31,9 @@ export const fetchProgramData = (
       }
     });
 
-    const apiResp = await (typeof window === 'undefined'
-      ? fetchProgram
-      : fetchApiProgram)(id).then(
-      (resp: IPriApiResourceResponse) => resp && resp.data
-    );
+    const apiResp = await (isOnServer ? fetchProgram : fetchApiProgram)(
+      id
+    ).then((resp: IPriApiResourceResponse) => resp && resp.data);
     const {
       featuredStory,
       featuredStories,

--- a/store/actions/fetchStoryData.ts
+++ b/store/actions/fetchStoryData.ts
@@ -19,9 +19,10 @@ export const fetchStoryData = (
 ): Promise<void> => {
   const state = getState();
   const type = 'node--stories';
+  const isOnServer = typeof window === 'undefined';
   let data = getDataByResource(state, type, id);
 
-  if (!data || !data.complete) {
+  if (!data || !data.complete || isOnServer) {
     dispatch({
       type: 'FETCH_CONTENT_DATA_REQUEST',
       payload: {
@@ -30,9 +31,9 @@ export const fetchStoryData = (
       }
     });
 
-    data = await (typeof window === 'undefined' ? fetchStory : fetchApiStory)(
-      id
-    ).then((resp: IPriApiResourceResponse) => resp && resp.data);
+    data = await (isOnServer ? fetchStory : fetchApiStory)(id).then(
+      (resp: IPriApiResourceResponse) => resp && resp.data
+    );
 
     dispatch({
       type: 'SET_RESOURCE_CONTEXT',

--- a/store/actions/fetchTeamData.ts
+++ b/store/actions/fetchTeamData.ts
@@ -8,7 +8,7 @@ import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiCollectionResponse } from 'pri-api-library/types';
 import { RootState } from '@interfaces/state';
-import { fetchTeam } from '@lib/fetch';
+import { fetchApiTeam, fetchTeam } from '@lib/fetch';
 import { getCollectionData } from '@store/reducers';
 import { appendResourceCollection } from './appendResourceCollection';
 
@@ -19,16 +19,18 @@ export const fetchTeamData = (): ThunkAction<void, {}, {}, AnyAction> => async (
   const state = getState();
   const type = 'team';
   const id = 'the_world';
+  const isOnServer = typeof window === 'undefined';
   const dataCheck = getCollectionData(state, type, id, 'members');
 
-  if (!dataCheck) {
+  if (!dataCheck || isOnServer) {
     dispatch({
       type: 'FETCH_TEAM_DATA_REQUEST'
     });
 
-    const teamMembers = await fetchTeam(id).then(
-      (resp: IPriApiCollectionResponse) => resp
-    );
+    const teamMembers = await (isOnServer
+      ? fetchTeam(id)
+      : fetchApiTeam()
+    ).then((resp: IPriApiCollectionResponse) => resp);
 
     dispatch(appendResourceCollection(teamMembers, type, id, 'members'));
 

--- a/store/actions/fetchTermData.ts
+++ b/store/actions/fetchTermData.ts
@@ -7,7 +7,7 @@ import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResourceResponse } from 'pri-api-library/types';
 import { RootState } from '@interfaces/state';
-import { fetchTerm } from '@lib/fetch';
+import { fetchApiTerm, fetchTerm } from '@lib/fetch';
 import { getDataByResource } from '@store/reducers';
 import { appendResourceCollection } from './appendResourceCollection';
 
@@ -19,9 +19,10 @@ export const fetchTermData = (
 ): Promise<void> => {
   const state = getState();
   const type = 'taxonomy_term--terms';
+  const isOnServer = typeof window === 'undefined';
   const data = getDataByResource(state, type, id);
 
-  if (!data) {
+  if (!data || isOnServer) {
     dispatch({
       type: 'FETCH_CONTENT_DATA_REQUEST',
       payload: {
@@ -30,7 +31,7 @@ export const fetchTermData = (
       }
     });
 
-    const apiResp = await fetchTerm(id).then(
+    const apiResp = await (isOnServer ? fetchTerm : fetchApiTerm)(id).then(
       (resp: IPriApiResourceResponse) => resp && resp.data
     );
     const {

--- a/store/reducers/index.ts
+++ b/store/reducers/index.ts
@@ -71,6 +71,24 @@ export const getCollectionData = (
   );
 };
 
+export const getHomepageData = (state: RootState) => ({
+  featuredStory: getCollectionData(
+    state,
+    'homepage',
+    undefined,
+    'featured story'
+  ),
+  featuredStories: getCollectionData(
+    state,
+    'homepage',
+    undefined,
+    'featured stories'
+  ),
+  stories: getCollectionData(state, 'homepage', undefined, 'stories'),
+  episodes: getCollectionData(state, 'homepage', undefined, 'episodes'),
+  latestStories: getCollectionData(state, 'homepage', undefined, 'latest')
+});
+
 export const getCtaData = (state: RootState, type: string, id: string) =>
   fromCtaData.getCtaData(state.ctaData, type, id);
 


### PR DESCRIPTION
Closes #263 

- Adds all page data props to static props so any change should trigger revalidation.
- Ensures data fetches always happen on server so redux data doesn't prevent revalidation.

## To Review

- [x] Use the Preview link: https://feat-263-content-update-faster.d2mc541hyaqum0.amplifyapp.com/.

> ...then...

- [x] Go to your flag story.
- [x] Inspect page, go to Network tab, and disable cache. (This should ensure only the cloudfront and built json files are delivering stale/fresh data.)
- [x] Edit the story in Drupal and publish changes.
- [x] Refresh story page.
- [x] You should still get stale content from CloudFront.
- [x] Go to your bio page, then click link to edited story.
- [x] Story should shown changes (browser fetched updated page json data from API.)
- [x] Wait 5 minutes...
- [x] Then refresh story page.
- [x] You may still get stale content.
- [x] Wait 10 seconds...
- [x] Refresh story again.
- [x] You should now see changes (new build for the page was triggered.)
