### PR TITLE
#322: url encode alias before request

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     // For ESLint
     "source.fixAll.eslint": false
   },
-  "editor.formatOnPaste": true
+  "editor.formatOnPaste": true,
+  "cSpell.words": ["metatags", "unsub"]
 }

--- a/components/pages/Audio/Audio.tsx
+++ b/components/pages/Audio/Audio.tsx
@@ -101,7 +101,10 @@ export const Audio = () => {
     }
 
     // Get CTA message data.
-    const context = [`file:${data.id}`, `node:${data.program.id}`];
+    const context = [
+      `file:${data.id}`,
+      ...(data.program ? [`node:${data.program.id}`] : [])
+    ];
     (async () => {
       await store.dispatch<any>(
         fetchCtaData(type, id, 'tw_cta_regions_content', context)

--- a/lib/fetch/api/fetchPriApi.ts
+++ b/lib/fetch/api/fetchPriApi.ts
@@ -138,7 +138,7 @@ export const fetchPriApiQueryAlias = async (
   keys?: object
 ): Promise<PriApiResourceResponse> =>
   fetchPriApi(
-    `query/alias/${alias.replace(/^\/+|\/+$/, '')}`,
+    `query/alias/${encodeURIComponent(alias.replace(/^\/+|\/+$/, ''))}`,
     params,
     keys
   ).then(resp => !resp.isFailure && resp.response);


### PR DESCRIPTION
Closes #322 

- fix error caused when non-URL encoded characters are present in aliases
- fix audio render error when program is missing
- spellcheck vscode settings

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to `2010/06/28/germany’s-new-relationship-with-turkish`
- [x] Ensure page renders with a 404 error. This is expected as this story's alias in Drupal does not include the apostrophe.
