### PR TITLE
HOTFIX: Only use story byline items that have a person set

### DIFF
--- a/components/pages/Story/Story.tsx
+++ b/components/pages/Story/Story.tsx
@@ -77,12 +77,14 @@ export const Story = () => {
 
   if (byline) {
     byline.forEach(({ person }) => {
-      plausibleEvents.push([
-        `Person: ${person.title}`,
-        {
-          props: { 'Page Type': 'Story' }
-        }
-      ]);
+      if (person) {
+        plausibleEvents.push([
+          `Person: ${person.title}`,
+          {
+            props: { 'Page Type': 'Story' }
+          }
+        ]);
+      }
     });
   }
 

--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -78,12 +78,14 @@ export const StoryHeader = ({ data }: Props) => {
           )}
           {byline && (
             <ul className={classes.byline}>
-              {byline.map(({ id, creditType, person }) => (
-                <li className={classes.bylineItem} key={id}>
-                  {creditType ? creditType.title : 'By'}{' '}
-                  <ContentLink className={classes.bylineLink} data={person} />
-                </li>
-              ))}
+              {byline
+                .filter(({ person }) => !!person)
+                .map(({ id, creditType, person }) => (
+                  <li className={classes.bylineItem} key={id}>
+                    {creditType ? creditType.title : 'By'}{' '}
+                    <ContentLink className={classes.bylineLink} data={person} />
+                  </li>
+                ))}
             </ul>
           )}
         </Box>

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -115,15 +115,17 @@ export const StoryHeader = ({ data }: Props) => {
                 )}
                 {byline && (
                   <ul className={classes.byline}>
-                    {byline.map(({ id, creditType, person }) => (
-                      <li className={classes.bylineItem} key={id}>
-                        {creditType ? creditType.title : 'By'}{' '}
-                        <ContentLink
-                          className={classes.bylineLink}
-                          data={person}
-                        />
-                      </li>
-                    ))}
+                    {byline
+                      .filter(({ person }) => !!person)
+                      .map(({ id, creditType, person }) => (
+                        <li className={classes.bylineItem} key={id}>
+                          {creditType ? creditType.title : 'By'}{' '}
+                          <ContentLink
+                            className={classes.bylineLink}
+                            data={person}
+                          />
+                        </li>
+                      ))}
                   </ul>
                 )}
               </Box>


### PR DESCRIPTION
## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to this story that has a _Producer_ byline w/o a person selected: `stories/2014-03-16/japanese-filmmaker-hayao-miyazaki-moves-beautiful-fantasy-world-war-ii-his-new`.
- [x] Ensure page loads and doesn't render the empty producer credit.
- [x] Ensure a plausible event is only fired for the shown person in the byline.
