### PR TITLE
#308: Let bylines wrap

### DIFF
--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.styles.ts
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.styles.ts
@@ -34,16 +34,9 @@ export const storyHeaderStyles = makeStyles((theme: Theme) =>
     date: {
       fontStyle: 'italic'
     },
-    meta: {
-      display: 'grid',
-      gridTemplateColumns: 'max-content',
-      gridTemplateAreas: "'INFO'",
-      justifyContent: 'space-between'
-    },
     info: {
       display: 'grid',
       alignContent: 'start',
-      gridArea: 'INFO',
       gridGap: theme.typography.pxToRem(4)
     },
     programLink: {

--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -45,61 +45,55 @@ export const StoryHeader = ({ data }: Props) => {
       <Box mb={3}>
         <Typography variant="h1">{title}</Typography>
       </Box>
-      <Box className={classes.meta} mb={2}>
-        <Box className={classes.info}>
-          {program && (
-            <ContentLink data={program} className={classes.programLink} />
-          )}
+      <Box className={classes.info} mb={2}>
+        {program && (
+          <ContentLink data={program} className={classes.programLink} />
+        )}
+        <Typography
+          variant="subtitle1"
+          component="div"
+          className={classes.date}
+        >
+          <Moment format="MMMM D, YYYY · h:mm A z" tz="America/New_York" unix>
+            {dateBroadcast || datePublished}
+          </Moment>
+        </Typography>
+        {dateUpdated && (
           <Typography
             variant="subtitle1"
             component="div"
             className={classes.date}
           >
-            <Moment format="MMMM D, YYYY · h:mm A z" tz="America/New_York" unix>
-              {dateBroadcast || datePublished}
+            {' '}
+            Updated on{' '}
+            <Moment format="MMM. D, YYYY · h:mm A z" tz="America/New_York" unix>
+              {dateUpdated}
             </Moment>
           </Typography>
-          {dateUpdated && (
-            <Typography
-              variant="subtitle1"
-              component="div"
-              className={classes.date}
-            >
-              {' '}
-              Updated on{' '}
-              <Moment
-                format="MMM. D, YYYY · h:mm A z"
-                tz="America/New_York"
-                unix
-              >
-                {dateUpdated}
-              </Moment>
-            </Typography>
-          )}
-          {bylines && (
-            <ul className={classes.byline}>
-              {bylines.map(([creditTitle, people]) => (
-                <li className={classes.bylineItem} key={creditTitle}>
-                  {creditTitle}{' '}
-                  <Box className={classes.bylinePeople} component="span">
-                    {people.map((person: IPriApiResource) => (
-                      <Box
-                        className={classes.bylinePerson}
-                        component="span"
-                        key={person.id}
-                      >
-                        <ContentLink
-                          className={classes.bylineLink}
-                          data={person}
-                        />
-                      </Box>
-                    ))}
-                  </Box>
-                </li>
-              ))}
-            </ul>
-          )}
-        </Box>
+        )}
+        {bylines && (
+          <ul className={classes.byline}>
+            {bylines.map(([creditTitle, people]) => (
+              <li className={classes.bylineItem} key={creditTitle}>
+                {creditTitle}{' '}
+                <Box className={classes.bylinePeople} component="span">
+                  {people.map((person: IPriApiResource) => (
+                    <Box
+                      className={classes.bylinePerson}
+                      component="span"
+                      key={person.id}
+                    >
+                      <ContentLink
+                        className={classes.bylineLink}
+                        data={person}
+                      />
+                    </Box>
+                  ))}
+                </Box>
+              </li>
+            ))}
+          </ul>
+        )}
       </Box>
     </Box>
   );

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.styles.ts
@@ -125,7 +125,6 @@ export const storyHeaderStyles = makeStyles((theme: Theme) =>
     date: {
       fontStyle: 'italic'
     },
-    meta: {},
     info: {
       display: 'grid',
       alignContent: 'start',

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -78,65 +78,63 @@ export const StoryHeader = ({ data }: Props) => {
                 </Typography>
               )}
             </Box>
-            <Box className={classes.meta} mb={2}>
-              <Box className={classes.info}>
-                {program && (
-                  <ContentLink data={program} className={classes.programLink} />
-                )}
+            <Box className={classes.info} mb={2}>
+              {program && (
+                <ContentLink data={program} className={classes.programLink} />
+              )}
+              <Typography
+                variant="subtitle1"
+                component="div"
+                className={classes.date}
+              >
+                <Moment
+                  format="MMMM D, YYYY · h:mm A z"
+                  tz="America/New_York"
+                  unix
+                >
+                  {dateBroadcast || datePublished}
+                </Moment>
+              </Typography>
+              {dateUpdated && (
                 <Typography
                   variant="subtitle1"
                   component="div"
                   className={classes.date}
                 >
+                  {' '}
+                  Updated on{' '}
                   <Moment
-                    format="MMMM D, YYYY · h:mm A z"
+                    format="MMM. D, YYYY · h:mm A z"
                     tz="America/New_York"
                     unix
                   >
-                    {dateBroadcast || datePublished}
+                    {dateUpdated}
                   </Moment>
                 </Typography>
-                {dateUpdated && (
-                  <Typography
-                    variant="subtitle1"
-                    component="div"
-                    className={classes.date}
-                  >
-                    {' '}
-                    Updated on{' '}
-                    <Moment
-                      format="MMM. D, YYYY · h:mm A z"
-                      tz="America/New_York"
-                      unix
-                    >
-                      {dateUpdated}
-                    </Moment>
-                  </Typography>
-                )}
-                {bylines && (
-                  <ul className={classes.byline}>
-                    {bylines.map(([creditTitle, people]) => (
-                      <li className={classes.bylineItem} key={creditTitle}>
-                        {creditTitle}{' '}
-                        <Box className={classes.bylinePeople} component="span">
-                          {people.map((person: IPriApiResource) => (
-                            <Box
-                              className={classes.bylinePerson}
-                              component="span"
-                              key={person.id}
-                            >
-                              <ContentLink
-                                className={classes.bylineLink}
-                                data={person}
-                              />
-                            </Box>
-                          ))}
-                        </Box>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </Box>
+              )}
+              {bylines && (
+                <ul className={classes.byline}>
+                  {bylines.map(([creditTitle, people]) => (
+                    <li className={classes.bylineItem} key={creditTitle}>
+                      {creditTitle}{' '}
+                      <Box className={classes.bylinePeople} component="span">
+                        {people.map((person: IPriApiResource) => (
+                          <Box
+                            className={classes.bylinePerson}
+                            component="span"
+                            key={person.id}
+                          >
+                            <ContentLink
+                              className={classes.bylineLink}
+                              data={person}
+                            />
+                          </Box>
+                        ))}
+                      </Box>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </Box>
           </Container>
         </Box>


### PR DESCRIPTION
Closes #308 

- Removes unnecessary wrapper from header info block.

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to `stories/2008-08-29/pause-play-record`.
- [x] Inspect page and go into responsive view.
- [x] Resize window to a mobile device size.
- [x] Ensure bylines wrap as expected.
