### PR TITLE
#311: Landing page header layout improvements

### DIFF
--- a/components/LandingPageHeader/LandingPageHeader.styles.ts
+++ b/components/LandingPageHeader/LandingPageHeader.styles.ts
@@ -15,7 +15,9 @@ export const landingPageHeaderTheme = (theme: Theme) =>
   createMuiTheme(theme, {
     typography: {
       h1: {
-        fontSize: theme.typography.pxToRem(48)
+        fontSize: `clamp(${theme.typography.pxToRem(
+          18
+        )}, 10vw, ${theme.typography.pxToRem(48)})`
       },
       subtitle1: {
         fontSize: '1.5rem',
@@ -31,7 +33,6 @@ export const landingPageHeaderStyles = makeStyles((theme: Theme) =>
       display: 'grid',
       gridTemplateRows: 'max-content max-content',
       alignItems: 'end',
-      maxHeight: '75vh',
       overflow: 'hidden',
       backgroundColor: theme.palette.primary.light,
       marginBottom: theme.typography.pxToRem(theme.spacing(2))
@@ -113,11 +114,13 @@ export const landingPageHeaderStyles = makeStyles((theme: Theme) =>
       gridGap: theme.typography.pxToRem(theme.spacing(2))
     },
     logo: {
+      position: 'relative',
       flexShrink: 0,
-      margin: theme.typography.pxToRem(theme.spacing(3)),
-      [theme.breakpoints.up('sm')]: {
-        marginLeft: 0
-      },
+      ...((min, size, max) => ({
+        width: `clamp(${min}, ${size}, ${max})`,
+        height: `clamp(${min}, ${size}, ${max})`
+      }))(theme.typography.pxToRem(80), '60vw', theme.typography.pxToRem(200)),
+      margin: `${theme.typography.pxToRem(theme.spacing(3))} 0`,
       [theme.breakpoints.up('md')]: {
         margin: 0,
         marginRight: theme.typography.pxToRem(theme.spacing(3))

--- a/components/LandingPageHeader/LandingPageHeader.tsx
+++ b/components/LandingPageHeader/LandingPageHeader.tsx
@@ -66,15 +66,15 @@ export const LandingPageHeader = ({
         <Box className={cx('content')}>
           <Container fixed className={cx('header')}>
             {logo && (
-              <Image
-                src={logo.url}
-                alt={logo.alt}
-                layout="fixed"
-                width={220}
-                height={220}
-                objectFit="cover"
-                className={cx('logo')}
-              />
+              <Box className={cx('logo')}>
+                <Image
+                  src={logo.url}
+                  alt={logo.alt}
+                  layout="fill"
+                  objectFit="cover"
+                  className={cx('logo')}
+                />
+              </Box>
             )}
             <Box className={cx('text')}>
               <Typography variant="h1">{title}</Typography>

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -66,8 +66,8 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
       alignItems: 'start',
       padding: `${theme.spacing(2)}px`,
       [theme.breakpoints.down('xs')]: {
-        gridTemplateColumns: '100px 1fr',
-        alignItems: 'center'
+        display: 'flex',
+        flexDirection: 'column'
       },
       '$noImage &': {},
       '$short &': {

--- a/components/StoryCardGrid/StoryCardGrid.styles.ts
+++ b/components/StoryCardGrid/StoryCardGrid.styles.ts
@@ -55,8 +55,6 @@ export const storyCardGridTheme = (theme: Theme) =>
           alignItems: 'stretch',
           height: '100%',
           [theme.breakpoints.down('xs')]: {
-            display: 'grid',
-            gridTemplateColumns: '100px 1fr',
             gridGap: `${theme.spacing(2)}px`,
             padding: `${theme.spacing(2)}px`
           }


### PR DESCRIPTION
Closes #311 

- fix issue with content clipping on thinner mobile devices
- improve logo scaling
- improve title heading scaling
- improve small story cards layout on xs mobile

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to TW program page.
- [x] Inspect page and switch to device view. Select `Galaxy Fold` device.
- [x] Ensure header content isn't clipped.
- [x] Ensure logo and title scale appropriately.
- [x] Note change to non-feature story cards to not cause headlines to squish into thin columns of text. Should be me legible.
- [x] Ensure header content layout looks good at any device size.
- [x] Go to a category, preferably one with a long name (`categories/education`). 
- [x] Ensure header title scales well to all device sizes.
