### PR TITLE
HOTFIX: Story related links w/o image no longer cause error

### DIFF
--- a/components/pages/Story/layouts/default/components/StoryRelatedLinks/StoryRelatedLinks.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryRelatedLinks/StoryRelatedLinks.default.tsx
@@ -45,15 +45,17 @@ export const StoryRelatedLinks = ({
               <ContentLink data={story}>
                 <Card square elevation={1}>
                   <CardActionArea>
-                    <CardMedia>
-                      <Image
-                        src={image.url}
-                        alt={image.alt}
-                        layout="fill"
-                        objectFit="cover"
-                        sizes={sizes}
-                      />
-                    </CardMedia>
+                    {image && (
+                      <CardMedia>
+                        <Image
+                          src={image.url}
+                          alt={image.alt}
+                          layout="fill"
+                          objectFit="cover"
+                          sizes={sizes}
+                        />
+                      </CardMedia>
+                    )}
                     <CardContent>
                       <Typography variant="h5" component="h2">
                         {title}


### PR DESCRIPTION
- Only renders card image when image data exists.

## To Review

- [x] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to `/stories/2018-02-08/aha-moment-billy-joel-s-lullabye` and ensure page loads.
- [x] Note related cards render w/o image when linked story doesn't have a lede image.
