### PR TITLE
#333: Fix API request for category banner image data

### DIFF
--- a/lib/fetch/category/fetchCategory.ts
+++ b/lib/fetch/category/fetchCategory.ts
@@ -28,7 +28,7 @@ export const fetchCategory = async (
       'metatags',
       'title',
       'teaser',
-      'bannerImage',
+      'banner_image',
       'logo',
       'hosts',
       'sponsors',


### PR DESCRIPTION
Closes #333

- Correct naming of `banner_image` field name in category API request.

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to http://localhost:3000/categories/thaw-decoding-thwaites-glacier.

> ...then...

- [x] Ensure header image is shown.
