### PR TITLE
Add sort param to api request

### DIFF
--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -561,7 +561,8 @@ export const fetchApiSearch = (
       query: {
         ...(q && { q }),
         ...(label && { l: `${label}` }),
-        ...(start && { s: `${start}` })
+        ...(start && { s: `${start}` }),
+        t: 'date:d:s'
       }
     })
   ).then(r => r.status === 200 && r.json()) as Promise<


### PR DESCRIPTION
- Adds a sort param to search api requests to sort by date in descending order. Story URL's include a date format Google recognizes. More work may need to be done to get episodes and media to sort by date.
- This assumes the date sort is the desired result ordering, and forgoes adding sort options to search form for now.

## To Review

- Code review. This is non-breaking. PR for the search lambda needs to merge and deploy for this to work.
