### PR TITLE
#328: Landing Page Header Size

### DIFF
--- a/components/LandingPageHeader/LandingPageHeader.styles.ts
+++ b/components/LandingPageHeader/LandingPageHeader.styles.ts
@@ -31,21 +31,31 @@ export const landingPageHeaderStyles = makeStyles((theme: Theme) =>
     root: {
       position: 'relative',
       display: 'grid',
-      gridTemplateRows: 'max-content max-content',
+      gridTemplateRows: '1fr max-content',
       alignItems: 'end',
       overflow: 'hidden',
+      minHeight: '15vh',
       backgroundColor: theme.palette.primary.light,
-      marginBottom: theme.typography.pxToRem(theme.spacing(2))
+      marginBottom: theme.typography.pxToRem(theme.spacing(2)),
+      '&$withImage': {
+        minHeight: '35vh'
+      }
     },
     imageWrapper: {
-      gridColumn: '1 / -1',
-      gridRow: '1 / -1',
-      height: '100%',
-      zIndex: 0
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      width: '100%',
+      zIndex: 0,
+      [theme.breakpoints.up('md')]: {
+        alignSelf: 'start',
+        gridColumn: '1 / -1',
+        gridRow: '1 / -1',
+        height: '100%'
+      }
     },
     image: {
-      height: '100%',
-      maxHeight: '75vh'
+      height: '100%'
     },
     content: {
       position: 'relative',
@@ -56,7 +66,6 @@ export const landingPageHeaderStyles = makeStyles((theme: Theme) =>
       // gridTemplateColumns: '1fr 100vw 1fr',
       gridGap: theme.typography.pxToRem(theme.spacing(2)),
       width: '100%',
-      minHeight: '33.33333%',
       padding: theme.typography.pxToRem(theme.spacing(3)),
       '&::before, &::after': {
         content: '""',
@@ -81,13 +90,6 @@ export const landingPageHeaderStyles = makeStyles((theme: Theme) =>
         height: '150%',
         [theme.breakpoints.down('sm')]: {
           height: '80%'
-        }
-      },
-      [theme.breakpoints.up('md')]: {
-        '$withImage &': {
-          position: 'absolute',
-          bottom: 0,
-          gridRow: 'unset'
         }
       }
     },

--- a/components/LandingPageHeader/LandingPageHeader.tsx
+++ b/components/LandingPageHeader/LandingPageHeader.tsx
@@ -7,13 +7,7 @@ import React from 'react';
 import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
-import {
-  Box,
-  Container,
-  Typography,
-  ThemeProvider,
-  Hidden
-} from '@material-ui/core';
+import { Box, Container, Typography, ThemeProvider } from '@material-ui/core';
 import {
   landingPageHeaderStyles,
   landingPageHeaderTheme
@@ -34,33 +28,20 @@ export const LandingPageHeader = ({
 }: ILandingPageHeaderProps) => {
   const classes = landingPageHeaderStyles({});
   const cx = classNames.bind(classes);
+  const { alt } = image || ({} as any);
   return (
     <ThemeProvider theme={landingPageHeaderTheme}>
       <Box className={cx('root', { withImage: !!image })}>
         {image && (
           <Box className={cx('imageWrapper')}>
-            <Hidden mdUp>
-              <Image
-                className={cx('image')}
-                src={image.url}
-                alt={image.alt}
-                layout="fill"
-                objectFit="cover"
-                priority
-              />
-            </Hidden>
-            <Hidden smDown>
-              <Image
-                className={cx('image')}
-                src={image.url}
-                alt={image.alt}
-                layout="responsive"
-                width={image.metadata.width}
-                height={image.metadata.height}
-                objectFit="cover"
-                priority
-              />
-            </Hidden>
+            <Image
+              alt={alt}
+              className={cx('image')}
+              src={image.url}
+              layout="fill"
+              objectFit="cover"
+              priority
+            />
           </Box>
         )}
         <Box className={cx('content')}>


### PR DESCRIPTION
Closes #328 

- updates landing page header styles to size like feature story headers
- reduce the min height of landing page headers

## To Review

- [ ] Use the Preview link: https://fix-328-landing-page-header-image-max-height.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to a program landing page that has a banner image.
- [x] Ensure the header height doesn't become larger than the window height, but never clips its content, as you resize the window.
- [ ] Go to a category page that doesn't have a banner image.
- [ ] Ensure the header content is never clipped as you resize the window.
