### PR TITLE
HOTFIX: Render featured stories when missing bio

### DIFF
--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -177,13 +177,15 @@ export const Bio = () => {
   const mainElements = [
     {
       key: 'main top',
-      children: bio && (
+      children: (
         <>
-          <Box mt={3}>
-            <Box className={cx('body')}>
-              <HtmlContent html={bio} />
+          {bio && (
+            <Box mt={3}>
+              <Box className={cx('body')}>
+                <HtmlContent html={bio} />
+              </Box>
             </Box>
-          </Box>
+          )}
           <Box mt={bio ? 6 : 3}>
             {featuredStory && (
               <StoryCard data={featuredStory} feature priority />

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -485,7 +485,8 @@ export const fetchApiPersonAudio = async (
   req?: IncomingMessage
 ): Promise<IPriApiCollectionResponse> =>
   fetchApi('file/audio', req, {
-    'filter[audioAuthor]': id,
+    'filter[audioAuthor][value]': id,
+    'filter[audioAuthor][operator]': '"CONTAINS"',
     sort: '-broadcast_date',
     ...(audioType && { 'filter[type]': audioType }),
     ...(page && { page: `${page}` }),

--- a/lib/fetch/person/fetchPersonAudio.ts
+++ b/lib/fetch/person/fetchPersonAudio.ts
@@ -19,7 +19,8 @@ export const fetchPersonAudio = async (
 ): Promise<PriApiResourceResponse> =>
   fetchPriApiQuery('file--audio', {
     ...basicAudioParams,
-    'filter[audioAuthor]': id,
+    'filter[audioAuthor][value]': id,
+    'filter[audioAuthor][operator]': '"CONTAINS"',
     sort: '-broadcast_date',
     ...(audioType && { 'filter[type]': audioType }),
     ...(page && { page: `${page}` }),

--- a/store/actions/appendResourceCollection.ts
+++ b/store/actions/appendResourceCollection.ts
@@ -15,19 +15,21 @@ export const appendResourceCollection = (
 ): ThunkAction<void, {}, {}, AnyAction> => (
   dispatch: ThunkDispatch<{}, {}, AnyAction>
 ): void => {
-  const payloadItems = resp.data.filter(v => !!v);
+  const payloadItems = resp.data?.filter(v => !!v);
 
-  dispatch({
-    type: 'FETCH_BULK_CONTENT_DATA_SUCCESS',
-    payload: payloadItems
-  });
+  if (payloadItems) {
+    dispatch({
+      type: 'FETCH_BULK_CONTENT_DATA_SUCCESS',
+      payload: payloadItems
+    });
 
-  dispatch({
-    type: 'APPEND_REFS_TO_COLLECTION',
-    payload: {
-      resource: { type, id },
-      collection,
-      ...resp
-    }
-  });
+    dispatch({
+      type: 'APPEND_REFS_TO_COLLECTION',
+      payload: {
+        resource: { type, id },
+        collection,
+        ...resp
+      }
+    });
+  }
 };


### PR DESCRIPTION
- Fixes a render bug that would not render featured stories cards if the Person was missing bio body content
- Fixes bio segment audio fetch to include segments with multiple authors that include the person
- Updates bio stories fetching to be in line with other landing pages query logic

## To Review

- [x] Use the Preview link: https://fix-bio-stories-fetch-pagination.d2mc541hyaqum0.amplifyapp.com/people/rebecca-kanthor

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to `people/rebecca-kanthor` bio page.
- [x] Ensure featured stories cards are rendered.
- [x] Ensure more stories get loaded and appended to stories list.
- [x] Note: There are quite a few stories by Rebecca that need resaved to get the byline data valid in the API.
