### PR TITLE
#174: Add social share menu

### DIFF
--- a/components/SocialShareMenu/SocialShareMenu.styles.ts
+++ b/components/SocialShareMenu/SocialShareMenu.styles.ts
@@ -1,0 +1,19 @@
+/**
+ * @file SocialShareMenu.style.ts
+ * Styles for SocialShareMenu.
+ */
+
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+export const socialShareMenuStyles = makeStyles(
+  (theme: Theme) =>
+    createStyles({
+      root: {
+        position: 'fixed',
+        bottom: theme.typography.pxToRem(theme.spacing(2)),
+        right: theme.typography.pxToRem(theme.spacing(2)),
+        zIndex: theme.zIndex.speedDial
+      }
+    }),
+  { name: 'TwSocialShareMenu' }
+);

--- a/components/SocialShareMenu/SocialShareMenu.styles.ts
+++ b/components/SocialShareMenu/SocialShareMenu.styles.ts
@@ -3,6 +3,7 @@
  * Styles for SocialShareMenu.
  */
 
+import { addCssColorAlpha } from '@lib/parse/color';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 export const socialShareMenuStyles = makeStyles(
@@ -13,6 +14,18 @@ export const socialShareMenuStyles = makeStyles(
         bottom: theme.typography.pxToRem(theme.spacing(2)),
         right: theme.typography.pxToRem(theme.spacing(2)),
         zIndex: theme.zIndex.speedDial
+      },
+      staticTooltipLabel: {
+        backgroundColor: 'transparent',
+        color: theme.palette.common.white,
+        fontWeight: theme.typography.fontWeightBold,
+        paddingRight: 0
+      },
+      backdropRoot: {
+        backgroundImage: `linear-gradient(-45deg, ${addCssColorAlpha(
+          theme.palette.grey[900],
+          0.75
+        )}, ${addCssColorAlpha(theme.palette.grey[900], 0.25)})`
       }
     }),
   { name: 'TwSocialShareMenu' }

--- a/components/SocialShareMenu/SocialShareMenu.tsx
+++ b/components/SocialShareMenu/SocialShareMenu.tsx
@@ -14,6 +14,7 @@ import {
   faFlipboard,
   faWhatsapp
 } from '@fortawesome/free-brands-svg-icons';
+import Backdrop from '@material-ui/core/Backdrop';
 import Box from '@material-ui/core/Box';
 import NoSsr from '@material-ui/core/NoSsr';
 import CloseRounded from '@material-ui/icons/CloseRounded';
@@ -105,6 +106,9 @@ export const SocialShareMenu = () => {
             {links.map(({ key, link: { title, url } }, index) => (
               <SpeedDialAction
                 key={key}
+                classes={{
+                  staticTooltipLabel: cx('staticTooltipLabel')
+                }}
                 icon={<SvgIcon color="primary">{iconsMap.get(key)}</SvgIcon>}
                 tooltipTitle={title}
                 delay={index * 50}
@@ -113,6 +117,14 @@ export const SocialShareMenu = () => {
               />
             ))}
           </SpeedDial>
+          {isTouch && (
+            <Backdrop
+              classes={{
+                root: cx('backdropRoot')
+              }}
+              open={open}
+            />
+          )}
         </Box>
       </NoSsr>
     )

--- a/components/SocialShareMenu/SocialShareMenu.tsx
+++ b/components/SocialShareMenu/SocialShareMenu.tsx
@@ -1,0 +1,120 @@
+/**
+ * @file SocialShareMenu.tsx
+ * Component for social share menu.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useStore } from 'react-redux';
+import classNames from 'classnames/bind';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faFacebook,
+  faTwitter,
+  faLinkedin,
+  faFlipboard,
+  faWhatsapp
+} from '@fortawesome/free-brands-svg-icons';
+import Box from '@material-ui/core/Box';
+import NoSsr from '@material-ui/core/NoSsr';
+import CloseRounded from '@material-ui/icons/CloseRounded';
+import EmailRounded from '@material-ui/icons/EmailRounded';
+import ShareRoundedIcon from '@material-ui/icons/ShareRounded';
+import SvgIcon from '@material-ui/core/SvgIcon';
+import { IIconsMap } from '@interfaces/icons';
+import { SpeedDial, SpeedDialAction, SpeedDialIcon } from '@material-ui/lab';
+import { getUiSocialShareMenu } from '@store/reducers';
+import { socialShareMenuStyles } from './SocialShareMenu.styles';
+
+const defaultIconsMap = new Map();
+[
+  ['facebook', <FontAwesomeIcon size="sm" icon={faFacebook} />],
+  ['twitter', <FontAwesomeIcon size="sm" icon={faTwitter} />],
+  ['linkedin', <FontAwesomeIcon size="sm" icon={faLinkedin} />],
+  ['flipboard', <FontAwesomeIcon size="sm" icon={faFlipboard} />],
+  ['whatsapp', <FontAwesomeIcon size="sm" icon={faWhatsapp} />],
+  ['email', <EmailRounded />]
+].forEach(([key, icon]) => {
+  defaultIconsMap.set(key, icon);
+});
+
+const getIconsMap = (icons?: IIconsMap) => {
+  const iconsMap = new Map();
+
+  defaultIconsMap.forEach((value, key) => iconsMap.set(key, value));
+
+  if (icons) {
+    Object.entries(icons).forEach(([key, icon]) => iconsMap.set(key, icon));
+  }
+
+  return iconsMap;
+};
+
+export const SocialShareMenu = () => {
+  const store = useStore();
+  const [state, updateForce] = useState(store.getState());
+  const unsub = store.subscribe(() => {
+    updateForce(store.getState());
+  });
+  const { shown, links, icons } = getUiSocialShareMenu(state) || {};
+  const [open, setOpen] = useState(false);
+  const [isTouch, setIsTouch] = useState(false);
+  const classes = socialShareMenuStyles({});
+  const cx = classNames.bind(classes);
+  const iconsMap = getIconsMap(icons);
+
+  const handleTouchStart = () => {
+    setIsTouch(true);
+  };
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleActionClick = (url: string) => () => {
+    window.open(url, '_ blank');
+  };
+
+  useEffect(() => {
+    return () => {
+      unsub();
+    };
+  }, []);
+
+  return (
+    !!links && (
+      <NoSsr>
+        <Box className={cx('root')}>
+          <SpeedDial
+            ariaLabel="Show Share Links"
+            hidden={!shown}
+            icon={
+              <SpeedDialIcon
+                icon={<ShareRoundedIcon />}
+                openIcon={<CloseRounded />}
+              />
+            }
+            onClose={handleClose}
+            onOpen={handleOpen}
+            onTouchStart={handleTouchStart}
+            open={open}
+          >
+            {links.map(({ key, link: { title, url } }, index) => (
+              <SpeedDialAction
+                key={key}
+                icon={<SvgIcon color="primary">{iconsMap.get(key)}</SvgIcon>}
+                tooltipTitle={title}
+                delay={index * 50}
+                onClick={handleActionClick(url)}
+                tooltipOpen={isTouch}
+              />
+            ))}
+          </SpeedDial>
+        </Box>
+      </NoSsr>
+    )
+  );
+};

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -37,7 +37,7 @@ import { SpotifyPlayer } from '@components/SpotifyPlayer';
 import { StoryCard } from '@components/StoryCard';
 import { CtaRegion } from '@components/CtaRegion';
 import { AppContext } from '@contexts/AppContext';
-import { RootState } from '@interfaces/state';
+import { RootState, UiAction } from '@interfaces/state';
 import { appendResourceCollection } from '@store/actions/appendResourceCollection';
 import { fetchCtaData } from '@store/actions/fetchCtaData';
 import { fetchEpisodeData } from '@store/actions/fetchEpisodeData';
@@ -163,6 +163,44 @@ export const Episode = () => {
       })();
     }
 
+    // Show social hare menu.
+    const { shareLinks } = data;
+    store.dispatch<UiAction>({
+      type: 'UI_SHOW_SOCIAL_SHARE_MENU',
+      payload: {
+        ui: {
+          socialShareMenu: {
+            links: [
+              {
+                key: 'facebook',
+                link: shareLinks.facebook
+              },
+              {
+                key: 'twitter',
+                link: shareLinks.twitter
+              },
+              {
+                key: 'linkedin',
+                link: shareLinks.linkedin
+              },
+              {
+                key: 'flipboard',
+                link: shareLinks.flipboard
+              },
+              {
+                key: 'whatsapp',
+                link: shareLinks.whatsapp
+              },
+              {
+                key: 'email',
+                link: shareLinks.email
+              }
+            ]
+          }
+        }
+      }
+    });
+
     // Get CTA message data.
     const context = [`node:${data.id}`, `node:${data.program.id}`];
     (async () => {
@@ -172,6 +210,10 @@ export const Episode = () => {
     })();
 
     return () => {
+      // Hide social hare menu.
+      store.dispatch<UiAction>({
+        type: 'UI_HIDE_SOCIAL_SHARE_MENU'
+      });
       unsub();
     };
   }, [id]);

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -172,12 +172,12 @@ export const Episode = () => {
           socialShareMenu: {
             links: [
               {
-                key: 'facebook',
-                link: shareLinks.facebook
-              },
-              {
                 key: 'twitter',
                 link: shareLinks.twitter
+              },
+              {
+                key: 'facebook',
+                link: shareLinks.facebook
               },
               {
                 key: 'linkedin',

--- a/components/pages/Story/Story.tsx
+++ b/components/pages/Story/Story.tsx
@@ -10,10 +10,9 @@ import pad from 'lodash/pad';
 import { AppContext } from '@contexts/AppContext';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
-import { RootState } from '@interfaces/state';
+import { RootState, UiAction } from '@interfaces/state';
 import { fetchApiCategoryStories } from '@lib/fetch';
 import { appendResourceCollection } from '@store/actions/appendResourceCollection';
-// import { fetchCtaData } from '@store/actions/fetchCtaData';
 import { fetchStoryData } from '@store/actions/fetchStoryData';
 import { getDataByResource, getCollectionData } from '@store/reducers';
 import { layoutComponentMap } from './layouts';
@@ -97,6 +96,44 @@ export const Story = () => {
       })();
     }
 
+    // Show social hare menu.
+    const { shareLinks } = data;
+    store.dispatch<UiAction>({
+      type: 'UI_SHOW_SOCIAL_SHARE_MENU',
+      payload: {
+        ui: {
+          socialShareMenu: {
+            links: [
+              {
+                key: 'facebook',
+                link: shareLinks.facebook
+              },
+              {
+                key: 'twitter',
+                link: shareLinks.twitter
+              },
+              {
+                key: 'linkedin',
+                link: shareLinks.linkedin
+              },
+              {
+                key: 'flipboard',
+                link: shareLinks.flipboard
+              },
+              {
+                key: 'whatsapp',
+                link: shareLinks.whatsapp
+              },
+              {
+                key: 'email',
+                link: shareLinks.email
+              }
+            ]
+          }
+        }
+      }
+    });
+
     // Get missing related stories data.
     const collection = 'related';
     const { primaryCategory } = data;
@@ -131,27 +168,11 @@ export const Story = () => {
       })();
     }
 
-    // // Get CTA message data.
-    // const context = [
-    //   `node:${data.id}`,
-    //   `node:${data.program?.id}`,
-    //   `term:${data.primaryCategory?.id}`,
-    //   ...((data.categories &&
-    //     !!data.categories.length &&
-    //     data.categories.filter(v => !!v).map(({ id: tid }) => `term:${tid}`)) ||
-    //     []),
-    //   ...((data.vertical &&
-    //     !!data.vertical.length &&
-    //     data.vertical.filter(v => !!v).map(({ tid }) => `term:${tid}`)) ||
-    //     [])
-    // ];
-    // (async () => {
-    //   await store.dispatch<any>(
-    //     fetchCtaData(type, id, 'tw_cta_regions_content', context)
-    //   );
-    // })();
-
     return () => {
+      // Show social hare menu.
+      store.dispatch<UiAction>({
+        type: 'UI_HIDE_SOCIAL_SHARE_MENU'
+      });
       unsub();
     };
   }, [id]);

--- a/components/pages/Story/Story.tsx
+++ b/components/pages/Story/Story.tsx
@@ -105,12 +105,12 @@ export const Story = () => {
           socialShareMenu: {
             links: [
               {
-                key: 'facebook',
-                link: shareLinks.facebook
-              },
-              {
                 key: 'twitter',
                 link: shareLinks.twitter
+              },
+              {
+                key: 'facebook',
+                link: shareLinks.facebook
               },
               {
                 key: 'linkedin',

--- a/interfaces/icons/icons.interface.ts
+++ b/interfaces/icons/icons.interface.ts
@@ -1,0 +1,10 @@
+/**
+ * @file interfaces/icon/icon.interface.tsx
+ * Interfaces for icons.
+ */
+
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+export interface IIconsMap {
+  [k: string]: typeof SvgIcon;
+}

--- a/interfaces/icons/index.ts
+++ b/interfaces/icons/index.ts
@@ -1,0 +1,1 @@
+export * from './icons.interface';

--- a/interfaces/social/index.ts
+++ b/interfaces/social/index.ts
@@ -1,0 +1,1 @@
+export * from './social.interface';

--- a/interfaces/social/social.interface.ts
+++ b/interfaces/social/social.interface.ts
@@ -1,0 +1,12 @@
+/**
+ * @file interfaces/icon/icon.interface.tsx
+ * Interfaces for icons.
+ */
+
+export interface ISocialLink {
+  key: string;
+  link: {
+    title: string;
+    url: string;
+  };
+}

--- a/interfaces/state/ui.interface.ts
+++ b/interfaces/state/ui.interface.ts
@@ -5,17 +5,26 @@
  */
 
 import { AnyAction } from 'redux';
+import { IIconsMap } from '@interfaces/icons';
+import { ISocialLink } from '@interfaces/social';
 
 export interface DrawerState {
   open: boolean;
 }
 
+export interface SocialShareMenuState {
+  shown?: boolean;
+  links?: ISocialLink[];
+  icons?: IIconsMap;
+}
+
 export interface UiState {
   drawer?: DrawerState;
+  socialShareMenu?: SocialShareMenuState;
 }
 
 export interface UiAction extends AnyAction {
-  payload: {
+  payload?: {
     ui?: UiState;
   };
 }

--- a/lib/fetch/api/params/episode.ts
+++ b/lib/fetch/api/params/episode.ts
@@ -84,6 +84,7 @@ export const fullEpisodeParams = {
     'stories.image',
     'stories.primary_category.title',
     'stories.primary_category.metatags',
-    'spotify_playlist'
+    'spotify_playlist',
+    'share_links'
   ]
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "test": "NODE_ENV=test jest --verbose"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
+    "@fortawesome/free-brands-svg-icons": "^5.15.4",
+    "@fortawesome/free-regular-svg-icons": "^5.15.4",
+    "@fortawesome/react-fontawesome": "^0.1.16",
     "@material-ui/core": "^4.7.2",
     "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.35",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,6 +16,7 @@ import { AppHeader } from '@components/AppHeader';
 import { AppLoadingBar } from '@components/AppLoadingBar';
 import { AppSearch } from '@components/AppSearch';
 import { AppContext } from '@contexts/AppContext';
+import { SocialShareMenu } from '@components/SocialShareMenu/SocialShareMenu';
 import { baseMuiTheme, appTheme } from '@theme/App.theme';
 import { wrapper } from '@store';
 import { fetchCtaData } from '@store/actions/fetchCtaData';
@@ -87,6 +88,7 @@ const TwApp: FC<AppProps> = ({ Component, pageProps }: AppProps) => {
             <AppFooter />
             <AppSearch />
             <AppCtaLoadUnder />
+            <SocialShareMenu />
           </Box>
         </AppContext.Provider>
         <CssBaseline />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheets } from '@material-ui/core/styles';
+import { blue } from '@theme/colors';
 
 class TwDocument extends Document {
   render() {
@@ -30,6 +31,7 @@ class TwDocument extends Document {
             href="/opensearch.xml"
           />
           <link rel="icon" href="/images/favicon.png" />
+          <style>{`html { background: ${blue[600]}; }`}</style>
         </Head>
         <body>
           <Main />

--- a/store/reducers/index.ts
+++ b/store/reducers/index.ts
@@ -23,6 +23,9 @@ export const initialState: RootState = {
   ui: {
     drawer: {
       open: true
+    },
+    socialShareMenu: {
+      shown: false
     }
   }
 };
@@ -123,5 +126,8 @@ export const getSearchQuery = (state: RootState) =>
   fromSearch.getSearchQuery(state.search);
 export const getSearchData = (state: RootState, query: string) =>
   fromSearch.getSearchData(state.search, query);
+
 export const getUiDrawerOpen = (state: RootState) =>
   fromUi.getUiDrawerOpen(state.ui);
+export const getUiSocialShareMenu = (state: RootState) =>
+  fromUi.getUiSocialShareMenu(state.ui);

--- a/store/reducers/ui.ts
+++ b/store/reducers/ui.ts
@@ -30,9 +30,28 @@ export const ui = (state = {}, action: UiAction): State => {
         }
       } as UiState;
 
+    case 'UI_SHOW_SOCIAL_SHARE_MENU':
+      return {
+        ...state,
+        socialShareMenu: {
+          shown: true,
+          links: action.payload.ui.socialShareMenu.links,
+          icons: action.payload.ui.socialShareMenu.icons
+        }
+      } as UiState;
+
+    case 'UI_HIDE_SOCIAL_SHARE_MENU':
+      return {
+        ...state,
+        socialShareMenu: {
+          shown: false
+        }
+      } as UiState;
+
     default:
       return state;
   }
 };
 
 export const getUiDrawerOpen = (state: UiState) => state?.drawer?.open;
+export const getUiSocialShareMenu = (state: UiState) => state?.socialShareMenu;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,6 +1301,39 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fortawesome/fontawesome-common-types@^0.2.36":
+  version "0.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
+  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+
+"@fortawesome/fontawesome-svg-core@^1.2.36":
+  version "1.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz#4f2ea6f778298e0c47c6524ce2e7fd58eb6930e3"
+  integrity sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/free-brands-svg-icons@^5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.4.tgz#ec8a44dd383bcdd58aa7d1c96f38251e6fec9733"
+  integrity sha512-f1witbwycL9cTENJegcmcZRYyawAFbm8+c6IirLmwbbpqz46wyjbQYLuxOc7weXFXfB7QR8/Vd2u5R3q6JYD9g==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/free-regular-svg-icons@^5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.4.tgz#b97edab436954333bbeac09cfc40c6a951081a02"
+  integrity sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/react-fontawesome@^0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.16.tgz#ce7665490214e20f929368d6b65f68884a99276a"
+  integrity sha512-aLmzDwC9rEOAJv2UJdMns89VZR5Ry4IHu5dQQh24Z/lWKEm44lfQr1UNalZlkUaQN8d155tNh+CS7ntntj1VMA==
+  dependencies:
+    prop-types "^15.7.2"
+
 "@hapi/accept@5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.2.tgz#ab7043b037e68b722f93f376afb05e85c0699523"


### PR DESCRIPTION
Closes #174 

- add social share menu to app ui
- update story and episode pages to show and populate social share menu links
- add bg color to html for better load flash and pulldown of page top


## To Review

- [ ] Use the Preview link: https://feat-174-social-share-toolbar.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Note that social share FAB is not shown on homepage.
- [x] Visit a story.
- [x] Ensure social share menu is shown.
- [x] Try each share link and ensure they work as expected.
- [x] Switch the dev tools to responsive/mobile view mode.
- [x] Refresh page then try out the UX of the social share menu on mobile.
- [x] Navigate to a program, bio, or category page.
- [x] Ensure the social share tools get hidden.
- [x] Visit an episode and test social share menu as you did with a story.
