### PR TITLE
#279 Episode card update

### DIFF
--- a/components/EpisodeCard/EpisodeCard.styles.ts
+++ b/components/EpisodeCard/EpisodeCard.styles.ts
@@ -116,6 +116,9 @@ export const episodeCardTheme = (theme: Theme) =>
           width: '100%',
           height: 0,
           paddingTop: `${(9 / 16) * 100}%`,
+          [theme.breakpoints.up('sm')]: {
+            paddingTop: `${(1 / 3) * 100}%`
+          },
           '& > :only-child': {
             position: 'absolute',
             top: 0,

--- a/components/EpisodeCard/EpisodeCard.styles.ts
+++ b/components/EpisodeCard/EpisodeCard.styles.ts
@@ -116,9 +116,6 @@ export const episodeCardTheme = (theme: Theme) =>
           width: '100%',
           height: 0,
           paddingTop: `${(9 / 16) * 100}%`,
-          [theme.breakpoints.up('sm')]: {
-            paddingTop: `${(1 / 3) * 100}%`
-          },
           '& > :only-child': {
             position: 'absolute',
             top: 0,

--- a/components/EpisodeCard/EpisodeCard.styles.ts
+++ b/components/EpisodeCard/EpisodeCard.styles.ts
@@ -58,15 +58,7 @@ export const episodeCardStyles = makeStyles((theme: Theme) => {
       textIndent: '-2000vw'
     },
     title: {
-      display: 'grid',
-      gridTemplateColumns: 'min-content 1fr',
-      gridGap: `${theme.spacing(1)}px`,
-      alignItems: 'center',
       marginTop: theme.typography.pxToRem(theme.spacing(1))
-    },
-    playIcon: {
-      alignSelf: 'start',
-      fontSize: theme.typography.pxToRem(48)
     }
   });
 });

--- a/components/EpisodeCard/EpisodeCard.tsx
+++ b/components/EpisodeCard/EpisodeCard.tsx
@@ -14,7 +14,6 @@ import {
   CardActionArea,
   CardContent,
   CardMedia,
-  Grid,
   Typography
 } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';

--- a/components/EpisodeCard/EpisodeCard.tsx
+++ b/components/EpisodeCard/EpisodeCard.tsx
@@ -10,6 +10,7 @@ import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
+  Box,
   Card,
   CardActionArea,
   CardContent,
@@ -31,7 +32,7 @@ export interface EpisodeCardProps {
 }
 
 export const EpisodeCard = ({ data, label, priority }: EpisodeCardProps) => {
-  const { title, image, audio, dateBroadcast, datePublished } = data;
+  const { image, audio, dateBroadcast, datePublished } = data;
   const { segments } = audio || {};
   const classes = episodeCardStyles({});
   const cx = classNames.bind(classes);
@@ -65,6 +66,18 @@ export const EpisodeCard = ({ data, label, priority }: EpisodeCardProps) => {
               alignItems="center"
               spacing={1}
             >
+              <Grid item xs="auto" zeroMinWidth>
+                <Typography
+                  variant="h5"
+                  component="h2"
+                  gutterBottom
+                  className={cx('title')}
+                >
+                  <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
+                    {dateBroadcast || datePublished}
+                  </Moment>
+                </Typography>
+              </Grid>
               {label && (
                 <Grid item xs="auto" zeroMinWidth>
                   <Typography variant="overline" noWrap>
@@ -72,29 +85,7 @@ export const EpisodeCard = ({ data, label, priority }: EpisodeCardProps) => {
                   </Typography>
                 </Grid>
               )}
-              <Grid item xs="auto" zeroMinWidth>
-                <Typography
-                  variant="subtitle2"
-                  component="span"
-                  color="textSecondary"
-                  gutterBottom
-                  noWrap
-                >
-                  <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
-                    {dateBroadcast || datePublished}
-                  </Moment>
-                </Typography>
-              </Grid>
             </Grid>
-            <Typography
-              variant="h5"
-              component="h2"
-              gutterBottom
-              className={cx('title')}
-            >
-              {' '}
-              {title}
-            </Typography>
             <ContentLink data={data} className={cx('link')} />
             {segments && (
               <>

--- a/components/EpisodeCard/EpisodeCard.tsx
+++ b/components/EpisodeCard/EpisodeCard.tsx
@@ -30,8 +30,8 @@ export interface EpisodeCardProps {
   priority?: boolean;
 }
 
-export const EpisodeCard = ({ data, label, priority }: EpisodeCardProps) => {
-  const { image, audio, dateBroadcast, datePublished } = data;
+export const EpisodeCard = ({ data, priority }: EpisodeCardProps) => {
+  const { title, image, audio, dateBroadcast, datePublished } = data;
   const { segments } = audio || {};
   const classes = episodeCardStyles({});
   const cx = classNames.bind(classes);
@@ -72,18 +72,16 @@ export const EpisodeCard = ({ data, label, priority }: EpisodeCardProps) => {
                   gutterBottom
                   className={cx('title')}
                 >
-                  <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
+                  <Moment
+                    format="dddd, MMMM D, YYYY"
+                    tz="America/New_York"
+                    unix
+                  >
                     {dateBroadcast || datePublished}
                   </Moment>
+                  : {title}
                 </Typography>
               </Grid>
-              {label && (
-                <Grid item xs="auto" zeroMinWidth>
-                  <Typography variant="overline" noWrap>
-                    {label}
-                  </Typography>
-                </Grid>
-              )}
             </Grid>
             <ContentLink data={data} className={cx('link')} />
             {segments && (

--- a/components/EpisodeCard/EpisodeCard.tsx
+++ b/components/EpisodeCard/EpisodeCard.tsx
@@ -59,30 +59,19 @@ export const EpisodeCard = ({ data, priority }: EpisodeCardProps) => {
             </CardMedia>
           )}
           <CardContent>
-            <Grid
-              container
-              justify="space-between"
-              alignItems="center"
-              spacing={1}
+            <Typography component="span">
+              <Moment format="dddd, MMMM D, YYYY" tz="America/New_York" unix>
+                {dateBroadcast || datePublished}
+              </Moment>
+            </Typography>
+            <Typography
+              variant="h5"
+              component="h2"
+              gutterBottom
+              className={cx('title')}
             >
-              <Grid item xs="auto" zeroMinWidth>
-                <Typography
-                  variant="h5"
-                  component="h2"
-                  gutterBottom
-                  className={cx('title')}
-                >
-                  <Moment
-                    format="dddd, MMMM D, YYYY"
-                    tz="America/New_York"
-                    unix
-                  >
-                    {dateBroadcast || datePublished}
-                  </Moment>
-                  : {title}
-                </Typography>
-              </Grid>
-            </Grid>
+              {title}
+            </Typography>
             <ContentLink data={data} className={cx('link')} />
             {segments && (
               <>

--- a/components/EpisodeCard/EpisodeCard.tsx
+++ b/components/EpisodeCard/EpisodeCard.tsx
@@ -10,14 +10,17 @@ import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
+  Box,
   Card,
   CardActionArea,
   CardContent,
   CardMedia,
   Typography
 } from '@material-ui/core';
+import { EqualizerRounded } from '@material-ui/icons';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { ContentLink } from '@components/ContentLink';
+import { HtmlContent } from '@components/HtmlContent';
 import { SidebarAudioList } from '@components/Sidebar/SidebarAudioList';
 import { episodeCardStyles, episodeCardTheme } from './EpisodeCard.styles';
 
@@ -30,7 +33,7 @@ export interface EpisodeCardProps {
 }
 
 export const EpisodeCard = ({ data, priority }: EpisodeCardProps) => {
-  const { title, image, audio, dateBroadcast, datePublished } = data;
+  const { title, teaser, image, audio, dateBroadcast, datePublished } = data;
   const { segments } = audio || {};
   const classes = episodeCardStyles({});
   const cx = classNames.bind(classes);
@@ -71,9 +74,19 @@ export const EpisodeCard = ({ data, priority }: EpisodeCardProps) => {
             >
               {title}
             </Typography>
+            <Typography variant="body1" component="div" color="textSecondary">
+              <Box className={cx('body')}>
+                <HtmlContent html={teaser} />
+              </Box>
+            </Typography>
             <ContentLink data={data} className={cx('link')} />
             {segments && (
               <>
+                <Box component="header" className={cx('header')}>
+                  <Typography variant="h2">
+                    <EqualizerRounded /> In this episode:
+                  </Typography>
+                </Box>
                 <SidebarAudioList data={segments} />
               </>
             )}

--- a/components/EpisodeCard/EpisodeCard.tsx
+++ b/components/EpisodeCard/EpisodeCard.tsx
@@ -10,7 +10,6 @@ import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
-  Box,
   Card,
   CardActionArea,
   CardContent,

--- a/components/EpisodeCard/EpisodeCard.tsx
+++ b/components/EpisodeCard/EpisodeCard.tsx
@@ -10,7 +10,6 @@ import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
-  Box,
   Card,
   CardActionArea,
   CardContent,
@@ -18,10 +17,8 @@ import {
   Grid,
   Typography
 } from '@material-ui/core';
-import { EqualizerRounded, PlayCircleOutlineRounded } from '@material-ui/icons';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { ContentLink } from '@components/ContentLink';
-import { HtmlContent } from '@components/HtmlContent';
 import { SidebarAudioList } from '@components/Sidebar/SidebarAudioList';
 import { episodeCardStyles, episodeCardTheme } from './EpisodeCard.styles';
 
@@ -34,7 +31,7 @@ export interface EpisodeCardProps {
 }
 
 export const EpisodeCard = ({ data, label, priority }: EpisodeCardProps) => {
-  const { teaser, title, image, audio, dateBroadcast, datePublished } = data;
+  const { title, image, audio, dateBroadcast, datePublished } = data;
   const { segments } = audio || {};
   const classes = episodeCardStyles({});
   const cx = classNames.bind(classes);
@@ -95,26 +92,12 @@ export const EpisodeCard = ({ data, label, priority }: EpisodeCardProps) => {
               gutterBottom
               className={cx('title')}
             >
-              <PlayCircleOutlineRounded
-                color="primary"
-                fontSize="large"
-                className={cx('playIcon')}
-              />{' '}
+              {' '}
               {title}
-            </Typography>
-            <Typography variant="body1" component="div" color="textSecondary">
-              <Box className={cx('body')}>
-                <HtmlContent html={teaser} />
-              </Box>
             </Typography>
             <ContentLink data={data} className={cx('link')} />
             {segments && (
               <>
-                <Box component="header" className={cx('header')}>
-                  <Typography variant="h2">
-                    <EqualizerRounded /> In this episode:
-                  </Typography>
-                </Box>
                 <SidebarAudioList data={segments} />
               </>
             )}

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
@@ -11,7 +11,7 @@ import {
   Theme
 } from '@material-ui/core/styles';
 
-export const sidebarEpisodeStyles = makeStyles((theme: Theme) =>
+export const sidebarEpisodeStyles = makeStyles(() =>
   createStyles({
     imageWrapper: {
       paddingTop: 'unset'
@@ -26,8 +26,7 @@ export const sidebarEpisodeStyles = makeStyles((theme: Theme) =>
       textIndent: '-2000vw'
     },
     title: {
-      marginTop: '0',
-      marginBottom: '0'
+      marginBlock: 0
     }
   })
 );
@@ -77,7 +76,7 @@ export const sidebarEpisodeTheme = (theme: Theme) =>
         root: {
           color: theme.palette.text.primary,
           fontWeight: theme.typography.fontWeightBold,
-          paddingBottom: '8px'
+          paddingBottom: `${theme.spacing(1)}px`
         }
       },
       MuiCardMedia: {

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
@@ -26,7 +26,7 @@ export const sidebarEpisodeStyles = makeStyles((theme: Theme) =>
       textIndent: '-2000vw'
     },
     title: {
-      marginTop: theme.typography.pxToRem(theme.spacing(1.5)),
+      marginTop: '0',
       marginBottom: '0'
     }
   })
@@ -76,7 +76,8 @@ export const sidebarEpisodeTheme = (theme: Theme) =>
       MuiCardContent: {
         root: {
           color: theme.palette.text.primary,
-          fontWeight: theme.typography.fontWeightBold
+          fontWeight: theme.typography.fontWeightBold,
+          paddingBottom: '8px'
         }
       },
       MuiCardMedia: {

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
@@ -42,16 +42,6 @@ export const sidebarEpisodeTheme = (theme: Theme) =>
       },
       h5: {
         fontSize: theme.typography.pxToRem(18)
-      },
-      overline: {
-        display: 'inline-block',
-        padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
-        background: theme.palette.grey[200],
-        border: `1px solid ${theme.palette.grey[300]}`,
-        borderRadius: '12px',
-        fontSize: theme.typography.pxToRem(14),
-        fontWeight: theme.typography.fontWeightRegular,
-        lineHeight: 1
       }
     },
     overrides: {
@@ -76,7 +66,7 @@ export const sidebarEpisodeTheme = (theme: Theme) =>
         root: {
           color: theme.palette.text.primary,
           fontWeight: theme.typography.fontWeightBold,
-          paddingBottom: `${theme.spacing(1)}px`
+          paddingBlock: `${theme.spacing(1)}px`
         }
       },
       MuiCardMedia: {

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.styles.ts
@@ -13,15 +13,6 @@ import {
 
 export const sidebarEpisodeStyles = makeStyles((theme: Theme) =>
   createStyles({
-    root: {
-      '& hr': {
-        marginBlockStart: 0,
-        marginBlockEnd: 0,
-        background: 'none',
-        border: 'none',
-        borderTop: `1px solid ${theme.palette.divider}`
-      }
-    },
     imageWrapper: {
       paddingTop: 'unset'
     },
@@ -35,15 +26,8 @@ export const sidebarEpisodeStyles = makeStyles((theme: Theme) =>
       textIndent: '-2000vw'
     },
     title: {
-      display: 'grid',
-      gridTemplateColumns: 'min-content 1fr',
-      gridGap: `${theme.spacing(1)}px`,
-      alignItems: 'center',
-      marginTop: theme.typography.pxToRem(theme.spacing(1))
-    },
-    playIcon: {
-      alignSelf: 'start',
-      fontSize: theme.typography.pxToRem(48)
+      marginTop: theme.typography.pxToRem(theme.spacing(1.5)),
+      marginBottom: '0'
     }
   })
 );

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -36,14 +36,7 @@ export interface SidebarEpisodeProps {
 }
 
 export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
-  const {
-    title,
-    image,
-    audio,
-    program,
-    dateBroadcast,
-    datePublished
-  } = data;
+  const { image, audio, program, dateBroadcast, datePublished } = data;
   const { segments } = audio || {};
   const classes = sidebarEpisodeStyles({});
   const cx = classNames.bind(classes);
@@ -78,6 +71,18 @@ export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
               alignItems="center"
               spacing={1}
             >
+              <Grid item xs="auto" zeroMinWidth>
+                <Typography
+                  variant="h5"
+                  component="h2"
+                  gutterBottom
+                  className={cx('title')}
+                >
+                  <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
+                    {dateBroadcast || datePublished}
+                  </Moment>
+                </Typography>
+              </Grid>
               {label && (
                 <Grid item xs="auto" zeroMinWidth>
                   <Typography variant="overline" noWrap>
@@ -85,29 +90,7 @@ export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
                   </Typography>
                 </Grid>
               )}
-              <Grid item xs="auto" zeroMinWidth>
-                <Typography
-                  variant="subtitle2"
-                  component="span"
-                  color="textSecondary"
-                  gutterBottom
-                  noWrap
-                >
-                  <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
-                    {dateBroadcast || datePublished}
-                  </Moment>
-                </Typography>
-              </Grid>
             </Grid>
-            <Typography
-              variant="h5"
-              component="h2"
-              gutterBottom
-              className={cx('title')}
-            >
-              {' '}
-              {title}
-            </Typography>
             <ContentLink data={data} className={cx('link')} />
           </CardContent>
         </CardActionArea>

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -24,7 +24,6 @@ import {
   sidebarEpisodeStyles,
   sidebarEpisodeTheme
 } from './SidebarEpisode.styles';
-import { SidebarHeader } from '../SidebarHeader';
 import { SidebarAudioList } from '../SidebarAudioList';
 import { SidebarFooter } from '../SidebarFooter';
 

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -10,7 +10,6 @@ import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
-  Box,
   Card,
   CardActionArea,
   CardContent,
@@ -18,11 +17,9 @@ import {
   Grid,
   Typography
 } from '@material-ui/core';
-import { EqualizerRounded, PlayCircleOutlineRounded } from '@material-ui/icons';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { ContentButton } from '@components/ContentButton';
 import { ContentLink } from '@components/ContentLink';
-import { HtmlContent } from '@components/HtmlContent';
 import {
   sidebarEpisodeStyles,
   sidebarEpisodeTheme
@@ -40,7 +37,6 @@ export interface SidebarEpisodeProps {
 
 export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
   const {
-    teaser,
     title,
     image,
     audio,
@@ -109,29 +105,14 @@ export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
               gutterBottom
               className={cx('title')}
             >
-              <PlayCircleOutlineRounded
-                color="primary"
-                fontSize="large"
-                className={cx('playIcon')}
-              />{' '}
+              {' '}
               {title}
-            </Typography>
-            <Typography variant="body1" component="div" color="textSecondary">
-              <Box className={cx('body')} my={2}>
-                <HtmlContent html={teaser} />
-              </Box>
             </Typography>
             <ContentLink data={data} className={cx('link')} />
           </CardContent>
         </CardActionArea>
         {segments && (
           <>
-            <hr />
-            <SidebarHeader>
-              <Typography variant="h2">
-                <EqualizerRounded /> In this episode:
-              </Typography>
-            </SidebarHeader>
             <SidebarAudioList disablePadding data={segments} />
           </>
         )}

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -6,18 +6,16 @@
 import React from 'react';
 import 'moment-timezone';
 import dynamic from 'next/dynamic';
-import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
   Card,
   CardActionArea,
   CardContent,
-  CardMedia,
-  Grid,
   Typography
 } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
+import { Headset } from '@material-ui/icons';
 import { ContentButton } from '@components/ContentButton';
 import { ContentLink } from '@components/ContentLink';
 import {
@@ -25,6 +23,7 @@ import {
   sidebarEpisodeTheme
 } from './SidebarEpisode.styles';
 import { SidebarAudioList } from '../SidebarAudioList';
+import { SidebarHeader } from '../SidebarHeader';
 import { SidebarFooter } from '../SidebarFooter';
 
 const Moment = dynamic(() => import('react-moment')) as any;
@@ -35,61 +34,31 @@ export interface SidebarEpisodeProps {
 }
 
 export const SidebarEpisode = ({ data, label }: SidebarEpisodeProps) => {
-  const { image, audio, program, dateBroadcast, datePublished } = data;
+  const { audio, program, dateBroadcast, datePublished } = data;
   const { segments } = audio || {};
   const classes = sidebarEpisodeStyles({});
   const cx = classNames.bind(classes);
-  const imageWidth = [
-    ['max-width: 600px', '100vw'],
-    ['max-width: 960px', '552px'],
-    ['max-width: 1280px', '300px'],
-    [null, '400px']
-  ];
-  const sizes = imageWidth.map(([q, w]) => (q ? `(${q}) ${w}` : w)).join(', ');
 
   return (
     <ThemeProvider theme={sidebarEpisodeTheme}>
       <Card square elevation={1} className={cx('root')}>
         <CardActionArea>
-          {image && (
-            <CardMedia>
-              <Image
-                src={image.url}
-                alt={image.alt}
-                layout="fill"
-                objectFit="cover"
-                sizes={sizes}
-                priority
-              />
-            </CardMedia>
-          )}
+          <SidebarHeader>
+            <Typography variant="h2">
+              <Headset /> {label}
+            </Typography>
+          </SidebarHeader>
           <CardContent>
-            <Grid
-              container
-              justify="space-between"
-              alignItems="center"
-              spacing={1}
+            <Typography
+              variant="h5"
+              component="h2"
+              gutterBottom
+              className={cx('title')}
             >
-              <Grid item xs="auto" zeroMinWidth>
-                <Typography
-                  variant="h5"
-                  component="h2"
-                  gutterBottom
-                  className={cx('title')}
-                >
-                  <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
-                    {dateBroadcast || datePublished}
-                  </Moment>
-                </Typography>
-              </Grid>
-              {label && (
-                <Grid item xs="auto" zeroMinWidth>
-                  <Typography variant="overline" noWrap>
-                    {label}
-                  </Typography>
-                </Grid>
-              )}
-            </Grid>
+              <Moment format="dddd, MMMM D, YYYY" tz="America/New_York" unix>
+                {dateBroadcast || datePublished}
+              </Moment>
+            </Typography>
             <ContentLink data={data} className={cx('link')} />
           </CardContent>
         </CardActionArea>

--- a/components/Tags/Tags.styles.ts
+++ b/components/Tags/Tags.styles.ts
@@ -16,7 +16,7 @@ export const tagsStyles = makeStyles((theme: Theme) =>
       color: theme.palette.grey[700]
     },
     label: {
-      margin: '0',
+      margin: 0,
       fontSize: theme.typography.pxToRem(14),
       fontWeight: theme.typography.fontWeightRegular,
       '&::after': {

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -180,17 +180,17 @@ export const Homepage = () => {
               <Hidden only="sm">
                 <SidebarCta data={sidebarTop} />
               </Hidden>
+              <Box mt={3}>
+                <SidebarLatestStories
+                  data={latestStories[1]}
+                  label="Latest from our partners"
+                />
+              </Box>
               <Hidden xsDown mdUp>
                 <CtaRegion data={sidebarTop} />
               </Hidden>
             </Box>
           )}
-          <Box mt={3}>
-            <SidebarLatestStories
-              data={latestStories[1]}
-              label="Latest from our partners"
-            />
-          </Box>
         </Box>
       )
     },

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -174,7 +174,7 @@ export const Homepage = () => {
       key: 'sidebar top',
       children: (
         <Box mt={3}>
-          <SidebarEpisode data={latestEpisode} label="Latest Edition" />
+          <SidebarEpisode data={latestEpisode} label="Latest Episode" />
           {sidebarTop && (
             <Box mt={3}>
               <Hidden only="sm">
@@ -185,6 +185,19 @@ export const Homepage = () => {
               </Hidden>
             </Box>
           )}
+          <Box mt={3}>
+            <SidebarLatestStories
+              data={latestStories[1]}
+              label="Latest from our partners"
+            />
+          </Box>
+        </Box>
+      )
+    },
+    {
+      key: 'sidebar bottom',
+      children: (
+        <Box mt={3}>
           {categoriesMenu && (
             <Box mt={3}>
               <Sidebar item elevated>
@@ -197,17 +210,6 @@ export const Homepage = () => {
               </Sidebar>
             </Box>
           )}
-        </Box>
-      )
-    },
-    {
-      key: 'sidebar bottom',
-      children: (
-        <Box mt={3}>
-          <SidebarLatestStories
-            data={latestStories[1]}
-            label="Latest from our partners"
-          />
           {sidebarBottom && (
             <Box mt={3}>
               <Hidden only="sm">

--- a/components/pages/Program/Program.tsx
+++ b/components/pages/Program/Program.tsx
@@ -218,7 +218,7 @@ export const Program = () => {
             </>
           )}
           {isEpisodesView && (
-            <EpisodeCard data={latestEpisode} label="Latest Edition" />
+            <EpisodeCard data={latestEpisode} label="Latest Episode" />
           )}
           {ctaInlineTop && (
             <Box mt={3}>
@@ -321,7 +321,7 @@ export const Program = () => {
       children: (
         <Box mt={3}>
           {latestEpisode && !isEpisodesView && (
-            <SidebarEpisode data={latestEpisode} label="Latest Edition" />
+            <SidebarEpisode data={latestEpisode} label="Latest Episode" />
           )}
           <Box mt={2}>
             <Sidebar item elevated>

--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -187,7 +187,7 @@ export const Term = () => {
             </>
           )}
           {isEpisodesView && (
-            <EpisodeCard data={latestEpisode} label="Latest Edition" />
+            <EpisodeCard data={latestEpisode} label="Latest Episode" />
           )}
           {ctaInlineTop && (
             <Box mt={3}>
@@ -295,7 +295,7 @@ export const Term = () => {
                 ...latestEpisode,
                 program: data
               }}
-              label="Latest Edition"
+              label="Latest Episode"
             />
           )}
           {ctaSidebarTop && (


### PR DESCRIPTION
Closes #279 

- Updates the styles of episode cards as presented throughout the site.

## To Review

- [ ] Use the Preview link https://feat-episode-card-update.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] View the episode card on the homepage. Ensure it looks okay
- [x] go to /programs/the-world?=episodes and ensure card style reflects changes.
