### PR TITLE
HOTFIX: don't render story dates when missing data

### DIFF
--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -49,15 +49,17 @@ export const StoryHeader = ({ data }: Props) => {
         {program && (
           <ContentLink data={program} className={classes.programLink} />
         )}
-        <Typography
-          variant="subtitle1"
-          component="div"
-          className={classes.date}
-        >
-          <Moment format="MMMM D, YYYY · h:mm A z" tz="America/New_York" unix>
-            {dateBroadcast || datePublished}
-          </Moment>
-        </Typography>
+        {(dateBroadcast || datePublished) && (
+          <Typography
+            variant="subtitle1"
+            component="div"
+            className={classes.date}
+          >
+            <Moment format="MMMM D, YYYY · h:mm A z" tz="America/New_York" unix>
+              {dateBroadcast || datePublished}
+            </Moment>
+          </Typography>
+        )}
         {dateUpdated && (
           <Typography
             variant="subtitle1"

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -82,19 +82,21 @@ export const StoryHeader = ({ data }: Props) => {
               {program && (
                 <ContentLink data={program} className={classes.programLink} />
               )}
-              <Typography
-                variant="subtitle1"
-                component="div"
-                className={classes.date}
-              >
-                <Moment
-                  format="MMMM D, YYYY · h:mm A z"
-                  tz="America/New_York"
-                  unix
+              {(dateBroadcast || datePublished) && (
+                <Typography
+                  variant="subtitle1"
+                  component="div"
+                  className={classes.date}
                 >
-                  {dateBroadcast || datePublished}
-                </Moment>
-              </Typography>
+                  <Moment
+                    format="MMMM D, YYYY · h:mm A z"
+                    tz="America/New_York"
+                    unix
+                  >
+                    {dateBroadcast || datePublished}
+                  </Moment>
+                </Typography>
+              )}
               {dateUpdated && (
                 <Typography
                   variant="subtitle1"


### PR DESCRIPTION
- Prevents rendering of date of story from 1969 when date value is missing from story

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.

> ...then...

- [ ] Go to http://localhost:3000/stories/your-american-tax-dollars-just-sent-300-us-paratroopers-train-ukrainian-soldiers
- [ ] Ensure date is not shown in header
