### PR TITLE
#248: Add `pubdate` metatag to relevant content pages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,21 @@
     "source.fixAll.eslint": false
   },
   "editor.formatOnPaste": true,
-  "cSpell.words": ["metatags", "unsub"]
+  "cSpell.words": [
+    "cflds",
+    "customsearch",
+    "Denormalized",
+    "flipboard",
+    "Lede",
+    "metatags",
+    "optin",
+    "popout",
+    "pubdate",
+    "shortlink",
+    "targetable",
+    "theworld",
+    "unfetch",
+    "unsub",
+    "VERCEL"
+  ]
 }

--- a/components/NewsletterForm/NewsletterForm.tsx
+++ b/components/NewsletterForm/NewsletterForm.tsx
@@ -18,7 +18,7 @@ import {
 import { useAmp } from 'next/amp';
 import { SendSharp } from '@material-ui/icons';
 import { INewsletterOptions, INewsletterData } from '@interfaces/newsletter';
-import { postNewsletterSubsciption } from '@lib/fetch/api';
+import { postNewsletterSubscription } from '@lib/fetch/api';
 import { validateEmailAddress } from '@lib/validate';
 import {
   newsletterFormTheme,
@@ -68,7 +68,7 @@ export const NewsletterForm = ({
   };
 
   const handleSubscribe = async () => {
-    const resp = await postNewsletterSubsciption(data, {
+    const resp = await postNewsletterSubscription(data, {
       ...options,
       ...(isAmp && { 'source-position': `${options['source-position']}-amp` })
     });

--- a/components/pages/Audio/Audio.tsx
+++ b/components/pages/Audio/Audio.tsx
@@ -7,7 +7,6 @@ import React, { useContext, useEffect, useState } from 'react';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import pad from 'lodash/pad';
 import { Box, Container, Grid } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { AudioPlayer } from '@components/AudioPlayer';
@@ -17,6 +16,7 @@ import { HtmlContent } from '@components/HtmlContent';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
 import { RootState } from '@interfaces/state';
+import { parseUtcDate } from '@lib/parse/date';
 import { fetchCtaData } from '@store/actions/fetchCtaData';
 import { fetchAudioData } from '@store/actions/fetchAudioData';
 import { getDataByResource, getCtaRegionData } from '@store/reducers';
@@ -42,7 +42,7 @@ export const Audio = () => {
   }
 
   const {
-    metatags,
+    metatags: dataMetatags,
     title,
     audioAuthor,
     audioTitle,
@@ -51,6 +51,12 @@ export const Audio = () => {
     dateBroadcast,
     description
   } = data;
+  const metatags = {
+    ...dataMetatags,
+    ...(dateBroadcast && {
+      pubdate: parseUtcDate(dateBroadcast * 1000).join('-')
+    })
+  };
 
   const ctaInlineEnd = getCtaRegionData(
     state,
@@ -69,14 +75,11 @@ export const Audio = () => {
     }),
     ...(dateBroadcast &&
       (() => {
-        const dt = new Date(dateBroadcast * 1000);
-        const dtYear = dt.getFullYear();
-        const dtMonth = pad(`${dt.getMonth() + 1}`, 2, '0');
-        const dtDate = pad(`${dt.getDate()}`, 2, '0');
+        const dt = parseUtcDate(dateBroadcast * 1000);
         return {
-          'Broadcast Year': `${dtYear}`,
-          'Broadcast Month': `${dtYear}-${dtMonth}`,
-          'Broadcast Date': `${dtYear}-${dtMonth}-${dtDate}`
+          'Broadcast Year': dt[0],
+          'Broadcast Month': dt.slice(0, 1).join('-'),
+          'Broadcast Date': dt.join('-')
         };
       })())
   };

--- a/components/pages/Audio/Audio.tsx
+++ b/components/pages/Audio/Audio.tsx
@@ -48,13 +48,13 @@ export const Audio = () => {
     audioTitle,
     audioType,
     season,
-    dateBroadcast,
+    broadcastDate,
     description
   } = data;
   const metatags = {
     ...dataMetatags,
-    ...(dateBroadcast && {
-      pubdate: parseUtcDate(dateBroadcast * 1000).join('-')
+    ...(broadcastDate && {
+      pubdate: parseUtcDate(broadcastDate * 1000).join('-')
     })
   };
 
@@ -73,9 +73,9 @@ export const Audio = () => {
     ...(season && {
       Season: season
     }),
-    ...(dateBroadcast &&
+    ...(broadcastDate &&
       (() => {
-        const dt = parseUtcDate(dateBroadcast * 1000);
+        const dt = parseUtcDate(broadcastDate * 1000);
         return {
           'Broadcast Year': dt[0],
           'Broadcast Month': dt.slice(0, 1).join('-'),

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -7,7 +7,6 @@ import React, { useContext, useEffect, useState } from 'react';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import pad from 'lodash/pad';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
   Box,
@@ -38,6 +37,7 @@ import { StoryCard } from '@components/StoryCard';
 import { CtaRegion } from '@components/CtaRegion';
 import { AppContext } from '@contexts/AppContext';
 import { RootState, UiAction } from '@interfaces/state';
+import { parseUtcDate } from '@lib/parse/date';
 import { appendResourceCollection } from '@store/actions/appendResourceCollection';
 import { fetchCtaData } from '@store/actions/fetchCtaData';
 import { fetchEpisodeData } from '@store/actions/fetchEpisodeData';
@@ -69,7 +69,7 @@ export const Episode = () => {
   }
 
   const {
-    metatags,
+    metatags: dataMetatags,
     title,
     season,
     dateBroadcast,
@@ -84,6 +84,12 @@ export const Episode = () => {
     reporters,
     spotifyPlaylist
   } = data;
+  const metatags = {
+    ...dataMetatags,
+    ...((dateBroadcast || datePublished) && {
+      pubdate: parseUtcDate((dateBroadcast || datePublished) * 1000).join('-')
+    })
+  };
   const { segments } = audio || {};
 
   const storiesState = getCollectionData(state, type, id, 'stories');
@@ -115,26 +121,20 @@ export const Episode = () => {
     }),
     ...(dateBroadcast &&
       (() => {
-        const dt = new Date(dateBroadcast * 1000);
-        const dtYear = dt.getFullYear();
-        const dtMonth = pad(`${dt.getMonth() + 1}`, 2, '0');
-        const dtDate = pad(`${dt.getDate()}`, 2, '0');
+        const dt = parseUtcDate(dateBroadcast * 1000);
         return {
-          'Broadcast Year': `${dtYear}`,
-          'Broadcast Month': `${dtYear}-${dtMonth}`,
-          'Broadcast Date': `${dtYear}-${dtMonth}-${dtDate}`
+          'Broadcast Year': dt[0],
+          'Broadcast Month': dt.slice(0, 1).join('-'),
+          'Broadcast Date': dt.join('-')
         };
       })()),
     ...(datePublished &&
       (() => {
-        const dt = new Date(datePublished * 1000);
-        const dtYear = dt.getFullYear();
-        const dtMonth = pad(`${dt.getMonth() + 1}`, 2, '0');
-        const dtDate = pad(`${dt.getDate()}`, 2, '0');
+        const dt = parseUtcDate(datePublished * 1000);
         return {
-          'Published Year': `${dtYear}`,
-          'Published Month': `${dtYear}-${dtMonth}`,
-          'Published Date': `${dtYear}-${dtMonth}-${dtDate}`
+          'Published Year': dt[0],
+          'Published Month': dt.slice(0, 1).join('-'),
+          'Published Date': dt.join('-')
         };
       })())
   };

--- a/components/pages/Video/Video.tsx
+++ b/components/pages/Video/Video.tsx
@@ -7,7 +7,6 @@ import React, { useContext, useEffect, useState } from 'react';
 import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import pad from 'lodash/pad';
 import { Box, Container, Grid } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { LedeVideo } from '@components/LedeVideo';
@@ -41,7 +40,7 @@ export const Video = () => {
     return null;
   }
 
-  const { metatags, title, date, description } = data;
+  const { metatags, title, description } = data;
 
   const ctaInlineEnd = getCtaRegionData(
     state,
@@ -52,21 +51,9 @@ export const Video = () => {
 
   // Plausible Events.
   const props = {
-    Title: title,
-    ...(date &&
-      (() => {
-        const dt = new Date(date * 1000);
-        const dtYear = dt.getFullYear();
-        const dtMonth = pad(`${dt.getMonth() + 1}`, 2, '0');
-        const dtDate = pad(`${dt.getDate()}`, 2, '0');
-        return {
-          'Broadcast Year': `${dtYear}`,
-          'Broadcast Month': `${dtYear}-${dtMonth}`,
-          'Broadcast Date': `${dtYear}-${dtMonth}-${dtDate}`
-        };
-      })())
+    Title: title
   };
-  const plausibleEvents: PlausibleEventArgs[] = [['Audio', { props }]];
+  const plausibleEvents: PlausibleEventArgs[] = [['Video', { props }]];
 
   useEffect(() => {
     if (!data.complete) {

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -130,7 +130,7 @@ export const fetchApiNewsletter = async (id: string, req?: IncomingMessage) =>
  * @param newsletter Newsletter data object.
  * @param options Newsletter subscription options.
  */
-export const postNewsletterSubsciption = async (
+export const postNewsletterSubscription = async (
   newsletter: INewsletterData,
   options: INewsletterOptions
 ) => {
@@ -562,7 +562,7 @@ export const fetchApiSearch = (
         ...(q && { q }),
         ...(label && { l: `${label}` }),
         ...(start && { s: `${start}` }),
-        t: 'date:d:s'
+        t: 'metatags-pubdate:d,date:d:s'
       }
     })
   ).then(r => r.status === 200 && r.json()) as Promise<

--- a/lib/parse/date/index.ts
+++ b/lib/parse/date/index.ts
@@ -1,0 +1,1 @@
+export * from './utc';

--- a/lib/parse/date/utc.spec.ts
+++ b/lib/parse/date/utc.spec.ts
@@ -1,0 +1,15 @@
+import { parseUtcDate } from './index';
+
+describe('lib/parse/date', () => {
+  describe('parseUtcDate', () => {
+    test('should parse UTC date into array of padded date parts', () => {
+      const result = parseUtcDate(1645044300000); // UTC Date for February 16, 2022 · 3:45 PM EST
+
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual('2022');
+      expect(result[1]).toEqual('02');
+      expect(result[2]).toEqual('16');
+    });
+  });
+});

--- a/lib/parse/date/utc.ts
+++ b/lib/parse/date/utc.ts
@@ -1,0 +1,17 @@
+import padStart from 'lodash/padStart';
+
+/**
+ * Parse UCT date into and array of padded date parts.
+ * Example. `['2022, '02', '16']` for February, 16 2022.
+ *
+ * @param seconds number
+ *    Duration in seconds.
+ */
+export const parseUtcDate = (utcDate: number): string[] => {
+  const dt = new Date(utcDate);
+  const dtYear = `${dt.getFullYear()}`;
+  const dtMonth = padStart(`${dt.getMonth() + 1}`, 2, '0');
+  const dtDate = padStart(`${dt.getDate()}`, 2, '0');
+
+  return [dtYear, dtMonth, dtDate];
+};


### PR DESCRIPTION
Refers to #248 

- add `pubdate` metatag to story, episode, and audio pages
- add `metatags-pubdate` to search requests sort param
- move UTC date parsing to lib and add tests
- various spelling corrections

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to any story with a broadcast or published date.
- [x] View source and find `pubdate` metatag. Ensure the date matches what would be displayed as the contents date.
- [ ] Repeat for Episode and Audio pages.
