### PR TITLE
#301: Refactor key hashing to not use base-64

### DIFF
--- a/components/MetaTags/MetaTags.tsx
+++ b/components/MetaTags/MetaTags.tsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import { parse } from 'url';
 import Head from 'next/head';
-import { encode } from 'base-64';
 import { OpenGraph } from '@components/OpenGraph';
 import { TwitterCard } from '@components/TwitterCard';
 
@@ -69,7 +68,7 @@ export const MetaTags = ({ data }: IMetaTagsProps) => {
   };
   const keyGen = (k: string, v: string) =>
     // eslint-disable-next-line no-control-regex
-    `${k}:${encode(v.replace(/[^\x00-\x7F]/g, ''))}`;
+    `${k}:${v}`;
   const renderMetaOther = () =>
     Object.entries(metaOther).map(
       ([k, v]) =>

--- a/components/OpenGraph/OpenGraph.tsx
+++ b/components/OpenGraph/OpenGraph.tsx
@@ -4,7 +4,6 @@
  */
 
 import React from 'react';
-import { encode } from 'base-64';
 import { IImageStyle } from '@interfaces/content';
 
 export interface IOpenGraphProps {
@@ -35,7 +34,7 @@ export const OpenGraph = ({
     {image &&
       (Array.isArray(image) ? image : [image]).map(
         ({ src, type: imageType, width, height }) => (
-          <React.Fragment key={`i:${encode(src)}`}>
+          <React.Fragment key={`i:${src}`}>
             <meta property="og:image" content={src} />
             {imageType && <meta property="og:image:type" content={imageType} />}
             {width && <meta property="og:image:width" content={`${width}`} />}

--- a/next.config.js
+++ b/next.config.js
@@ -34,7 +34,8 @@ module.exports = withPlausibleProxy({
       'pri9.lndo.site',
       'media-pri-dev.s3.us-east-1.amazonaws.com',
       'www.loe.org',
-      'www.globalpost.com'
+      'www.globalpost.com',
+      'media2.wnyc.org'
     ],
     deviceSizes: [370, 600, 960, 1280, 1920],
     imageSizes: [50, 100, 300, 400, 568, 808]

--- a/store/reducers/search.ts
+++ b/store/reducers/search.ts
@@ -5,13 +5,12 @@
  */
 
 import { HYDRATE } from 'next-redux-wrapper';
-import { encode } from 'base-64';
 import { SearchAction, SearchState, RootState } from '@interfaces/state';
 
 type State = SearchState | RootState;
 
 export const search = (state = {}, action: SearchAction): State => {
-  let queryHash: string;
+  let query: string;
   let s: State;
 
   switch (action.type) {
@@ -52,7 +51,7 @@ export const search = (state = {}, action: SearchAction): State => {
       } as SearchState;
 
     case 'FETCH_SEARCH_SUCCESS':
-      queryHash = encode(action.payload.query);
+      query = (action.payload.query || '').toLowerCase();
       s = state as SearchState;
 
       return {
@@ -60,13 +59,13 @@ export const search = (state = {}, action: SearchAction): State => {
         query: action.payload.query,
         searches: {
           ...(s.searches || {}),
-          [queryHash]: {
-            ...(s.searches?.[queryHash] || {}),
+          [query]: {
+            ...(s.searches?.[query] || {}),
             ...action.payload.data.reduce(
               (a: any, { label, data }) => ({
                 ...a,
                 [label]: [
-                  ...((s as SearchState).searches?.[queryHash]?.[label] || []),
+                  ...((s as SearchState).searches?.[query]?.[label] || []),
                   data
                 ]
               }),
@@ -85,4 +84,4 @@ export const getSearchOpen = (state: SearchState) => state.open;
 export const getSearchLoading = (state: SearchState) => state.loading;
 export const getSearchQuery = (state: SearchState) => state?.query || '';
 export const getSearchData = (state: SearchState, query: string) =>
-  state.searches?.[encode(query)];
+  state.searches?.[query.toLowerCase()];


### PR DESCRIPTION
Closes #301

- Refactor hashing of content values for use as keys to not use base-64 encode.

## To Review

- [x] Use the Preview link: https://fix-301-alias-page-hash-error-non-latin.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to this story: `stories/2016-02-10/chinese-cartoonist-skewers-communist-rulers-afar`.
- [x] Ensure page loads.
