### PR TITLE
HOTFIX: Move social platform ID/Tokens to env variables

### DIFF
--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -29,7 +29,7 @@ export interface IHtmlContentProps {
 
 export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
   const cleanHtml = (dirtyHtml: string) => {
-    return [(h: string) => h.replace(/<[^>]+>\s*<\/[^>]+>/, '')].reduce(
+    return [(h: string) => h.replace(/<[^>/]+>\s*<\/[^>]+>/, '')].reduce(
       (acc, func) => func(acc),
       dirtyHtml
     );

--- a/components/HtmlContent/transforms/facebookPost.tsx
+++ b/components/HtmlContent/transforms/facebookPost.tsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import { FacebookProvider, EmbeddedPost } from 'react-facebook';
 import { DomElement } from 'htmlparser2';
-import { fb } from '@config';
 
 export const facebookPost = (node: DomElement) => {
   let embedUrl: string;
@@ -32,7 +31,7 @@ export const facebookPost = (node: DomElement) => {
 
   if (embedUrl) {
     return (
-      <FacebookProvider appId={fb.appId}>
+      <FacebookProvider appId={process.env.FB_APP_ID}>
         <EmbeddedPost href={embedUrl} />
       </FacebookProvider>
     );

--- a/components/HtmlContent/transforms/facebookVideo.tsx
+++ b/components/HtmlContent/transforms/facebookVideo.tsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import { FacebookProvider, EmbeddedVideo } from 'react-facebook';
 import { DomElement } from 'htmlparser2';
-import { fb } from '@config';
 
 export const facebookVideo = (node: DomElement) => {
   let embedUrl: string;
@@ -34,7 +33,7 @@ export const facebookVideo = (node: DomElement) => {
 
   if (embedUrl) {
     return (
-      <FacebookProvider appId={fb.appId}>
+      <FacebookProvider appId={process.env.FB_APP_ID}>
         <EmbeddedVideo href={embedUrl} />
       </FacebookProvider>
     );

--- a/components/HtmlContent/transforms/instagramEmbed.tsx
+++ b/components/HtmlContent/transforms/instagramEmbed.tsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import InstagramEmbed from 'react-instagram-embed';
 import { DomElement } from 'htmlparser2';
-import { fb } from '@config';
 
 export const instagramEmebed = (node: DomElement) => {
   let url: string;
@@ -31,7 +30,10 @@ export const instagramEmebed = (node: DomElement) => {
 
   if (url) {
     return (
-      <InstagramEmbed url={url} clientAccessToken={fb.clientAccessToken} />
+      <InstagramEmbed
+        url={url}
+        clientAccessToken={process.env.FB_ACCESS_TOKEN}
+      />
     );
   }
 

--- a/components/OpenGraph/OpenGraph.tsx
+++ b/components/OpenGraph/OpenGraph.tsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import { encode } from 'base-64';
-import { fb } from '@config';
 import { IImageStyle } from '@interfaces/content';
 
 export interface IOpenGraphProps {
@@ -26,8 +25,8 @@ export const OpenGraph = ({
   children
 }: IOpenGraphProps) => (
   <>
-    <meta property="fb:admins" content={fb.admins} />
-    <meta property="fb:app_id" content={fb.appId} />
+    <meta property="fb:admins" content={process.env.FB_ADMINS} />
+    <meta property="fb:app_id" content={process.env.FB_APP_ID} />
     <meta property="og:site_name" content="The World from PRX" />
     <meta property="og:type" content={type} />
     <meta property="og:title" content={title} />

--- a/components/TwitterCard/TwitterCard.tsx
+++ b/components/TwitterCard/TwitterCard.tsx
@@ -4,7 +4,6 @@
  */
 
 import React from 'react';
-import { twitter } from '@config';
 import { IImageStyle } from '@interfaces/content';
 
 export interface ITwitterCardProps {
@@ -25,7 +24,7 @@ export const TwitterCard = ({
   children
 }: ITwitterCardProps) => (
   <>
-    <meta name="twitter:account_id" content={twitter.accountId} />
+    <meta name="twitter:account_id" content={process.env.TWITTER_ACCOUNT_ID} />
     <meta name="twitter:card" content={type} />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:url" content={url} />

--- a/config/development.js
+++ b/config/development.js
@@ -4,15 +4,5 @@ module.exports = {
     domain: 'api.pri.org',
     apiPath: 'api',
     apiVersion: '1.0'
-  },
-  fb: {
-    admins: '16800048',
-    appId: '142079625983010',
-    clientToken: '987e1f53e945ba53f8fbd95d8c82c93e',
-    clientAccessToken: '142079625983010|987e1f53e945ba53f8fbd95d8c82c93e'
-  },
-  twitter: {
-    accountId: '24953039'
-  },
-  analytics: {}
+  }
 };

--- a/config/index.js
+++ b/config/index.js
@@ -32,14 +32,6 @@ const config = {
     ...(defaultConfig.analytics || {}),
     ...(localConfig.analytics || {})
   },
-  fb: {
-    ...(defaultConfig.fb || {}),
-    ...(localConfig.fb || {})
-  },
-  twitter: {
-    ...(defaultConfig.twitter || {}),
-    ...(localConfig.twitter || {})
-  },
   priApi: {
     ...(defaultConfig.priApi || {}),
     ...(localConfig.priApi || {})
@@ -51,15 +43,15 @@ const {
   priApi: { protocol, domain, apiPath, apiVersion }
 } = config;
 // Get env domain, fall back to configured domain.
-const { PRI_API_DOMAIN: configDomain = domain } = process.env;
+const apiDomain = process.env.PRI_API_DOMAIN || domain;
 // Construct base API URL.
-const apiUrlBase = `${protocol}://${configDomain}/${apiPath}/v${apiVersion}`;
+const apiUrlBase = `${protocol}://${apiDomain}/${apiPath}/v${apiVersion}`;
 
 module.exports = {
   ...config,
   priApi: {
     ...priApi,
-    domain: configDomain,
+    domain: apiDomain,
     apiUrlBase
   }
 };

--- a/config/production.js
+++ b/config/production.js
@@ -4,15 +4,5 @@ module.exports = {
     domain: 'api.pri.org',
     apiPath: 'api',
     apiVersion: '1.0'
-  },
-  fb: {
-    admins: '16800048',
-    appId: '142079625983010',
-    clientToken: '987e1f53e945ba53f8fbd95d8c82c93e',
-    clientAccessToken: '142079625983010|987e1f53e945ba53f8fbd95d8c82c93e'
-  },
-  twitter: {
-    accountId: '24953039'
-  },
-  analytics: {}
+  }
 };

--- a/next.config.js
+++ b/next.config.js
@@ -16,8 +16,11 @@ module.exports = withPlausibleProxy({
     CM_API_KEY: process.env.CM_API_KEY,
     CSE_API_KEY: process.env.CSE_API_KEY,
     FB_ACCESS_TOKEN: process.env.FB_ACCESS_TOKEN,
+    FB_ADMINS: process.env.FB_ADMINS,
+    FB_APP_ID: process.env.FB_APP_ID,
     PRI_API_CONFIG: priApi,
     ISR_REVALIDATE: process.env.ISR_REVALIDATE,
+    TWITTER_ACCOUNT_ID: process.env.TWITTER_ACCOUNT_ID,
     TW_API_RESOURCE_CACHE_CONTROL: process.env.TW_API_RESOURCE_CACHE_CONTROL,
     TW_API_COLLECTION_CACHE_CONTROL:
       process.env.TW_API_COLLECTION_CACHE_CONTROL,


### PR DESCRIPTION
- Updates components to get social platform ID's/tokens from env variables
- Fixes issue with HtmlContent clean-up pattern matching closing tags followed by spaces. (See live Privacy page.)

## To Review

- [x] Use the Preview link: https://feat-move-fb-access-key-to-env-variable.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Inspect headers for og and twitter metatags. (Due to how app inits, you may want to disable js temporarily to inspect header tags.)
- [x] Go to privacy page and ensure the content renders as expected.
