### PR TITLE
#299: Term page routing and rendering fixes

### DIFF
--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -84,15 +84,11 @@ export const Term = () => {
     id,
     'featured story'
   );
-  const featuredStory = featuredStoryState.items[1][0];
-  const { items: featuredStories } = getCollectionData(
-    state,
-    type,
-    id,
-    'featured stories'
-  );
+  const featuredStory = featuredStoryState?.items[1][0];
+  const { items: featuredStories } =
+    getCollectionData(state, type, id, 'featured stories') || {};
   const storiesState = getCollectionData(state, type, id, 'stories');
-  const { items: stories, page, next, count } = storiesState;
+  const { items: stories, page, next, count } = storiesState || {};
   const hasStories = count > 0;
   const episodesState = getCollectionData(state, type, id, 'episodes');
   const {

--- a/lib/fetch/term/fetchTermStories.spec.ts
+++ b/lib/fetch/term/fetchTermStories.spec.ts
@@ -2,13 +2,19 @@ import { generateFieldNameFromPath } from './fetchTermStories';
 
 describe('lib/fetch/term', () => {
   describe('generateFieldNameFromPath', () => {
-    test('should generate `tags` path.', () => {
+    test('should generate `tags` field name.', () => {
       const result = generateFieldNameFromPath('/tags/foo');
 
       expect(result).toEqual('tags');
     });
 
-    test('should generate `opencalais_*` path.', () => {
+    test('should generate `format` field name.', () => {
+      const result = generateFieldNameFromPath('/story-format/foo');
+
+      expect(result).toEqual('format');
+    });
+
+    test('should generate `opencalais_*` field name.', () => {
       let result = generateFieldNameFromPath('/city/foo');
       expect(result).toEqual('opencalais_city');
 
@@ -16,10 +22,22 @@ describe('lib/fetch/term', () => {
       expect(result).toEqual('opencalais_country');
     });
 
-    test('should generate `opencalais_province` path.', () => {
+    test('should generate `opencalais_province` field name.', () => {
       const result = generateFieldNameFromPath('/province-or-state/foo');
 
       expect(result).toEqual('opencalais_province');
+    });
+
+    test('should generate `opencalais_social` field name.', () => {
+      const result = generateFieldNameFromPath('/social-tags/foo');
+
+      expect(result).toEqual('opencalais_social');
+    });
+
+    test('should generate `false` field name.', () => {
+      const result = generateFieldNameFromPath('/countries-regions/foo');
+
+      expect(result).toEqual(false);
     });
   });
 });

--- a/pages/api/term/[id]/stories/[page].ts
+++ b/pages/api/term/[id]/stories/[page].ts
@@ -3,51 +3,20 @@
  * Gather term stories data from CMS API.
  */
 import { NextApiRequest, NextApiResponse } from 'next';
-import {
-  IPriApiResourceResponse,
-  IPriApiCollectionResponse
-} from 'pri-api-library/types';
-import { fetchPriApiItem, fetchPriApiQuery } from '@lib/fetch/api';
-import { basicStoryParams } from '@lib/fetch/api/params';
-import { generateLinkHrefForContent } from '@lib/routing';
+import { fetchTermStories } from '@lib/fetch';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, page = '1', range = 15, exclude } = req.query;
 
   if (id) {
-    const term = (await fetchPriApiItem(
-      'taxonomy_term--terms',
-      id as string
-    )) as IPriApiResourceResponse;
+    const stories = await fetchTermStories(
+      id as string,
+      parseInt(page as string, 10),
+      parseInt(range as string, 10),
+      exclude as string
+    );
 
-    if (term) {
-      const { featuredStories } = term.data;
-      const excluded =
-        (exclude || featuredStories) &&
-        [
-          ...(exclude && Array.isArray(exclude) ? exclude : [exclude]),
-          ...(featuredStories ? featuredStories.map(({ id: i }) => i) : [])
-        ]
-          .filter((v: string) => !!v)
-          .reduce((a, v, i) => ({ ...a, [`filter[id][value][${i}]`]: v }), {});
-      const { pathname } = generateLinkHrefForContent(term.data);
-      const [, fn] = pathname.split('/');
-      const fieldName = fn === 'tags' ? fn : `opencalais_${fn}`;
-
-      // Fetch list of stories. Paginated.
-      const stories = (await fetchPriApiQuery('node--stories', {
-        ...basicStoryParams,
-        'filter[status]': 1,
-        [`filter[${fieldName}]`]: id,
-        ...(excluded && {
-          ...excluded,
-          'filter[id][operator]': 'NOT IN'
-        }),
-        sort: '-date_published',
-        range,
-        page
-      })) as IPriApiCollectionResponse;
-
+    if (stories) {
       // Build response object.
       const apiResp = stories;
 

--- a/store/actions/fetchTermData.ts
+++ b/store/actions/fetchTermData.ts
@@ -53,27 +53,38 @@ export const fetchTermData = (
       }
     });
 
-    dispatch(
-      appendResourceCollection(
-        { data: [featuredStory], meta: { count: 1 } },
-        type,
-        id,
-        'featured story'
-      )
-    );
+    if (featuredStory) {
+      dispatch(
+        appendResourceCollection(
+          { data: [featuredStory], meta: { count: 1 } },
+          type,
+          id,
+          'featured story'
+        )
+      );
+    }
 
-    dispatch(
-      appendResourceCollection(
-        { data: [...featuredStories], meta: { count: featuredStories.length } },
-        type,
-        id,
-        'featured stories'
-      )
-    );
+    if (featuredStories?.length) {
+      dispatch(
+        appendResourceCollection(
+          {
+            data: [...featuredStories],
+            meta: { count: featuredStories.length }
+          },
+          type,
+          id,
+          'featured stories'
+        )
+      );
+    }
 
-    dispatch(appendResourceCollection(stories, type, id, 'stories'));
+    if (stories?.data?.length) {
+      dispatch(appendResourceCollection(stories, type, id, 'stories'));
+    }
 
-    dispatch(appendResourceCollection(episodes, type, id, 'episodes'));
+    if (episodes?.data?.length) {
+      dispatch(appendResourceCollection(episodes, type, id, 'episodes'));
+    }
   }
 
   return data;


### PR DESCRIPTION
Closes #299 

- handle term not used on any story or episode (no content links)
- add story field maps:
  - countries-regions
  - social-tags
  - story-format
- handle false field maps

## To Review

- [x] Use the Preview link: https://fix-299-missing-tag-routes.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to a `/social-tags` URL and ensure it loads with list of stories.
- [x] Go to a `/story-format` URL and ensure it loads with list of stories.
- [x] Go to a `/countries-regions` URL and ensure it loads with or without list of stories.
