### PR TITLE
#283 CTA Banner styling changes for CLS issues

### DIFF
--- a/components/AppCtaBanner/AppCtaBanner.styles.ts
+++ b/components/AppCtaBanner/AppCtaBanner.styles.ts
@@ -57,7 +57,6 @@ export const appCtaBannerTheme = (theme: Theme) =>
           justifyContent: 'center',
           marginTop: 0,
           marginBottom: 0,
-          minHeight: '48px',
           '& > * + *': {
             marginLeft: theme.spacing(2)
           }

--- a/components/AppCtaBanner/AppCtaBanner.styles.ts
+++ b/components/AppCtaBanner/AppCtaBanner.styles.ts
@@ -15,11 +15,11 @@ export const appCtaBannerTheme = (theme: Theme) =>
     typography: {
       h2: {
         color: theme.palette.primary.contrastText,
-        fontSize: '1.5rem'
+        fontSize: '1.2rem'
       },
       body1: {
-        fontSize: '1.1rem',
-        lineHeight: 1.4
+        fontSize: '1rem',
+        lineHeight: 1.3
       }
     },
     overrides: {
@@ -40,8 +40,8 @@ export const appCtaBannerTheme = (theme: Theme) =>
           paddingLeft: theme.spacing(2)
         },
         label: {
-          paddingTop: theme.spacing(2),
-          paddingBottom: theme.spacing(2),
+          paddingTop: theme.spacing(1),
+          paddingBottom: theme.spacing(0),
           textAlign: 'left'
         }
       },
@@ -55,7 +55,9 @@ export const appCtaBannerTheme = (theme: Theme) =>
       MuiToolbar: {
         root: {
           justifyContent: 'center',
-          marginTop: theme.spacing(3),
+          marginTop: 0,
+          marginBottom: 0,
+          minHeight: '48px',
           '& > * + *': {
             marginLeft: theme.spacing(2)
           }

--- a/components/AppCtaBanner/AppCtaBanner.tsx
+++ b/components/AppCtaBanner/AppCtaBanner.tsx
@@ -64,9 +64,9 @@ export const AppCtaBanner = () => {
             className={cx('root')}
             display="flex"
             alignItems="center"
-            minHeight={300}
-            px={4}
-            py={3}
+            minHeight="230"
+            px={2}
+            py={2}
           >
             <Container maxWidth="md">
               <CtaMessageComponent data={shownMessage} onClose={handleClose} />

--- a/components/AppCtaBanner/AppCtaBanner.tsx
+++ b/components/AppCtaBanner/AppCtaBanner.tsx
@@ -64,7 +64,7 @@ export const AppCtaBanner = () => {
             className={cx('root')}
             display="flex"
             alignItems="center"
-            minHeight="230"
+            minHeight={230}
             px={2}
             py={2}
           >


### PR DESCRIPTION
Closes #283 

- Improves the CLS (cumulative layout shift) caused by the donation banner to something a little more tolerable. From a score over 2.5 to more of a warning at 1.7.

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.

> ...then...

- [ ] If you don't have it already, Install the [Web Vitals Chrome extension](https://chrome.google.com/webstore/detail/web-vitals/ahfhijdlegdabablpippeagghigmibma) and enable to run in the Developer tools console (in private windows too!!)
- [ ] Clear your cookies or open a new private window to ensure you get the banner on page load
- [ ] Go to https://theworld.org with the developer console open, note the CLS score (its over 2.5, which is the error threshold)
- [ ] Go to [localhost:3000](https://localhost:3000) with the developer console open and note the score (for me it was around 1.7 after the changes. Slight improvement.
- [ ] ensure banner styles are okay in mobile. 
