### PR TITLE
#284: Handle province term paths

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,4 +1,13 @@
 version: 1
+test:
+  phases:
+    preTest:
+      commands:
+        - yarn install
+    test:
+      commands:
+        - yarn lint
+        - yarn test
 frontend:
   phases:
     preBuild:
@@ -17,12 +26,3 @@ frontend:
     paths:
       - 'node_modules/**/*'
       - '.next/cache/**/*'
-test:
-  phases:
-    preTest:
-      commands:
-        - yarn install
-    test:
-      commands:
-        - yarn lint
-        - yarn test

--- a/amplify.yml
+++ b/amplify.yml
@@ -17,3 +17,11 @@ frontend:
     paths:
       - 'node_modules/**/*'
       - '.next/cache/**/*'
+test:
+  preTest:
+    commands:
+      - yarn install
+  test:
+    commands:
+      - yarn lint
+      - yarn test

--- a/amplify.yml
+++ b/amplify.yml
@@ -3,14 +3,15 @@ test:
   phases:
     preTest:
       commands:
+        - mkdir .jest
         - yarn install
     test:
       commands:
         - yarn lint
-        - yarn test --json --outputFile=.jest/reports/jestReport.json
+        - yarn test --json --outputFile=.jest/jestReport.json
   artifacts:
     baseDirectory: .jest
-    configFilePath: '**/jestReport.json'
+    configFilePath: 'jestReport.json'
     files:
       - '**/*'
 frontend:

--- a/amplify.yml
+++ b/amplify.yml
@@ -7,7 +7,12 @@ test:
     test:
       commands:
         - yarn lint
-        - yarn test
+        - yarn test --json --outputFile=.jest/reports/jestReport.json
+  artifacts:
+    baseDirectory: .jest
+    configFilePath: '**/jestReport.json'
+    files:
+      - '**/*'
 frontend:
   phases:
     preBuild:

--- a/amplify.yml
+++ b/amplify.yml
@@ -18,10 +18,11 @@ frontend:
       - 'node_modules/**/*'
       - '.next/cache/**/*'
 test:
-  preTest:
-    commands:
-      - yarn install
-  test:
-    commands:
-      - yarn lint
-      - yarn test
+  phases:
+    preTest:
+      commands:
+        - yarn install
+    test:
+      commands:
+        - yarn lint
+        - yarn test

--- a/components/AppCtaBanner/AppCtaBanner.tsx
+++ b/components/AppCtaBanner/AppCtaBanner.tsx
@@ -72,7 +72,12 @@ export const AppCtaBanner = () => {
               <CtaMessageComponent data={shownMessage} onClose={handleClose} />
             </Container>
             <Box position="absolute" top={0} right={0}>
-              <IconButton aria-label="close" color="inherit" disableRipple onClick={handleClose}>
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                disableRipple
+                onClick={handleClose}
+              >
                 <CloseSharp />
               </IconButton>
             </Box>

--- a/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
+++ b/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
@@ -74,7 +74,12 @@ export const AppCtaLoadUnder = () => {
               <CtaMessageComponent data={shownMessage} onClose={handleClose} />
             </Container>
             <Box position="absolute" top={0} right={0}>
-              <IconButton aria-label="close" color="inherit" disableRipple onClick={handleClose}>
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                disableRipple
+                onClick={handleClose}
+              >
                 <CloseSharp />
               </IconButton>
             </Box>

--- a/components/Sidebar/SidebarCta/SidebarCta.styles.ts
+++ b/components/Sidebar/SidebarCta/SidebarCta.styles.ts
@@ -4,9 +4,7 @@
  */
 
 import { createMuiTheme, Theme } from '@material-ui/core/styles';
-import { BlockRounded } from '@material-ui/icons';
 import { blue, grey } from '@theme/colors';
-import { NONAME } from 'dns';
 
 export const sidebarCtaTheme = (theme: Theme) =>
   createMuiTheme(theme, {

--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -136,7 +136,7 @@ export const Term = () => {
       // Get CTA message data.
       const context = [`term:${id}`];
       await store.dispatch<any>(
-        fetchCtaData('tw_cta_regions_landing', type, id, context)
+        fetchCtaData(type, id, 'tw_cta_regions_landing', context)
       );
     })();
   }, [id]);

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,16 @@ module.exports = {
   },
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '^@components(.*)$': '<rootDir>/components$1',
+    '^@config(.*)$': '<rootDir>/config$1',
+    '^@contexts(.*)$': '<rootDir>/contexts$1',
+    '^@interfaces(.*)$': '<rootDir>/interfaces$1',
+    '^@lib(.*)$': '<rootDir>/lib$1',
+    '^@store(.*)$': '<rootDir>/store$1',
+    '^@svg(.*)$': '<rootDir>/assets/svg$1',
+    '^@theme(.*)$': '<rootDir>/theme$1'
+  },
   globals: {
     'ts-jest': {
       tsConfig: 'tsconfig.jest.json'

--- a/lib/fetch/term/fetchTerm.ts
+++ b/lib/fetch/term/fetchTerm.ts
@@ -44,7 +44,7 @@ export const fetchTerm = async (
       fetchTermStories(term).then((resp: IPriApiCollectionResponse) => resp),
       fetchTermEpisodes(term).then((resp: IPriApiCollectionResponse) => resp)
     ]);
-    const storiesData = [...stories.data];
+    const storiesData = stories ? [...stories.data] : [];
 
     // Build response object.
     const resp = {

--- a/lib/fetch/term/fetchTermStories.spec.ts
+++ b/lib/fetch/term/fetchTermStories.spec.ts
@@ -1,0 +1,25 @@
+import { generateFieldNameFromPath } from './fetchTermStories';
+
+describe('lib/fetch/term', () => {
+  describe(generateFieldNameFromPath, () => {
+    test('should generate `tags` path.', () => {
+      const result = generateFieldNameFromPath('/tags/foo');
+
+      expect(result).toEqual('tags');
+    });
+
+    test('should generate `opencalais_*` path.', () => {
+      let result = generateFieldNameFromPath('/city/foo');
+      expect(result).toEqual('opencalais_city');
+
+      result = generateFieldNameFromPath('/country/foo');
+      expect(result).toEqual('opencalais_country');
+    });
+
+    test('should generate `opencalais_province` path.', () => {
+      const result = generateFieldNameFromPath('/province-or-state/foo');
+
+      expect(result).toEqual('opencalais_province');
+    });
+  });
+});

--- a/lib/fetch/term/fetchTermStories.ts
+++ b/lib/fetch/term/fetchTermStories.ts
@@ -13,6 +13,21 @@ import { generateLinkHrefForContent } from '@lib/routing';
 import { fetchPriApiItem, fetchPriApiQuery } from '../api/fetchPriApi';
 import { basicStoryParams } from '../api/params';
 
+export const generateFieldNameFromPath = (pathname: string): string => {
+  const [, vocabSlug] = pathname.split('/');
+  const fn = (slug => {
+    switch (slug) {
+      case 'province-or-state':
+        return 'province';
+
+      default:
+        return slug.replace(/\W+/, '');
+    }
+  })(vocabSlug);
+  const fieldName = fn === 'tags' ? fn : `opencalais_${fn}`;
+  return fieldName;
+};
+
 export const fetchTermStories = async (
   id: string | IPriApiResource,
   page: number = 1,
@@ -40,8 +55,7 @@ export const fetchTermStories = async (
         .filter((v: string) => !!v)
         .reduce((a, v, i) => ({ ...a, [`filter[id][value][${i}]`]: v }), {});
     const { pathname } = generateLinkHrefForContent(term) || {};
-    const [, fn] = pathname.split('/');
-    const fieldName = fn === 'tags' ? fn : `opencalais_${fn}`;
+    const fieldName = generateFieldNameFromPath(pathname);
 
     // Fetch list of stories. Paginated.
     return fetchPriApiQuery('node--stories', {


### PR DESCRIPTION
Closes #284

- adds logic to handle inconsistencies in mapping term path slugs to term fields on stories
- adds tests for new field name from pathname generator
- adds tests to amplify deployment process

## To Review

- [x] Use the Preview link: https://fix-284-handle-province-term-path.d2mc541hyaqum0.amplifyapp.com/province-or-state/texas

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure `province-or-state/*` routes render as expected.
- [x] Log into AWS console: https://d-906713e952.awsapps.com/start#/
- [x] Choose __The World > AdministratorAccess - Management console__.
- [x] Go to Amplify build for this branch: https://us-east-2.console.aws.amazon.com/amplify/home?region=us-east-2&code=f2a43046ad4b96bcc7b9#/d2mc541hyaqum0/fix-284-handle-province-term-path/6
- [x] Note that test tab has output and tests completed successfully.
