### PR TITLE
HOTFIX: Try hashing static props data

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "react-twitter-embed": "^3.0.3",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
-    "uid": "^2.0.0"
+    "uid": "^2.0.0",
+    "utf8": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -150,7 +150,7 @@ export const getStaticProps = wrapper.getStaticProps(
             type: resourceType,
             id: resourceId,
             dataHash: crypto
-              .createHash('md5')
+              .createHash('sha256')
               .update(JSON.stringify(data))
               .digest('hex')
           },

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -7,8 +7,7 @@ import React, { useEffect } from 'react';
 import { useStore } from 'react-redux';
 import { GetStaticPropsResult } from 'next';
 import dynamic from 'next/dynamic';
-import base64 from 'base-64';
-import utf8 from 'utf8';
+import crypto from 'crypto';
 import { Url } from 'url';
 import {
   IPriApiCollectionResponse,
@@ -150,7 +149,10 @@ export const getStaticProps = wrapper.getStaticProps(
           props: {
             type: resourceType,
             id: resourceId,
-            dataHash: base64.encode(utf8.encode(JSON.stringify(data)))
+            dataHash: crypto
+              .createHash('md5')
+              .update(JSON.stringify(data))
+              .digest('hex')
           },
           revalidate: 10
         };

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -7,6 +7,7 @@ import React, { useEffect } from 'react';
 import { useStore } from 'react-redux';
 import { GetStaticPropsResult } from 'next';
 import dynamic from 'next/dynamic';
+import { encode } from 'base-64';
 import { Url } from 'url';
 import {
   IPriApiCollectionResponse,
@@ -145,7 +146,11 @@ export const getStaticProps = wrapper.getStaticProps(
         }
 
         return {
-          props: { type: resourceType, id: resourceId, ...data },
+          props: {
+            type: resourceType,
+            id: resourceId,
+            dataHash: encode(JSON.stringify(data))
+          },
           revalidate: 10
         };
       }

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -7,7 +7,8 @@ import React, { useEffect } from 'react';
 import { useStore } from 'react-redux';
 import { GetStaticPropsResult } from 'next';
 import dynamic from 'next/dynamic';
-import { encode } from 'base-64';
+import base64 from 'base-64';
+import utf8 from 'utf8';
 import { Url } from 'url';
 import {
   IPriApiCollectionResponse,
@@ -149,7 +150,7 @@ export const getStaticProps = wrapper.getStaticProps(
           props: {
             type: resourceType,
             id: resourceId,
-            dataHash: encode(JSON.stringify(data))
+            dataHash: base64.encode(utf8.encode(JSON.stringify(data)))
           },
           revalidate: 10
         };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,8 @@
  */
 
 import React from 'react';
-import { encode } from 'base-64';
+import base64 from 'base-64';
+import utf8 from 'utf8';
 import { Homepage } from '@components/pages/Homepage';
 import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
@@ -24,7 +25,7 @@ export const getStaticProps = wrapper.getStaticProps(store => async () => {
 
   return {
     props: {
-      dataHash: encode(JSON.stringify(data))
+      dataHash: base64.encode(utf8.encode(JSON.stringify(data)))
     },
     revalidate: 10
   };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,7 +25,7 @@ export const getStaticProps = wrapper.getStaticProps(store => async () => {
   return {
     props: {
       dataHash: crypto
-        .createHash('md5')
+        .createHash('sha256')
         .update(JSON.stringify(data))
         .digest('hex')
     },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { encode } from 'base-64';
 import { Homepage } from '@components/pages/Homepage';
 import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
@@ -23,7 +24,7 @@ export const getStaticProps = wrapper.getStaticProps(store => async () => {
 
   return {
     props: {
-      ...data
+      dataHash: encode(JSON.stringify(data))
     },
     revalidate: 10
   };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,8 +4,7 @@
  */
 
 import React from 'react';
-import base64 from 'base-64';
-import utf8 from 'utf8';
+import crypto from 'crypto';
 import { Homepage } from '@components/pages/Homepage';
 import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
@@ -25,7 +24,10 @@ export const getStaticProps = wrapper.getStaticProps(store => async () => {
 
   return {
     props: {
-      dataHash: base64.encode(utf8.encode(JSON.stringify(data)))
+      dataHash: crypto
+        .createHash('md5')
+        .update(JSON.stringify(data))
+        .digest('hex')
     },
     revalidate: 10
   };

--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -7,8 +7,7 @@ import React, { useEffect } from 'react';
 import { useStore } from 'react-redux';
 import { GetStaticPropsResult } from 'next';
 import dynamic from 'next/dynamic';
-import base64 from 'base-64';
-import utf8 from 'utf8';
+import crypto from 'crypto';
 import {
   IPriApiResource,
   IPriApiResourceResponse
@@ -108,8 +107,13 @@ export const getStaticProps = wrapper.getStaticProps(
         );
 
         return {
-          props: { dataHash: base64.encode(utf8.encode(JSON.stringify(data))) },
-          revalidate: 10
+          props: {
+            dataHash: crypto
+              .createHash('md5')
+              .update(JSON.stringify(data))
+              .digest('hex'),
+            revalidate: 10
+          }
         };
       }
     }

--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -7,6 +7,7 @@ import React, { useEffect } from 'react';
 import { useStore } from 'react-redux';
 import { GetStaticPropsResult } from 'next';
 import dynamic from 'next/dynamic';
+import { encode } from 'base-64';
 import {
   IPriApiResource,
   IPriApiResourceResponse
@@ -106,7 +107,7 @@ export const getStaticProps = wrapper.getStaticProps(
         );
 
         return {
-          props: { ...data },
+          props: { dataHash: encode(JSON.stringify(data)) },
           revalidate: 10
         };
       }

--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -7,7 +7,8 @@ import React, { useEffect } from 'react';
 import { useStore } from 'react-redux';
 import { GetStaticPropsResult } from 'next';
 import dynamic from 'next/dynamic';
-import { encode } from 'base-64';
+import base64 from 'base-64';
+import utf8 from 'utf8';
 import {
   IPriApiResource,
   IPriApiResourceResponse
@@ -107,7 +108,7 @@ export const getStaticProps = wrapper.getStaticProps(
         );
 
         return {
-          props: { dataHash: encode(JSON.stringify(data)) },
+          props: { dataHash: base64.encode(utf8.encode(JSON.stringify(data))) },
           revalidate: 10
         };
       }

--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -109,7 +109,7 @@ export const getStaticProps = wrapper.getStaticProps(
         return {
           props: {
             dataHash: crypto
-              .createHash('md5')
+              .createHash('sha256')
               .update(JSON.stringify(data))
               .digest('hex'),
             revalidate: 10

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,12 +3016,7 @@ can-use-dom@^0.1.0:
   resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
-caniuse-lite@^1.0.30001181:
-  version "1.0.30001272"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz"
-  integrity sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==
-
-caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001230:
+caniuse-lite@^1.0.30001181, caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001230:
   version "1.0.30001272"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz"
   integrity sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==
@@ -9030,6 +9025,11 @@ use-subscription@1.5.1:
   integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
   dependencies:
     object-assign "^4.1.1"
+
+utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
+  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Perhaps the check that nextjs does for prop changes doesn't go deep enough to catch changes to nested references. Here we are creating an SHA256 string from the stringified JSON of the page data.

## To Review

- [ ] Use the Preview link: https://fix-isr-hash-data.d2mc541hyaqum0.amplifyapp.com/.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Not really anything more than looking at the React Component inspector to se what `pageProps` are being fed to page and noting the `dataHash` prop. Other than that it really seeing if changes get detected when editors add/update content.
