### PR TITLE
#273: Use `format` for `Story Format` Plausible goal

### DIFF
--- a/components/pages/Story/Story.tsx
+++ b/components/pages/Story/Story.tsx
@@ -37,13 +37,14 @@ export const Story = () => {
     dateBroadcast,
     datePublished,
     displayTemplate,
+    format,
     resourceDevelopment
   } = data;
   const LayoutComponent =
     layoutComponentMap[displayTemplate] || layoutComponentMap.standard;
   const props = {
     Title: title,
-    ...(displayTemplate && { 'Story Format': displayTemplate }),
+    ...(format && { 'Story Format': format.title }),
     ...(resourceDevelopment && {
       'Resource Development': resourceDevelopment
     }),

--- a/lib/fetch/api/params/story.ts
+++ b/lib/fetch/api/params/story.ts
@@ -42,6 +42,7 @@ export const fullStoryParams = {
     'opencalais_region',
     'opencalais_person',
     'tags',
+    'format',
     'video'
   ],
   fields: [
@@ -88,6 +89,7 @@ export const fullStoryParams = {
     'opencalais_person.metatags',
     'tags.title',
     'tags.metatags',
+    'format.title',
     'video'
   ]
 };


### PR DESCRIPTION
Closes #273 

## To Review

- [ ] Use the Preview link: https://fix-273-plausible-story-format-goal-use-format-prop.d2mc541hyaqum0.amplifyapp.com/.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Open debugger and go to Networks tab and filter for _Fetch/XHR_.
- [x] Visit a story page.
- [x] Ensure there is a `event` request sent for the `Story` goal, and its prop contain a `Story Format` w/ an expected value.
