### PR TITLE
#323: Remove default label text from audio player

### DIFF
--- a/components/AudioPlayer/AudioPlayer.tsx
+++ b/components/AudioPlayer/AudioPlayer.tsx
@@ -10,7 +10,7 @@ import { Box, IconButton, NoSsr } from '@material-ui/core';
 import { GetAppSharp, PlayArrowSharp } from '@material-ui/icons';
 import { ThemeProvider } from '@material-ui/core/styles';
 import classNames from 'classnames/bind';
-import { IDuarationProps } from '@components/Duration';
+import { IDurationProps } from '@components/Duration';
 import { formatDuration } from '@lib/parse/time';
 import { generateAudioDownloadFilename } from '@lib/parse/audio';
 import { AudioPlayerActionTypes as ActionTypes } from './AudioPlayer.actions';
@@ -25,7 +25,7 @@ import { ISliderValueLabelProps } from './SliderValueLabel';
 
 const Duration = dynamic(() =>
   import('@components/Duration').then(mod => mod.Duration)
-) as React.FC<IDuarationProps>;
+) as React.FC<IDurationProps>;
 
 const EmbedCode = dynamic(() =>
   import('./EmbedCode').then(mod => mod.EmbedCode)
@@ -77,7 +77,7 @@ export const AudioPlayer = ({
   data,
   downloadFilename,
   embeddedPlayerUrl,
-  message = 'Hear a different voice.',
+  message,
   popoutPlayerUrl
 }: IAudioPlayerProps) => {
   const { url } = data;
@@ -102,8 +102,8 @@ export const AudioPlayer = ({
     dispatch
   ] = useReducer(audioPlayerStateReducer, audioPlayerInitialState);
 
-  const showMessage = !hasPlayed && !embedCodeShown;
-  const showControls = hasPlayed && !embedCodeShown;
+  const showMessage = !!message?.length && !hasPlayed && !embedCodeShown;
+  const showControls = !message?.length || (hasPlayed && !embedCodeShown);
 
   const classes = audioPlayerStyles({ loaded, playing, hasPlayed, stuck });
   const cx = classNames.bind(classes);

--- a/components/Duration/Duration.tsx
+++ b/components/Duration/Duration.tsx
@@ -6,11 +6,11 @@
 import React, { HTMLAttributes } from 'react';
 import { formatDuration } from '@lib/parse/time';
 
-export interface IDuarationProps extends HTMLAttributes<{}> {
+export interface IDurationProps extends HTMLAttributes<{}> {
   seconds: number;
 }
 
-export const Duration = ({ seconds, ...other }: IDuarationProps) => (
+export const Duration = ({ seconds, ...other }: IDurationProps) => (
   <time dateTime={`P${Math.round(seconds)}S`} {...other}>
     {formatDuration(seconds)}
   </time>


### PR DESCRIPTION
Closes #323 

- Audio player defaults to showing controls when not configured for an intro message/label.
- Spelling correction to IDurationProp interface name


## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to any audio page.
- [x] Ensure the audio player no longer shows the old slogan, instead shows controls.
- [x] Go to a story.
- [x] Ensure the intro message of "Listen to this story" is shown.
