### PR TITLE
#302: Fix person story and audio queries

### DIFF
--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -501,8 +501,7 @@ export const fetchApiPersonAudio = async (
   req?: IncomingMessage
 ): Promise<IPriApiCollectionResponse> =>
   fetchApi('file/audio', req, {
-    'filter[audioAuthor][value]': id,
-    'filter[audioAuthor][operator]': '"CONTAINS"',
+    'filter[audioAuthor]': id,
     sort: '-broadcast_date',
     ...(audioType && { 'filter[type]': audioType }),
     ...(page && { page: `${page}` }),

--- a/lib/fetch/person/fetchPersonAudio.ts
+++ b/lib/fetch/person/fetchPersonAudio.ts
@@ -19,8 +19,7 @@ export const fetchPersonAudio = async (
 ): Promise<PriApiResourceResponse> =>
   fetchPriApiQuery('file--audio', {
     ...basicAudioParams,
-    'filter[audioAuthor][value]': id,
-    'filter[audioAuthor][operator]': '"CONTAINS"',
+    'filter[audioAuthor]': id,
     sort: '-broadcast_date',
     ...(audioType && { 'filter[type]': audioType }),
     ...(page && { page: `${page}` }),

--- a/lib/fetch/person/fetchPersonStories.ts
+++ b/lib/fetch/person/fetchPersonStories.ts
@@ -46,8 +46,7 @@ export const fetchPersonStories = async (
     return fetchPriApiQuery('node--stories', {
       ...basicStoryParams,
       'filter[status]': 1,
-      'filter[byline][value]': person.id,
-      'filter[byline][operator]': '"CONTAINS"',
+      'filter[byline]': person.id,
       ...(excluded && {
         ...excluded,
         'filter[id][operator]': 'NOT IN'

--- a/pages/api/person/[id]/stories/[page].ts
+++ b/pages/api/person/[id]/stories/[page].ts
@@ -34,8 +34,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       const stories = (await fetchPriApiQuery('node--stories', {
         ...basicStoryParams,
         'filter[status]': 1,
-        'filter[byline][value]': id,
-        'filter[byline][operator]': '"CONTAINS"',
+        'filter[byline]': id,
         ...(excluded && {
           ...excluded,
           'filter[id][operator]': 'NOT IN'


### PR DESCRIPTION
Closes #302 

- change operator to default, `=`.

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to `people/anita-elash` bio page.
- [x] Ensure only stories she is in the byline for show up.
- [x] Ensure only audio segments she is the audio author for show up.
