### PR TITLE
HOTFIX: Pages missing expected metatag values should no longer cause 500 errors

### DIFF
--- a/components/MetaTags/MetaTags.spec.ts
+++ b/components/MetaTags/MetaTags.spec.ts
@@ -1,0 +1,28 @@
+import { sanitizeContent } from './MetaTags';
+
+describe('Components/MetaTags', () => {
+  describe('sanitizeContent', () => {
+    test('should handle undefined value', () => {
+      const result = sanitizeContent(undefined);
+
+      expect(result).toBeUndefined();
+    });
+
+    test('should handle null value', () => {
+      const result = sanitizeContent(null);
+
+      expect(result).toBeUndefined();
+    });
+
+    test('should handle empty value', () => {
+      const result = sanitizeContent('');
+
+      expect(result).toEqual('');
+    });
+
+    test('should remove HTML tags.', () => {
+      const result = sanitizeContent('<b>foo</b>');
+      expect(result).toEqual('foo');
+    });
+  });
+});

--- a/components/MetaTags/MetaTags.tsx
+++ b/components/MetaTags/MetaTags.tsx
@@ -18,7 +18,8 @@ export interface IMetaTagsProps {
   data: IMetaTags;
 }
 
-const sanitizeContent = (content: string) => content.replace(/<[^>]+>/g, '');
+export const sanitizeContent = (content: string) =>
+  content?.replace(/<[^>]+>/g, '');
 
 export const MetaTags = ({ data }: IMetaTagsProps) => {
   const {

--- a/components/pages/Audio/components/AudioHeader/AudioHeader.tsx
+++ b/components/pages/Audio/components/AudioHeader/AudioHeader.tsx
@@ -29,14 +29,16 @@ export const AudioHeader = ({ data }: Props) => {
           {program?.metatags && (
             <ContentLink data={program} className={classes.programLink} />
           )}
-          <Moment
-            className={classes.date}
-            format="MMM. D, YYYY · h:mm A z"
-            tz="America/New_York"
-            unix
-          >
-            {broadcastDate}
-          </Moment>
+          {broadcastDate && (
+            <Moment
+              className={classes.date}
+              format="MMM. D, YYYY · h:mm A z"
+              tz="America/New_York"
+              unix
+            >
+              {broadcastDate}
+            </Moment>
+          )}
           {audioAuthor && !!audioAuthor.length && (
             <ul className={classes.byline}>
               {audioAuthor.map(

--- a/lib/fetch/term/fetchTermStories.spec.ts
+++ b/lib/fetch/term/fetchTermStories.spec.ts
@@ -1,7 +1,7 @@
 import { generateFieldNameFromPath } from './fetchTermStories';
 
 describe('lib/fetch/term', () => {
-  describe(generateFieldNameFromPath, () => {
+  describe('generateFieldNameFromPath', () => {
     test('should generate `tags` path.', () => {
       const result = generateFieldNameFromPath('/tags/foo');
 

--- a/lib/parse/color/hexToRgb.spec.ts
+++ b/lib/parse/color/hexToRgb.spec.ts
@@ -1,7 +1,7 @@
 import { hexToRgb, hexToCssRgba, addCssColorAlpha } from './index';
 
 describe('lib/parse/color', () => {
-  describe(hexToRgb, () => {
+  describe('hexToRgb', () => {
     test('should parse hex string to RGB values.', () => {
       const result = hexToRgb('#00FF00');
 

--- a/lib/parse/menu/parseMenu.spec.ts
+++ b/lib/parse/menu/parseMenu.spec.ts
@@ -1,98 +1,100 @@
 import { parseMenu } from './index';
 
-describe('parseMenu', () => {
-  const data = [
-    {
-      id: '1234',
-      name: 'Foo',
-      self: null,
-      type: null,
-      url: 'https://www.example.com/alias/path/foo',
-      attributes: {
-        title: 'Success',
-        class: ['btn-danger', 'icon-success']
-      }
-    },
-    {
-      id: '5678',
-      name: 'Bar',
-      self: null,
-      type: null,
-      url: 'https://www.example.com/alias/path/bar',
-      attributes: {
-        class: []
-      },
-      children: [
-        {
-          id: '8765',
-          self: null,
-          type: null,
-          attributes: {
-            name: 'Baz',
-            url: 'https://www.example.com/alias/path/bar',
-            attributes: []
-          }
+describe('lib/parse/menu', () => {
+  describe('parseMenu', () => {
+    const data = [
+      {
+        id: '1234',
+        name: 'Foo',
+        self: null,
+        type: null,
+        url: 'https://www.example.com/alias/path/foo',
+        attributes: {
+          title: 'Success',
+          class: ['btn-danger', 'icon-success']
         }
-      ]
-    }
-  ];
-  const result = parseMenu(data);
+      },
+      {
+        id: '5678',
+        name: 'Bar',
+        self: null,
+        type: null,
+        url: 'https://www.example.com/alias/path/bar',
+        attributes: {
+          class: []
+        },
+        children: [
+          {
+            id: '8765',
+            self: null,
+            type: null,
+            attributes: {
+              name: 'Baz',
+              url: 'https://www.example.com/alias/path/bar',
+              attributes: []
+            }
+          }
+        ]
+      }
+    ];
+    const result = parseMenu(data);
 
-  test('should return empty array.', () => {
-    expect(parseMenu(null)).toStrictEqual([]);
-  });
+    test('should return empty array.', () => {
+      expect(parseMenu(null)).toStrictEqual([]);
+    });
 
-  test('should have `key` property with `id` value.', () => {
-    expect(result[0]).toHaveProperty('key');
-    expect(result[0].key).toEqual(data[0].id);
-  });
+    test('should have `key` property with `id` value.', () => {
+      expect(result[0]).toHaveProperty('key');
+      expect(result[0].key).toEqual(data[0].id);
+    });
 
-  test('should have `name` property.', () => {
-    expect(result[0]).toHaveProperty('name');
-    expect(result[0].name).toEqual(data[0].name);
-    expect(result[1]).toHaveProperty('name');
-    expect(result[1].name).toEqual(data[1].name);
-  });
+    test('should have `name` property.', () => {
+      expect(result[0]).toHaveProperty('name');
+      expect(result[0].name).toEqual(data[0].name);
+      expect(result[1]).toHaveProperty('name');
+      expect(result[1].name).toEqual(data[1].name);
+    });
 
-  test('should have `title` value.', () => {
-    expect(result[0]).toHaveProperty('title');
-    expect(result[0].title).toEqual(data[0].attributes.title);
-  });
+    test('should have `title` value.', () => {
+      expect(result[0]).toHaveProperty('title');
+      expect(result[0].title).toEqual(data[0].attributes.title);
+    });
 
-  test('should have a `color` value.', () => {
-    expect(result[0]).toHaveProperty('color');
-    expect(result[0].color).toEqual('secondary');
-  });
+    test('should have a `color` value.', () => {
+      expect(result[0]).toHaveProperty('color');
+      expect(result[0].color).toEqual('secondary');
+    });
 
-  test('should have a `icon` value.', () => {
-    expect(result[0]).toHaveProperty('icon');
-    expect(result[0].icon).toEqual('success');
-  });
+    test('should have a `icon` value.', () => {
+      expect(result[0]).toHaveProperty('icon');
+      expect(result[0].icon).toEqual('success');
+    });
 
-  test('should not have a `title` value.', () => {
-    expect(result[1].title).toBeUndefined();
-  });
+    test('should not have a `title` value.', () => {
+      expect(result[1].title).toBeUndefined();
+    });
 
-  test('should not have a `color` value.', () => {
-    expect(result[1].color).toBeNull();
-  });
+    test('should not have a `color` value.', () => {
+      expect(result[1].color).toBeNull();
+    });
 
-  test('should not have a `icon` value.', () => {
-    expect(result[1].icon).toBeNull();
-  });
+    test('should not have a `icon` value.', () => {
+      expect(result[1].icon).toBeNull();
+    });
 
-  test('should have `children`.', () => {
-    expect(result[1]).toHaveProperty('children');
-    expect(result[1].children).not.toHaveLength(0);
-    expect(result[1].children[0]).toHaveProperty('key');
-    expect(result[1].children[0].key).toEqual(data[1].children[0].id);
-    expect(result[1].children[0]).toHaveProperty('name');
-    expect(result[1].children[0].name).toEqual(
-      data[1].children[0].attributes.name
-    );
-    expect(result[1].children[0]).toHaveProperty('url');
-    expect(result[1].children[0].url.href).toEqual(
-      data[1].children[0].attributes.url
-    );
+    test('should have `children`.', () => {
+      expect(result[1]).toHaveProperty('children');
+      expect(result[1].children).not.toHaveLength(0);
+      expect(result[1].children[0]).toHaveProperty('key');
+      expect(result[1].children[0].key).toEqual(data[1].children[0].id);
+      expect(result[1].children[0]).toHaveProperty('name');
+      expect(result[1].children[0].name).toEqual(
+        data[1].children[0].attributes.name
+      );
+      expect(result[1].children[0]).toHaveProperty('url');
+      expect(result[1].children[0].url.href).toEqual(
+        data[1].children[0].attributes.url
+      );
+    });
   });
 });

--- a/lib/routing/handleButtonClick.spec.ts
+++ b/lib/routing/handleButtonClick.spec.ts
@@ -1,21 +1,23 @@
 import { parse } from 'url';
 import { generateLinkHrefFromUrl } from './index';
 
-describe('generateLinkHrefFromUrl', () => {
-  test('should return with query object containing URL path in alias property.', () => {
-    const url = parse('https://www.example.com/alias/path/foo');
-    const result = generateLinkHrefFromUrl(url);
+describe('lib/routing', () => {
+  describe('generateLinkHrefFromUrl', () => {
+    test('should return with query object containing URL path in alias property.', () => {
+      const url = parse('https://www.example.com/alias/path/foo');
+      const result = generateLinkHrefFromUrl(url);
 
-    expect(result).toHaveProperty('query');
-    expect(result.query).toHaveProperty('alias');
-    expect(result.query.alias).toEqual(['alias', 'path', 'foo']);
-  });
+      expect(result).toHaveProperty('query');
+      expect(result.query).toHaveProperty('alias');
+      expect(result.query.alias).toEqual(['alias', 'path', 'foo']);
+    });
 
-  test('should return with query property as `null`', () => {
-    const url = parse('https://www.example.com/');
-    const result = generateLinkHrefFromUrl(url);
+    test('should return with query property as `null`', () => {
+      const url = parse('https://www.example.com/');
+      const result = generateLinkHrefFromUrl(url);
 
-    expect(result).toHaveProperty('query');
-    expect(result.query).toBeNull();
+      expect(result).toHaveProperty('query');
+      expect(result.query).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
- update audio header to not render a date when it is missing in the data
- add tests for sanitizing metatag values
- update all test describes for consistency

## To Review

- [ ] Use the Preview link: https://fix-error-missing-metatag-values.d2mc541hyaqum0.amplifyapp.com/media/2021-11-26/20211126seg1mp3

> ...then...

- [ ] Ensure page loads and renders as expected. Should just be a player and program link as all other data is missing from this audio file.
- [ ] Ensure no date is rendered.
