### PR TITLE
HOTFIX: Gets media pages rendering again

### DIFF
--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -108,12 +108,14 @@ export const getStaticProps = wrapper.getStaticProps(
 
         return {
           props: {
+            type: resourceType,
+            id: resourceId,
             dataHash: crypto
               .createHash('sha256')
               .update(JSON.stringify(data))
-              .digest('hex'),
-            revalidate: 10
-          }
+              .digest('hex')
+          },
+          revalidate: 10
         };
       }
     }


### PR DESCRIPTION
- add type and id to page props

## To Review

- [ ] Use the Preview link: https://fix-media-pages-not-rendering-data.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Visit a media page url and ensure it loads.
