### PR TITLE
#289: Add image page

### DIFF
--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -53,7 +53,7 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
   };
 
   return (
-    html && (
+    !!html && (
       <>
         {ReactHtmlParser(cleanHtml(html), {
           transform: transform as Transform

--- a/components/pages/Image/Image.styles.ts
+++ b/components/pages/Image/Image.styles.ts
@@ -1,0 +1,38 @@
+/**
+ * @file Image.styles.tsx
+ * Theme and styles for Image layout.
+ */
+
+import {
+  createMuiTheme,
+  createStyles,
+  makeStyles,
+  Theme
+} from '@material-ui/core/styles';
+import { storyBodyStyles } from '@components/pages/Story/layouts/default/styles/Story.body';
+
+export const imageTheme = (theme: Theme) =>
+  createMuiTheme(theme, {
+    typography: {
+      h1: {
+        fontSize: theme.typography.pxToRem(46)
+      },
+      h4: {
+        fontSize: theme.typography.pxToRem(20),
+        marginBottom: theme.typography.pxToRem(theme.spacing(2))
+      }
+    },
+    overrides: {
+      MuiDivider: {
+        root: {
+          marginBottom: theme.typography.pxToRem(theme.spacing(3))
+        }
+      }
+    }
+  });
+
+export const imageStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    ...storyBodyStyles(theme)
+  })
+);

--- a/components/pages/Image/Image.tsx
+++ b/components/pages/Image/Image.tsx
@@ -1,0 +1,117 @@
+/**
+ * @file Image.tsx
+ * Component for Image.
+ */
+
+import React, { useContext, useEffect, useState } from 'react';
+import { AnyAction } from 'redux';
+import { useStore } from 'react-redux';
+import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import { Box, Container, Grid } from '@material-ui/core';
+import { ThemeProvider } from '@material-ui/core/styles';
+import { CtaRegion } from '@components/CtaRegion';
+import { AppContext } from '@contexts/AppContext';
+import { HtmlContent } from '@components/HtmlContent';
+import { LedeImage } from '@components/LedeImage';
+import { MetaTags } from '@components/MetaTags';
+import { Plausible, PlausibleEventArgs } from '@components/Plausible';
+import { RootState } from '@interfaces/state';
+import { fetchCtaData } from '@store/actions/fetchCtaData';
+import { fetchAudioData } from '@store/actions/fetchAudioData';
+import { getDataByResource, getCtaRegionData } from '@store/reducers';
+import { imageStyles, imageTheme } from './Image.styles';
+import { ImageHeader } from './components/AudioHeader';
+
+export const Image = () => {
+  const {
+    page: {
+      resource: { type, id }
+    }
+  } = useContext(AppContext);
+  const store = useStore();
+  const [state, setState] = useState(store.getState());
+  const unsub = store.subscribe(() => {
+    setState(store.getState());
+  });
+  const classes = imageStyles({});
+  let data = getDataByResource(state, type, id);
+
+  if (!data) {
+    return null;
+  }
+
+  const { metatags, title, description } = data;
+
+  const ctaInlineEnd = getCtaRegionData(
+    state,
+    type,
+    id as string,
+    'tw_cta_region_content_inline_end'
+  );
+
+  // Plausible Events.
+  const props = {
+    Title: title
+  };
+  const plausibleEvents: PlausibleEventArgs[] = [['Image', { props }]];
+
+  useEffect(() => {
+    if (!data.complete) {
+      (async () => {
+        // Get content data.
+        await store.dispatch<any>(fetchAudioData(id));
+        data = getDataByResource(state, type, id);
+      })();
+    }
+
+    // Get CTA message data.
+    const context = [`file:${data.id}`];
+    (async () => {
+      await store.dispatch<any>(
+        fetchCtaData(type, id, 'tw_cta_regions_content', context)
+      );
+    })();
+
+    return () => {
+      unsub();
+    };
+  }, [id]);
+
+  return (
+    <ThemeProvider theme={imageTheme}>
+      <MetaTags
+        data={{
+          ...metatags,
+          description: metatags.description || description
+        }}
+      />
+      <Plausible events={plausibleEvents} subject={{ type, id }} />
+      <Container fixed>
+        <Grid container>
+          <Grid item xs={12}>
+            <ImageHeader data={data} />
+            <LedeImage data={data} />
+            <Box className={classes.body} my={2}>
+              <HtmlContent html={description} />
+            </Box>
+            {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />}
+          </Grid>
+        </Grid>
+      </Container>
+    </ThemeProvider>
+  );
+};
+
+export const fetchData = (
+  id: string
+): ThunkAction<void, {}, {}, AnyAction> => async (
+  dispatch: ThunkDispatch<{}, {}, AnyAction>,
+  getState: () => RootState
+): Promise<void> => {
+  const type = 'file--images';
+  const data = getDataByResource(getState(), type, id);
+
+  if (!data) {
+    await dispatch<any>(fetchAudioData(id));
+  }
+};

--- a/components/pages/Image/components/AudioHeader/ImageHeader.styles.ts
+++ b/components/pages/Image/components/AudioHeader/ImageHeader.styles.ts
@@ -1,0 +1,44 @@
+/**
+ * @file ImageHeader.style.tsx
+ * Styles for Image layout.
+ */
+
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+export const imageHeaderStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      fontSize: '1.2rem'
+    },
+    byline: {
+      padding: 0,
+      margin: 0,
+      listStyle: 'none'
+    },
+    bylineItem: {},
+    bylineLink: {
+      fontWeight: theme.typography.fontWeightBold
+    },
+    date: {
+      fontStyle: 'italic'
+    },
+    meta: {
+      display: 'grid',
+      gridTemplateColumns: 'max-content',
+      gridTemplateAreas: "'INFO'",
+      justifyContent: 'space-between'
+    },
+    info: {
+      display: 'grid',
+      alignContent: 'start',
+      gridArea: 'INFO',
+      gridGap: theme.typography.pxToRem(4)
+    },
+    programLink: {
+      fontWeight: theme.typography.fontWeightBold
+    },
+    categoryLink: {
+      fontWeight: theme.typography.fontWeightBold
+    }
+  })
+);

--- a/components/pages/Image/components/AudioHeader/ImageHeader.tsx
+++ b/components/pages/Image/components/AudioHeader/ImageHeader.tsx
@@ -1,0 +1,26 @@
+/**
+ * @file ImageHeader.ts
+ * Component for default image header.
+ */
+
+import React from 'react';
+import { IPriApiResource } from 'pri-api-library/types';
+import { Box, Typography } from '@material-ui/core';
+import { imageHeaderStyles } from './ImageHeader.styles';
+
+interface Props {
+  data: IPriApiResource;
+}
+
+export const ImageHeader = ({ data }: Props) => {
+  const { title } = data;
+  const classes = imageHeaderStyles({});
+
+  return (
+    <Box className={classes.root} mt={4} mb={2}>
+      <Box mb={3}>
+        <Typography variant="h1">{title}</Typography>
+      </Box>
+    </Box>
+  );
+};

--- a/components/pages/Image/components/AudioHeader/index.ts
+++ b/components/pages/Image/components/AudioHeader/index.ts
@@ -1,0 +1,1 @@
+export * from './ImageHeader';

--- a/components/pages/Image/components/index.ts
+++ b/components/pages/Image/components/index.ts
@@ -1,0 +1,1 @@
+export * from './AudioHeader';

--- a/components/pages/Image/index.ts
+++ b/components/pages/Image/index.ts
@@ -1,0 +1,2 @@
+export * from './Image';
+export { Image as default } from './Image'; // eslint-disable-line import/no-default-export

--- a/components/pages/ResourceComponentMap.ts
+++ b/components/pages/ResourceComponentMap.ts
@@ -6,6 +6,7 @@ const DynamicBio = dynamic(() => import('./Bio') as any);
 const DynamicCategory = dynamic(() => import('./Category') as any);
 const DynamicEpisode = dynamic(() => import('./Episode') as any);
 const DynamicHomepage = dynamic(() => import('./Homepage') as any);
+const DynamicImage = dynamic(() => import('./Image') as any);
 const DynamicNewsletter = dynamic(() => import('./Newsletter') as any);
 const DynamicPage = dynamic(() => import('./Page') as any);
 const DynamicProgram = dynamic(() => import('./Program') as any);
@@ -16,6 +17,7 @@ const DynamicTerm = dynamic(() => import('./Term') as any);
 // Map dyanmic component to a data/resource type.
 export const ResourceComponentMap = {
   'file--audio': DynamicAudio,
+  'file--images': DynamicImage,
   homepage: DynamicHomepage,
   'node--episodes': DynamicEpisode,
   'node--newsletter_sign_ups': DynamicNewsletter,

--- a/components/pages/ResourceFetchDataMap.ts
+++ b/components/pages/ResourceFetchDataMap.ts
@@ -1,6 +1,7 @@
 import { fetchAudioData } from '@store/actions/fetchAudioData';
 import { fetchCategoryData } from '@store/actions/fetchCategoryData';
 import { fetchEpisodeData } from '@store/actions/fetchEpisodeData';
+import { fetchImageData } from '@store/actions/fetchImageData';
 import { fetchNewsletterData } from '@store/actions/fetchNewsletterData';
 import { fetchPageData } from '@store/actions/fetchPageData';
 import { fetchPersonData } from '@store/actions/fetchPersonData';
@@ -12,6 +13,7 @@ import { fetchTermData } from '@store/actions/fetchTermData';
 export const ResourceFetchDataMap = new Map();
 
 ResourceFetchDataMap.set('file--audio', fetchAudioData);
+ResourceFetchDataMap.set('file--images', fetchImageData);
 ResourceFetchDataMap.set('node--episodes', fetchEpisodeData);
 ResourceFetchDataMap.set('node--newsletter_sign_ups', fetchNewsletterData);
 ResourceFetchDataMap.set('node--pages', fetchPageData);

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -208,6 +208,22 @@ export const fetchApiFileAudio = async (
 ): Promise<IPriApiResourceResponse> => fetchApi(`file/audio/${id}`, req);
 
 /**
+ * Method that simplifies GET queries for image file data.
+ *
+ * @param id
+ *    API id of image file.
+ * @param req
+ *    Request object from `getInitialProps` ctx object.
+ *
+ * @returns
+ *    Image file data object.
+ */
+export const fetchApiFileImage = async (
+  id: string,
+  req?: IncomingMessage
+): Promise<IPriApiResourceResponse> => fetchApi(`file/image/${id}`, req);
+
+/**
  * Method that simplifies GET queries for program data.
  *
  * @param id

--- a/lib/fetch/api/params/image.ts
+++ b/lib/fetch/api/params/image.ts
@@ -5,7 +5,7 @@
  */
 
 export const basicImageParams = {
-  fields: ['alt', 'metadata', 'styles']
+  fields: ['alt', 'metadata', 'metatags', 'styles']
 };
 
 export const fullImageParams = {
@@ -15,6 +15,7 @@ export const fullImageParams = {
     'url',
     'alt',
     'metadata',
+    'metatags',
     'credit',
     'caption',
     'styles',

--- a/lib/fetch/api/params/index.ts
+++ b/lib/fetch/api/params/index.ts
@@ -1,3 +1,4 @@
 export * from './audio';
 export * from './episode';
+export * from './image';
 export * from './story';

--- a/lib/fetch/image/fetchImage.ts
+++ b/lib/fetch/image/fetchImage.ts
@@ -1,0 +1,15 @@
+/**
+ * Fetch Image data from CMS API.
+ */
+
+import { PriApiResourceResponse } from 'pri-api-library/types';
+import { fetchPriApiItem } from '../api/fetchPriApi';
+import { fullImageParams } from '../api/params';
+
+export const fetchImage = async (
+  id: string
+): Promise<PriApiResourceResponse> => {
+  return fetchPriApiItem('file--images', id, {
+    ...fullImageParams
+  });
+};

--- a/lib/fetch/image/index.ts
+++ b/lib/fetch/image/index.ts
@@ -1,0 +1,1 @@
+export * from './fetchImage';

--- a/lib/fetch/index.ts
+++ b/lib/fetch/index.ts
@@ -4,6 +4,7 @@ export * from './audio';
 export * from './category';
 export * from './episode';
 export * from './homepage';
+export * from './image';
 export * from './newsletter';
 export * from './page';
 export * from './person';

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -25,6 +25,7 @@ import { fetchCtaData } from '@store/actions/fetchCtaData';
 
 // Define dynamic component imports.
 const DynamicAudio = dynamic(() => import('@components/pages/Audio'));
+const DynamicImage = dynamic(() => import('@components/pages/Image'));
 const DynamicBio = dynamic(() => import('@components/pages/Bio'));
 const DynamicCategory = dynamic(() => import('@components/pages/Category'));
 const DynamicEpisode = dynamic(() => import('@components/pages/Episode'));
@@ -52,6 +53,9 @@ const ContentProxy = ({ type, id }: Props) => {
   switch (type) {
     case 'file--audio':
       return <DynamicAudio />;
+
+    case 'file--images':
+      return <DynamicImage />;
 
     case 'node--episodes':
       return <DynamicEpisode />;
@@ -102,6 +106,8 @@ export const getStaticProps = wrapper.getStaticProps(
 
       default: {
         const aliasData = await store.dispatch<any>(fetchAliasData(aliasPath));
+
+        console.log(aliasData);
 
         // Update resource id and type.
         if (aliasData?.type === 'redirect--external') {

--- a/pages/api/file/image/[id].ts
+++ b/pages/api/file/image/[id].ts
@@ -1,18 +1,18 @@
 /**
- * @file file/audio/[id].ts
- * Gather audio file data from CMS API.
+ * @file file/image/[id].ts
+ * Gather image file data from CMS API.
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { IPriApiResourceResponse } from 'pri-api-library/types';
 import { fetchPriApiItem } from '@lib/fetch/api';
-import { fullAudioParams } from '@lib/fetch/api/params';
+import { fullImageParams } from '@lib/fetch/api/params';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
 
   if (id) {
-    const file = (await fetchPriApiItem('file--audio', id as string, {
-      ...fullAudioParams
+    const file = (await fetchPriApiItem('file--images', id as string, {
+      ...fullImageParams
     })) as IPriApiResourceResponse;
 
     if (file) {

--- a/pages/api/file/image/index.ts
+++ b/pages/api/file/image/index.ts
@@ -1,18 +1,18 @@
 /**
- * @file file/audio/index.ts
- * Gather audio file collection data from CMS API.
+ * @file file/image/index.ts
+ * Gather image file collection data from CMS API.
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchPriApiQuery } from '@lib/fetch/api';
 import { IPriApiCollectionResponse } from 'pri-api-library/types';
-import { basicAudioParams } from '@lib/fetch/api/params';
+import { basicImageParams } from '@lib/fetch/api/params';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const query = req.query || {};
 
-  const files = (await fetchPriApiQuery('file--audio', {
-    ...basicAudioParams,
-    sort: '-broadcast_date',
+  const files = (await fetchPriApiQuery('file--images', {
+    ...basicImageParams,
+    sort: '-id',
     ...query
   })) as IPriApiCollectionResponse;
 

--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -23,6 +23,7 @@ import { fetchCtaData } from '@store/actions/fetchCtaData';
 
 // Define dynamic component imports.
 const DynamicAudio = dynamic(() => import('@components/pages/Audio'));
+const DynamicImage = dynamic(() => import('@components/pages/Image'));
 
 interface StateProps extends RootState {}
 
@@ -41,6 +42,9 @@ const ContentProxy = ({ type, id }: Props) => {
   switch (type) {
     case 'file--audio':
       return <DynamicAudio />;
+
+    case 'file--images':
+      return <DynamicImage />;
 
     default:
       return <></>;

--- a/store/actions/fetchImageData.ts
+++ b/store/actions/fetchImageData.ts
@@ -1,0 +1,51 @@
+/**
+ * @file fetchImageData.ts
+ *
+ * Actions to fetch data for a image resource.
+ */
+
+import { AnyAction } from 'redux';
+import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import {
+  IPriApiResource,
+  IPriApiResourceResponse
+} from 'pri-api-library/types';
+import { RootState } from '@interfaces/state';
+import { fetchApiFileImage, fetchImage } from '@lib/fetch';
+import { getDataByResource } from '@store/reducers';
+
+export const fetchImageData = (
+  id: string
+): ThunkAction<void, {}, {}, AnyAction> => async (
+  dispatch: ThunkDispatch<{}, {}, AnyAction>,
+  getState: () => RootState
+): Promise<IPriApiResource> => {
+  const state = getState();
+  const type = 'file--images';
+  const isOnServer = typeof window === 'undefined';
+  let data = getDataByResource(state, type, id);
+
+  if (!data || !data.complete || isOnServer) {
+    dispatch({
+      type: 'FETCH_CONTENT_DATA_REQUEST',
+      payload: {
+        type,
+        id
+      }
+    });
+
+    data = await (isOnServer ? fetchImage : fetchApiFileImage)(id).then(
+      (resp: IPriApiResourceResponse) => resp && resp.data
+    );
+
+    dispatch({
+      type: 'FETCH_CONTENT_DATA_SUCCESS',
+      payload: {
+        ...data,
+        complete: true
+      }
+    });
+  }
+
+  return data;
+};


### PR DESCRIPTION
Closes #289

- add image page
- add image file api endpoint
- add fetch functions and actions for image data

## To Review

- [x] Use the Preview link: https://feat-289-image-page.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to an image alias URL: `/media/2022-01-11/people-line-enter-covid-19-vaccination-clinic-torch-1976-montreal-summer-olympics'
- [x] Ensure the page loads and shows the image.
- [x] Ensure page metatags are populated as expected.
- [x] Use the network inspector to check Plausible pings and ensure send props are set appropriately.
