### PR TITLE
HOTFIX: Logic for filling in featured stories arrays

### DIFF
--- a/lib/fetch/category/fetchCategory.ts
+++ b/lib/fetch/category/fetchCategory.ts
@@ -50,6 +50,7 @@ export const fetchCategory = async (
     const stories = await fetchCategoryStories(category).then(
       (resp: IPriApiCollectionResponse) => resp
     );
+    const storiesData = [...stories.data];
 
     // Build response object.
     const resp = {
@@ -57,13 +58,16 @@ export const fetchCategory = async (
         ...category,
         featuredStory: featuredStories
           ? featuredStories.shift()
-          : stories.data.shift(),
+          : storiesData.shift(),
         featuredStories: featuredStories
           ? featuredStories.concat(
-              stories.data.splice(0, 4 - featuredStories.length)
+              storiesData.splice(0, 4 - featuredStories.length)
             )
-          : stories.data.splice(0, 4),
-        stories
+          : storiesData.splice(0, 4),
+        stories: {
+          ...stories,
+          data: storiesData
+        }
       }
     } as IPriApiResourceResponse;
 

--- a/lib/fetch/category/fetchCategoryStories.ts
+++ b/lib/fetch/category/fetchCategoryStories.ts
@@ -31,10 +31,14 @@ export const fetchCategoryStories = async (
 
   if (category) {
     const { featuredStories } = category;
-    const excluded = (exclude || featuredStories) && [
-      ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
-      ...(featuredStories && featuredStories.map(({ id: i }) => i))
-    ];
+    const excluded =
+      (exclude || featuredStories) &&
+      [
+        ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
+        ...(featuredStories && featuredStories.map(({ id: i }) => i))
+      ]
+        .filter((v: string) => !!v)
+        .reduce((a, v, i) => ({ ...a, [`filter[id][value][${i}]`]: v }), {});
 
     // Fetch list of stories. Paginated.
     return fetchPriApiQuery('node--stories', {
@@ -42,8 +46,8 @@ export const fetchCategoryStories = async (
       'filter[status]': 1,
       [`filter[${field}]`]: category.id,
       ...(excluded && {
-        'filter[id][value]': excluded,
-        'filter[id][operator]': '<>'
+        ...excluded,
+        'filter[id][operator]': 'NOT IN'
       }),
       sort: '-date_published',
       range,

--- a/lib/fetch/program/fetchProgram.ts
+++ b/lib/fetch/program/fetchProgram.ts
@@ -44,6 +44,7 @@ export const fetchProgram = async (
         (resp: IPriApiCollectionResponse) => resp
       )
     ]);
+    const storiesData = [...stories.data];
 
     // Build response object.
     const resp = {
@@ -51,13 +52,17 @@ export const fetchProgram = async (
         ...program,
         featuredStory: featuredStories
           ? featuredStories.shift()
-          : stories.data.shift(),
+          : storiesData.shift(),
         featuredStories: featuredStories
-          ? featuredStories.concat(
-              stories.data.splice(0, 4 - featuredStories.length)
-            )
-          : stories.data.splice(0, 4),
-        stories,
+          ? [
+              ...featuredStories,
+              ...storiesData.splice(0, 4 - featuredStories.length)
+            ]
+          : storiesData.splice(0, 4),
+        stories: {
+          ...stories,
+          data: storiesData
+        },
         episodes
       }
     } as IPriApiResourceResponse;

--- a/lib/fetch/program/fetchProgramEpisodes.ts
+++ b/lib/fetch/program/fetchProgramEpisodes.ts
@@ -30,10 +30,14 @@ export const fetchProgramEpisodes = async (
 
   if (program) {
     const { featuredStories } = program;
-    const excluded = (exclude || featuredStories) && [
-      ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
-      ...(featuredStories && featuredStories.map(({ id: i }) => i))
-    ];
+    const excluded =
+      (exclude || featuredStories) &&
+      [
+        ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
+        ...(featuredStories && featuredStories.map(({ id: i }) => i))
+      ]
+        .filter((v: string) => !!v)
+        .reduce((a, v, i) => ({ ...a, [`filter[id][value][${i}]`]: v }), {});
 
     // Fetch list of stories. Paginated.
     return fetchPriApiQuery('node--episodes', {
@@ -41,8 +45,8 @@ export const fetchProgramEpisodes = async (
       'filter[status]': 1,
       'filter[program]': program.id,
       ...(excluded && {
-        'filter[id][value]': excluded,
-        'filter[id][operator]': '<>'
+        ...excluded,
+        'filter[id][operator]': 'NOT IN'
       }),
       sort: '-date_published',
       range,

--- a/lib/fetch/term/fetchTerm.ts
+++ b/lib/fetch/term/fetchTerm.ts
@@ -44,6 +44,7 @@ export const fetchTerm = async (
       fetchTermStories(term).then((resp: IPriApiCollectionResponse) => resp),
       fetchTermEpisodes(term).then((resp: IPriApiCollectionResponse) => resp)
     ]);
+    const storiesData = [...stories.data];
 
     // Build response object.
     const resp = {
@@ -51,13 +52,16 @@ export const fetchTerm = async (
         ...term,
         featuredStory: featuredStories
           ? featuredStories.shift()
-          : stories.data.shift(),
+          : storiesData.shift(),
         featuredStories: featuredStories
           ? featuredStories.concat(
-              stories.data.splice(0, 4 - featuredStories.length)
+              storiesData.splice(0, 4 - featuredStories.length)
             )
-          : stories.data.splice(0, 4),
-        stories,
+          : storiesData.splice(0, 4),
+        stories: {
+          ...stories,
+          data: storiesData
+        },
         episodes
       }
     } as IPriApiResourceResponse;

--- a/lib/fetch/term/fetchTermEpisodes.ts
+++ b/lib/fetch/term/fetchTermEpisodes.ts
@@ -30,10 +30,14 @@ export const fetchTermEpisodes = async (
 
   if (term) {
     const { featuredStories } = term;
-    const excluded = (exclude || featuredStories) && [
-      ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
-      ...(featuredStories && featuredStories.map(({ id: i }) => i))
-    ];
+    const excluded =
+      (exclude || featuredStories) &&
+      [
+        ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
+        ...(featuredStories && featuredStories.map(({ id: i }) => i))
+      ]
+        .filter((v: string) => !!v)
+        .reduce((a, v, i) => ({ ...a, [`filter[id][value][${i}]`]: v }), {});
 
     // Fetch list of stories. Paginated.
     return fetchPriApiQuery('node--episodes', {
@@ -41,8 +45,8 @@ export const fetchTermEpisodes = async (
       'filter[status]': 1,
       'filter[tags]': term.id,
       ...(excluded && {
-        'filter[id][value]': excluded,
-        'filter[id][operator]': '<>'
+        ...excluded,
+        'filter[id][operator]': 'NOT IN'
       }),
       sort: '-date_published',
       range,

--- a/lib/fetch/term/fetchTermStories.ts
+++ b/lib/fetch/term/fetchTermStories.ts
@@ -31,10 +31,14 @@ export const fetchTermStories = async (
 
   if (term) {
     const { featuredStories } = term;
-    const excluded = (exclude || featuredStories) && [
-      ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
-      ...(featuredStories && featuredStories.map(({ id: i }) => i))
-    ];
+    const excluded =
+      (exclude || featuredStories) &&
+      [
+        ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
+        ...(featuredStories && featuredStories.map(({ id: i }) => i))
+      ]
+        .filter((v: string) => !!v)
+        .reduce((a, v, i) => ({ ...a, [`filter[id][value][${i}]`]: v }), {});
     const { pathname } = generateLinkHrefForContent(term) || {};
     const [, fn] = pathname.split('/');
     const fieldName = fn === 'tags' ? fn : `opencalais_${fn}`;
@@ -45,8 +49,8 @@ export const fetchTermStories = async (
       'filter[status]': 1,
       [`filter[${fieldName}]`]: term.id,
       ...(excluded && {
-        'filter[id][value]': excluded,
-        'filter[id][operator]': '<>'
+        ...excluded,
+        'filter[id][operator]': 'NOT IN'
       }),
       sort: '-date_published',
       range,

--- a/pages/api/category/[id]/index.ts
+++ b/pages/api/category/[id]/index.ts
@@ -37,19 +37,23 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         undefined,
         req
       );
+      const storiesData = [...stories.data];
 
       // Build response object.
       const apiResp = {
         ...category,
         featuredStory: featuredStories
           ? featuredStories.shift()
-          : stories.data.shift(),
+          : storiesData.shift(),
         featuredStories: featuredStories
           ? featuredStories.concat(
-              stories.data.splice(0, 4 - featuredStories.length)
+              storiesData.splice(0, 4 - featuredStories.length)
             )
-          : stories.data.splice(0, 4),
-        stories
+          : storiesData.splice(0, 4),
+        stories: {
+          ...stories,
+          data: storiesData
+        }
       };
 
       return res.status(200).json(apiResp);

--- a/pages/api/program/[id]/episodes/[page].ts
+++ b/pages/api/program/[id]/episodes/[page].ts
@@ -20,9 +20,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     )) as IPriApiResourceResponse;
 
     if (program) {
-      const excluded = exclude && [
-        ...(exclude && Array.isArray(exclude) ? exclude : [exclude])
-      ];
+      const excluded =
+        exclude &&
+        [...(exclude && Array.isArray(exclude) ? exclude : [exclude])]
+          .filter((v: string) => !!v)
+          .reduce((a, v, i) => ({ ...a, [`filter[id][value][${i}]`]: v }), {});
 
       // Fetch list of episodes. Paginated.
       const episodes = (await fetchPriApiQuery('node--episodes', {
@@ -30,8 +32,8 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         'filter[status]': 1,
         'filter[program]': id,
         ...(excluded && {
-          'filter[id][value]': excluded,
-          'filter[id][operator]': '<>'
+          ...excluded,
+          'filter[id][operator]': 'NOT IN'
         }),
         sort: '-date_published',
         range,

--- a/pages/api/program/[id]/index.ts
+++ b/pages/api/program/[id]/index.ts
@@ -43,6 +43,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         undefined,
         req
       );
+      const storiesData = [...stories.data];
 
       // Fetch list of episodes. Paginated.
       const episodes = await fetchApiProgramEpisodes(
@@ -59,13 +60,17 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
           ...program.data,
           featuredStory: featuredStories
             ? featuredStories.shift()
-            : stories.data.shift(),
+            : storiesData.shift(),
           featuredStories: featuredStories
-            ? featuredStories.concat(
-                stories.data.splice(0, 4 - featuredStories.length)
-              )
-            : stories.data.splice(0, 4),
-          stories,
+            ? [
+                ...featuredStories,
+                ...storiesData.splice(0, 4 - featuredStories.length)
+              ]
+            : storiesData.splice(0, 4),
+          stories: {
+            ...stories,
+            data: storiesData
+          },
           episodes
         }
       };

--- a/pages/api/program/[id]/stories/[page].ts
+++ b/pages/api/program/[id]/stories/[page].ts
@@ -21,10 +21,14 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     if (program) {
       const { featuredStories } = program.data;
-      const excluded = (exclude || featuredStories) && [
-        ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
-        ...(featuredStories && featuredStories.map(({ id: i }) => i))
-      ];
+      const excluded =
+        (exclude || featuredStories) &&
+        [
+          ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
+          ...(featuredStories && featuredStories.map(({ id: i }) => i))
+        ]
+          .filter((v: string) => !!v)
+          .reduce((a, v, i) => ({ ...a, [`filter[id][value][${i}]`]: v }), {});
 
       // Fetch list of stories. Paginated.
       const stories = (await fetchPriApiQuery('node--stories', {
@@ -32,8 +36,8 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         'filter[status]': 1,
         'filter[program]': id,
         ...(excluded && {
-          'filter[id][value]': excluded,
-          'filter[id][operator]': '<>'
+          ...excluded,
+          'filter[id][operator]': 'NOT IN'
         }),
         sort: '-date_published',
         range,

--- a/pages/api/term/[id]/episodes/[page].ts
+++ b/pages/api/term/[id]/episodes/[page].ts
@@ -20,9 +20,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     )) as IPriApiResourceResponse;
 
     if (term) {
-      const excluded = exclude && [
-        ...(exclude && Array.isArray(exclude) ? exclude : [exclude])
-      ];
+      const excluded =
+        exclude &&
+        [...(exclude && Array.isArray(exclude) ? exclude : [exclude])]
+          .filter((v: string) => !!v)
+          .reduce((a, v, i) => ({ ...a, [`filter[id][value][${i}]`]: v }), {});
 
       // Fetch list of stories. Paginated.
       const stories = (await fetchPriApiQuery('node--episodes', {
@@ -30,8 +32,8 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         'filter[status]': 1,
         'filter[tags]': id,
         ...(excluded && {
-          'filter[id][value]': excluded,
-          'filter[id][operator]': '<>'
+          ...excluded,
+          'filter[id][operator]': 'NOT IN'
         }),
         sort: '-date_published',
         range,

--- a/pages/api/term/[id]/index.ts
+++ b/pages/api/term/[id]/index.ts
@@ -31,6 +31,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         undefined,
         req
       );
+      const storiesData = [...stories.data];
 
       // Fetch list of episodes. Paginated.
       const episodes = await fetchApiTermEpisodes(
@@ -46,13 +47,16 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         ...term.data,
         featuredStory: featuredStories
           ? featuredStories.shift()
-          : stories.data.shift(),
+          : storiesData.shift(),
         featuredStories: featuredStories
           ? featuredStories.concat(
-              stories.data.splice(0, 4 - featuredStories.length)
+              storiesData.splice(0, 4 - featuredStories.length)
             )
-          : stories.data.splice(0, 4),
-        stories,
+          : storiesData.splice(0, 4),
+        stories: {
+          ...stories,
+          data: storiesData
+        },
         episodes
       };
 


### PR DESCRIPTION
- fix logic used to fill in featured stories arrays with recent stories
- fix exclusion params used for collection queries

## To Review

- [x] Use the Preview link: https://fix-landing-page-featured-story-fill-logic.d2mc541hyaqum0.amplifyapp.com/.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to a program page that has no featured stories.
- [x] Note that the featured stories block has 1 hero and 4 small cards in a 4x4 grid.
- [x] Take note of the first three stories after the CTA.
- [x] Edit program and add 2 featured stories.
- [x] Refresh program page.
- [x] Ensure that the feature area still has 1 hero and 4 small cards in a 4x4 grid.
- [x] Ensure the last three feature stories are those previously noted being after CTA.
