### PR TITLE
Story Card Updates

### DIFF
--- a/components/LandingPage/LandingPage.tsx
+++ b/components/LandingPage/LandingPage.tsx
@@ -4,18 +4,32 @@
  */
 
 import React, { Fragment, ReactNode } from 'react';
-import { Container, Grid, Hidden } from '@material-ui/core';
+import {
+  Box,
+  BoxProps,
+  Container,
+  Grid,
+  GridSpacing,
+  Hidden
+} from '@material-ui/core';
 
 export interface ILandingPageItem {
   key: string;
   children: ReactNode;
 }
-export interface ILandingPageProps {
+export interface ILandingPageProps extends BoxProps {
   main: ILandingPageItem[];
   sidebar: ILandingPageItem[];
+  spacing?: GridSpacing;
 }
 
-export const LandingPage = ({ main, sidebar }: ILandingPageProps) => {
+export const LandingPage = ({
+  main,
+  sidebar,
+  spacing,
+  gridGap,
+  ...other
+}: ILandingPageProps) => {
   const max = Math.max(main.length, sidebar.length);
   const mainItems = [];
 
@@ -33,23 +47,29 @@ export const LandingPage = ({ main, sidebar }: ILandingPageProps) => {
   }
 
   return (
-    <Container fixed>
-      <Grid container spacing={3}>
-        <Grid item xs={12} md={8}>
-          {mainItems.map(
-            ({ key, children }: ILandingPageItem) =>
-              children && <Fragment key={key}>{children}</Fragment>
-          )}
+    <Box {...other}>
+      <Container fixed>
+        <Grid container spacing={spacing || 3}>
+          <Grid item xs={12} md={8}>
+            <Box display="grid" gridGap={gridGap}>
+              {mainItems.map(
+                ({ key, children }: ILandingPageItem) =>
+                  children && <Fragment key={key}>{children}</Fragment>
+              )}
+            </Box>
+          </Grid>
+          <Grid item xs md={4}>
+            <Hidden smDown implementation="css">
+              <Box display="grid" gridGap={gridGap}>
+                {sidebar.map(
+                  ({ key, children }: ILandingPageItem) =>
+                    children && <Fragment key={key}>{children}</Fragment>
+                )}
+              </Box>
+            </Hidden>
+          </Grid>
         </Grid>
-        <Grid item xs md={4}>
-          <Hidden smDown implementation="css">
-            {sidebar.map(
-              ({ key, children }: ILandingPageItem) =>
-                children && <Fragment key={key}>{children}</Fragment>
-            )}
-          </Hidden>
-        </Grid>
-      </Grid>
-    </Container>
+      </Container>
+    </Box>
   );
 };

--- a/components/Sidebar/Sidebar.styles.ts
+++ b/components/Sidebar/Sidebar.styles.ts
@@ -14,11 +14,7 @@ export const sidebarStyles = makeStyles((theme: Theme) =>
     container: {
       justifyContent: 'stretch'
     },
-    item: {
-      '& + &': {
-        marginTop: theme.spacing(2)
-      }
-    },
+    item: {},
     stretch: {
       flexGrow: 1,
       justifyContent: 'center'

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -15,7 +15,7 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {},
     title: {
-      marginTop: theme.typography.pxToRem(theme.spacing(1)),
+      marginTop: '0',
       [theme.breakpoints.down('xs')]: {
         fontSize: theme.typography.pxToRem(16),
         '$feature &': {
@@ -61,37 +61,23 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
     }),
     MuiCardActionAreaRoot: {
       display: 'grid',
-      gridTemplateColumns: '1fr 1fr',
+      gridTemplateColumns: '150px 2fr',
       gridGap: `${theme.spacing(2)}px`,
-      alignItems: 'start',
+      alignItems: 'center',
       padding: `${theme.spacing(2)}px`,
-      [theme.breakpoints.down('xs')]: {
-        display: 'flex',
-        flexDirection: 'column'
-      },
-      '$noImage &': {},
-      '$short &': {
-        gridTemplateColumns: '1fr 2fr'
-      },
       '$feature &': {
-        display: 'flex',
-        gridGap: 0,
-        flexDirection: 'column',
-        alignItems: 'stretch',
-        justifyContent: 'start',
-        height: '100%',
-        padding: 0
+        gridTemplateColumns: '1fr 1fr'
       }
     },
     MuiCardContentRoot: {
       overflow: 'hidden',
-      padding: 0,
-      '$feature &': {
-        padding: `${theme.spacing(2)}px`
-      }
+      padding: 0
     },
     MuiCardMediaRoot: {
-      paddingTop: `${100 / (16 / 9)}%`,
+      paddingTop: `${100 / (1 / 1)}%`,
+      '$feature &': {
+        paddingTop: `${100 / (16 / 9)}%`
+      },
       [theme.breakpoints.down('xs')]: {
         alignSelf: 'start'
       }

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -58,13 +58,10 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
       alignItems: 'center',
       padding: `${theme.spacing(2)}px`,
       '$feature &': {
-        gridTemplateColumns: '1fr 1fr'
+        gridTemplateColumns: '1fr'
       },
       [theme.breakpoints.down('sm')]: {
-        gridTemplateColumns: '1fr 2fr',
-        '$feature &': {
-          gridTemplateColumns: '1fr'
-        }
+        gridTemplateColumns: '1fr 2fr'
       }
     },
     MuiCardContentRoot: {
@@ -74,10 +71,13 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
     MuiCardMediaRoot: {
       paddingTop: `${100 / (1 / 1)}%`,
       '$feature &': {
-        paddingTop: `${100 / (16 / 9)}%`
+        paddingTop: `${100 / (3 / 1)}%`
       },
       [theme.breakpoints.down('sm')]: {
-        alignSelf: 'start'
+        alignSelf: 'start',
+        '$feature &': {
+          paddingTop: `${100 / (16 / 9)}%`
+        }
       }
     },
     feature: {},

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -13,7 +13,12 @@ import { addCssColorAlpha } from '@lib/parse/color';
 
 export const storyCardStyles = makeStyles((theme: Theme) =>
   createStyles({
-    root: {},
+    root: {
+      '& > * + *': {
+        display: 'grid',
+        marginTop: 0
+      }
+    },
     title: {
       marginTop: 0,
       fontSize: theme.typography.pxToRem(20),
@@ -58,7 +63,7 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
       [theme.breakpoints.down('sm')]: {
         gridTemplateColumns: '1fr 2fr',
         '$feature &': {
-          gridTemplateColumns: '1fr 2fr'
+          gridTemplateColumns: '1fr'
         }
       }
     },
@@ -71,7 +76,7 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
       '$feature &': {
         paddingTop: `${100 / (16 / 9)}%`
       },
-      [theme.breakpoints.down('xs')]: {
+      [theme.breakpoints.down('sm')]: {
         alignSelf: 'start'
       }
     },

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -70,15 +70,12 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
       padding: 0
     },
     MuiCardMediaRoot: {
-      paddingTop: `${100 / (1 / 1)}%`,
+      paddingTop: '100%',
       '$feature &': {
         paddingTop: `${100 / (16 / 9)}%`
       },
       [theme.breakpoints.down('sm')]: {
-        alignSelf: 'start',
-        '$feature &': {
-          paddingTop: `${100 / (16 / 9)}%`
-        }
+        alignSelf: 'start'
       }
     },
     feature: {},

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -108,7 +108,9 @@ export const storyCardTheme = (theme: Theme) =>
       },
       MuiCard: {
         root: {
-          color: theme.palette.primary.main
+          color: theme.palette.primary.main,
+          marginTop: 0,
+          borderTop: `1px solid ${theme.palette.grey[200]}`
         }
       },
       MuiCardActions: {

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -67,7 +67,10 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
       padding: 0
     },
     MuiCardMediaRoot: {
-      paddingTop: `${100 / (16 / 9)}%`,
+      paddingTop: `${100 / (1 / 1)}%`,
+      '$feature &': {
+        paddingTop: `${100 / (16 / 9)}%`
+      },
       [theme.breakpoints.down('xs')]: {
         alignSelf: 'start'
       }

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -15,23 +15,10 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {},
     title: {
-      marginTop: '0',
-      [theme.breakpoints.down('xs')]: {
-        fontSize: theme.typography.pxToRem(16),
-        '$feature &': {
-          fontSize: theme.typography.pxToRem(22)
-        }
-      }
-    },
-    teaser: {
-      '$feature &': {
+      marginTop: 0,
+      fontSize: theme.typography.pxToRem(20),
+      [theme.breakpoints.down('sm')]: {
         fontSize: theme.typography.pxToRem(18)
-      },
-      [theme.breakpoints.down('xs')]: {
-        display: 'none',
-        '$feature &': {
-          display: 'initial'
-        }
       }
     },
     imageWrapper: {
@@ -61,12 +48,18 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
     }),
     MuiCardActionAreaRoot: {
       display: 'grid',
-      gridTemplateColumns: '150px 2fr',
+      gridTemplateColumns: '1fr 3fr',
       gridGap: `${theme.spacing(2)}px`,
       alignItems: 'center',
       padding: `${theme.spacing(2)}px`,
       '$feature &': {
         gridTemplateColumns: '1fr 1fr'
+      },
+      [theme.breakpoints.down('sm')]: {
+        gridTemplateColumns: '1fr 2fr',
+        '$feature &': {
+          gridTemplateColumns: '1fr 2fr'
+        }
       }
     },
     MuiCardContentRoot: {
@@ -74,10 +67,7 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
       padding: 0
     },
     MuiCardMediaRoot: {
-      paddingTop: `${100 / (1 / 1)}%`,
-      '$feature &': {
-        paddingTop: `${100 / (16 / 9)}%`
-      },
+      paddingTop: `${100 / (16 / 9)}%`,
       [theme.breakpoints.down('xs')]: {
         alignSelf: 'start'
       }
@@ -96,8 +86,9 @@ export const storyCardTheme = (theme: Theme) =>
         lineHeight: 1.1
       },
       overline: {
-        display: 'block',
+        display: 'flex',
         position: 'relative',
+        alignItems: 'center',
         zIndex: 1,
         fontFamily:
           '"Open Sans","Helvetica Neue",Helvetica,Arial,"Nimbus Sans L",sans-serif',
@@ -174,7 +165,7 @@ export const storyCardTheme = (theme: Theme) =>
       },
       MuiTypography: {
         gutterBottom: {
-          marginBottom: theme.typography.pxToRem(theme.spacing(1.5))
+          marginBottom: theme.typography.pxToRem(theme.spacing(0.5))
         }
       }
     }

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -24,7 +24,8 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
       fontSize: theme.typography.pxToRem(20),
       [theme.breakpoints.down('sm')]: {
         fontSize: theme.typography.pxToRem(18)
-      }
+      },
+      lineHeight: '1.3'
     },
     imageWrapper: {
       position: 'absolute',
@@ -71,7 +72,7 @@ export const storyCardStyles = makeStyles((theme: Theme) =>
     MuiCardMediaRoot: {
       paddingTop: `${100 / (1 / 1)}%`,
       '$feature &': {
-        paddingTop: `${100 / (3 / 1)}%`
+        paddingTop: `${100 / (16 / 9)}%`
       },
       [theme.breakpoints.down('sm')]: {
         alignSelf: 'start',

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -51,6 +51,7 @@ export const StoryCard = ({
   const [isLoading, setIsLoading] = useState(false);
   const {
     title,
+    teaser,
     image,
     primaryCategory,
     crossLinks,
@@ -169,6 +170,14 @@ export const StoryCard = ({
                 </Grid>
               )}
             </Grid>
+            <Typography
+              variant="body1"
+              component="p"
+              color="textSecondary"
+              className={classes.teaser}
+            >
+              {teaser}
+            </Typography>
           </CardContent>
           <ContentLink data={data} className={cx('link')} />
         </CardActionArea>

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -137,21 +137,20 @@ export const StoryCard = ({
             </CardMedia>
           )}
           <CardContent classes={{ root: classes.MuiCardContentRoot }}>
+            <Typography
+              variant="h5"
+              component="h2"
+              gutterBottom
+              className={classes.title}
+            >
+              {title}
+            </Typography>
             <Grid
               container
-              justify="space-between"
+              justify="flex-start"
               spacing={1}
               style={{ marginBottom: 0 }}
             >
-              {primaryCategory && (
-                <Grid item xs="auto" zeroMinWidth>
-                  <Typography variant="overline" noWrap>
-                    <ContentLink data={primaryCategory}>
-                      {primaryCategory.title}
-                    </ContentLink>
-                  </Typography>
-                </Grid>
-              )}
               <Grid item xs="auto" zeroMinWidth>
                 <Typography
                   variant="subtitle2"
@@ -164,23 +163,16 @@ export const StoryCard = ({
                   </Moment>
                 </Typography>
               </Grid>
+              {primaryCategory && (
+                <Grid item xs="auto" zeroMinWidth>
+                  <Typography variant="overline" noWrap>
+                    <ContentLink data={primaryCategory}>
+                      {primaryCategory.title}
+                    </ContentLink>
+                  </Typography>
+                </Grid>
+              )}
             </Grid>
-            <Typography
-              variant="h5"
-              component="h2"
-              gutterBottom
-              className={classes.title}
-            >
-              {title}
-            </Typography>
-            <Typography
-              variant="body1"
-              component="p"
-              color="textSecondary"
-              className={classes.teaser}
-            >
-              {teaser}
-            </Typography>
           </CardContent>
           <ContentLink data={data} className={cx('link')} />
         </CardActionArea>

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -25,6 +25,7 @@ import {
   ListItemText,
   Typography
 } from '@material-ui/core';
+import { Label } from '@material-ui/icons';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { ContentLink } from '@components/ContentLink';
 import { ILink } from '@interfaces/link';
@@ -49,7 +50,6 @@ export const StoryCard = ({
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const {
-    teaser,
     title,
     image,
     primaryCategory,
@@ -152,12 +152,7 @@ export const StoryCard = ({
               style={{ marginBottom: 0 }}
             >
               <Grid item xs="auto" zeroMinWidth>
-                <Typography
-                  variant="subtitle2"
-                  component="span"
-                  color="textSecondary"
-                  noWrap
-                >
+                <Typography component="span">
                   <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
                     {dateBroadcast || datePublished}
                   </Moment>
@@ -166,6 +161,7 @@ export const StoryCard = ({
               {primaryCategory && (
                 <Grid item xs="auto" zeroMinWidth>
                   <Typography variant="overline" noWrap>
+                    <Label color="secondary" className={cx('labelIcon')} />
                     <ContentLink data={primaryCategory}>
                       {primaryCategory.title}
                     </ContentLink>

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -170,12 +170,7 @@ export const StoryCard = ({
                 </Grid>
               )}
             </Grid>
-            <Typography
-              variant="body1"
-              component="p"
-              color="textSecondary"
-              className={classes.teaser}
-            >
+            <Typography variant="body1" component="p" color="textSecondary">
               {teaser}
             </Typography>
           </CardContent>

--- a/components/StoryCardGrid/StoryCardGrid.styles.ts
+++ b/components/StoryCardGrid/StoryCardGrid.styles.ts
@@ -13,18 +13,10 @@ import {
 export const storyCardGridStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      '& > * + *': {
-        display: 'grid',
-        marginTop: 0
-      },
+      display: 'grid',
+      gridTemplateColumns: '1fr',
       [theme.breakpoints.up('sm')]: {
-        display: 'grid',
-        gridTemplateColumns: '1fr 1fr',
-        marginTop: 0,
-        gridGap: 0,
-        '& > * + *': {
-          marginTop: 0
-        }
+        gridTemplateColumns: '1fr 1fr'
       }
     },
     loadingBar: {
@@ -37,6 +29,9 @@ export const storyCardGridStyles = makeStyles((theme: Theme) =>
     },
     isLoading: {
       transform: 'translateY(-100%)'
+    },
+    title: {
+      fontSize: theme.typography.pxToRem(18)
     }
   })
 );
@@ -46,10 +41,7 @@ export const storyCardGridTheme = (theme: Theme) =>
     overrides: {
       MuiCard: {
         root: {
-          borderTop: `1px solid ${theme.palette.grey[200]}`,
-          '&:nth-child( odd )': {
-            borderRight: `1px solid ${theme.palette.grey[200]}`
-          }
+          display: 'grid'
         }
       },
       MuiCardActionArea: {
@@ -70,7 +62,7 @@ export const storyCardGridTheme = (theme: Theme) =>
         root: {
           alignSelf: 'center',
           height: 'auto',
-          paddingTop: `${100 / (1 / 1)}%`
+          paddingTop: '100%'
         }
       }
     }

--- a/components/StoryCardGrid/StoryCardGrid.styles.ts
+++ b/components/StoryCardGrid/StoryCardGrid.styles.ts
@@ -9,18 +9,20 @@ import {
   makeStyles,
   Theme
 } from '@material-ui/core/styles';
+import { yellow } from '@theme/colors';
 
 export const storyCardGridStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       '& > * + *': {
         display: 'grid',
-        marginTop: `${theme.spacing(0)}px`
+        marginTop: 0
       },
       [theme.breakpoints.up('sm')]: {
         display: 'grid',
         gridTemplateColumns: '1fr 1fr',
-        gridGap: `${theme.spacing(0)}px`,
+        marginTop: 0,
+        gridGap: 0,
         '& > * + *': {
           marginTop: 0
         }
@@ -42,12 +44,15 @@ export const storyCardGridStyles = makeStyles((theme: Theme) =>
 
 export const storyCardGridTheme = (theme: Theme) =>
   createMuiTheme(theme, {
-    typography: {
-      h5: {
-        fontSize: theme.typography.pxToRem(16)
-      }
-    },
     overrides: {
+      MuiCard: {
+        root: {
+          borderTop: `1px solid ${theme.palette.grey[200]}`,
+          '&:nth-child( odd )': {
+            borderRight: `1px solid ${theme.palette.grey[200]}`
+          }
+        }
+      },
       MuiCardActionArea: {
         root: {
           display: 'grid',

--- a/components/StoryCardGrid/StoryCardGrid.styles.ts
+++ b/components/StoryCardGrid/StoryCardGrid.styles.ts
@@ -31,7 +31,7 @@ export const storyCardGridStyles = makeStyles((theme: Theme) =>
       transform: 'translateY(-100%)'
     },
     title: {
-      fontSize: theme.typography.pxToRem(18)
+      fontSize: theme.typography.pxToRem(16)
     }
   })
 );

--- a/components/StoryCardGrid/StoryCardGrid.styles.ts
+++ b/components/StoryCardGrid/StoryCardGrid.styles.ts
@@ -9,7 +9,6 @@ import {
   makeStyles,
   Theme
 } from '@material-ui/core/styles';
-import { yellow } from '@theme/colors';
 
 export const storyCardGridStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -59,7 +58,7 @@ export const storyCardGridTheme = (theme: Theme) =>
           gridTemplateColumns: '1fr 2fr',
           gridGap: `${theme.spacing(2)}px`,
           alignItems: 'center',
-          padding: `${theme.spacing(2)}px`,
+          padding: `${theme.spacing(2)}px`
         }
       },
       MuiCardContent: {

--- a/components/StoryCardGrid/StoryCardGrid.styles.ts
+++ b/components/StoryCardGrid/StoryCardGrid.styles.ts
@@ -14,12 +14,13 @@ export const storyCardGridStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       '& > * + *': {
-        marginTop: `${theme.spacing(2)}px`
+        display: 'grid',
+        marginTop: `${theme.spacing(0)}px`
       },
       [theme.breakpoints.up('sm')]: {
         display: 'grid',
         gridTemplateColumns: '1fr 1fr',
-        gridGap: `${theme.spacing(2)}px`,
+        gridGap: `${theme.spacing(0)}px`,
         '& > * + *': {
           marginTop: 0
         }
@@ -49,29 +50,23 @@ export const storyCardGridTheme = (theme: Theme) =>
     overrides: {
       MuiCardActionArea: {
         root: {
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'start',
-          alignItems: 'stretch',
-          height: '100%',
-          [theme.breakpoints.down('xs')]: {
-            gridGap: `${theme.spacing(2)}px`,
-            padding: `${theme.spacing(2)}px`
-          }
+          display: 'grid',
+          gridTemplateColumns: '1fr 2fr',
+          gridGap: `${theme.spacing(2)}px`,
+          alignItems: 'center',
+          padding: `${theme.spacing(2)}px`,
         }
       },
       MuiCardContent: {
         root: {
-          [theme.breakpoints.down('xs')]: {
-            padding: 0
-          }
+          padding: 0
         }
       },
       MuiCardMedia: {
         root: {
-          alignSelf: 'start',
+          alignSelf: 'center',
           height: 'auto',
-          paddingTop: `${100 / (16 / 9)}%`
+          paddingTop: `${100 / (1 / 1)}%`
         }
       }
     }

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -27,6 +27,7 @@ import {
   ListItemText,
   Typography
 } from '@material-ui/core';
+import { Label } from '@material-ui/icons';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { ContentLink } from '@components/ContentLink';
 import { ILink } from '@interfaces/link';
@@ -139,38 +140,6 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                     </CardMedia>
                   )}
                   <CardContent>
-                    <Grid
-                      container
-                      justify="space-between"
-                      spacing={1}
-                      style={{ marginBottom: 0 }}
-                    >
-                      {primaryCategory && (
-                        <Grid item xs="auto" zeroMinWidth>
-                          <Typography variant="overline" noWrap>
-                            <ContentLink data={primaryCategory}>
-                              {primaryCategory.title}
-                            </ContentLink>
-                          </Typography>
-                        </Grid>
-                      )}
-                      <Grid item xs="auto" zeroMinWidth>
-                        <Typography
-                          variant="subtitle2"
-                          component="span"
-                          color="textSecondary"
-                          noWrap
-                        >
-                          <Moment
-                            format="MMM. D, YYYY"
-                            tz="America/New_York"
-                            unix
-                          >
-                            {dateBroadcast || datePublished}
-                          </Moment>
-                        </Typography>
-                      </Grid>
-                    </Grid>
                     <Typography
                       variant="h5"
                       component="h2"
@@ -179,6 +148,30 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                     >
                       {title}
                     </Typography>
+                    <Grid
+                      container
+                      justify="flex-start"
+                      spacing={1}
+                      style={{ marginBottom: 0 }}
+                    >
+                      <Grid item xs="auto" zeroMinWidth>
+                        <Typography component="span">
+                          <Moment format="MMMM D, YYYY" tz="America/New_York"  unix>
+                            {dateBroadcast || datePublished}
+                          </Moment>
+                        </Typography>
+                      </Grid>
+                      {primaryCategory && (
+                        <Grid item xs="auto" zeroMinWidth>
+                          <Typography variant="overline" noWrap>
+                            <Label color="secondary" className={cx('labelIcon')} />
+                            <ContentLink data={primaryCategory}>
+                              {primaryCategory.title}
+                            </ContentLink>
+                          </Typography>
+                        </Grid>
+                      )}
+                    </Grid>
                     <ContentLink data={item} className={cxCard('link')} />
                   </CardContent>
                 </CardActionArea>

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -118,7 +118,7 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
             const { pathname } = generateLinkHrefForContent(item);
             const isLoading = pathname === loadingUrl;
             return (
-              <Card square elevation={1} key={id}>
+              <Card square key={id}>
                 <CardActionArea>
                   {image && (
                     <CardMedia>
@@ -144,7 +144,7 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                       variant="h5"
                       component="h2"
                       gutterBottom
-                      className={cxCard('title')}
+                      className={cx('title')}
                     >
                       {title}
                     </Typography>

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -156,7 +156,11 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                     >
                       <Grid item xs="auto" zeroMinWidth>
                         <Typography component="span">
-                          <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
+                          <Moment
+                            format="MMMM D, YYYY"
+                            tz="America/New_York"
+                            unix
+                          >
                             {dateBroadcast || datePublished}
                           </Moment>
                         </Typography>

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -156,7 +156,7 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                     >
                       <Grid item xs="auto" zeroMinWidth>
                         <Typography component="span">
-                          <Moment format="MMMM D, YYYY" tz="America/New_York"  unix>
+                          <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
                             {dateBroadcast || datePublished}
                           </Moment>
                         </Typography>
@@ -164,7 +164,7 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                       {primaryCategory && (
                         <Grid item xs="auto" zeroMinWidth>
                           <Typography variant="overline" noWrap>
-                            <Label color="secondary" className={cx('labelIcon')} />
+                            <Label color="secondary" />
                             <ContentLink data={primaryCategory}>
                               {primaryCategory.title}
                             </ContentLink>

--- a/components/pages/Category/Category.tsx
+++ b/components/pages/Category/Category.tsx
@@ -157,44 +157,46 @@ export const Category = () => {
     {
       key: 'main top',
       children: (
-        <Box mt={3}>
-          {featuredStory && <StoryCard data={featuredStory} feature priority />}
-          {featuredStories && (
-            <StoryCardGrid data={featuredStories[1]} mt={0} />
-          )}
+        <>
+          <Box display="grid" gridGap={8}>
+            {featuredStory && (
+              <StoryCard data={featuredStory} feature priority />
+            )}
+            {featuredStories && (
+              <StoryCardGrid data={featuredStories[1]} gridGap={8} />
+            )}
+          </Box>
           {ctaInlineTop && (
-            <Box mt={1} mb={1}>
+            <>
               <Hidden xsDown>
                 <CtaRegion data={ctaInlineTop} />
               </Hidden>
               <Hidden smUp>
                 <SidebarCta data={ctaInlineTop} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     },
     {
       key: 'main bottom',
       children: (
-        <Box mt={0}>
+        <>
           {stories &&
             stories
               .reduce((a, p) => [...a, ...p], [])
               .map((item: IPriApiResource) => (
-                <Box mt={0} key={item.id}>
-                  <StoryCard
-                    data={item}
-                    feature={
-                      item.displayTemplate &&
-                      item.displayTemplate !== 'standard'
-                    }
-                  />
-                </Box>
+                <StoryCard
+                  data={item}
+                  feature={
+                    item.displayTemplate && item.displayTemplate !== 'standard'
+                  }
+                  key={item.id}
+                />
               ))}
           {next && (
-            <Box mt={1}>
+            <Box>
               <Button
                 variant="contained"
                 size="large"
@@ -210,16 +212,16 @@ export const Category = () => {
             </Box>
           )}
           {ctaInlineBottom && (
-            <Box mt={1} mb={1}>
+            <>
               <Hidden xsDown>
                 <CtaRegion data={ctaInlineBottom} />
               </Hidden>
               <Hidden smUp>
                 <SidebarCta data={ctaInlineBottom} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     }
   ];
@@ -228,72 +230,70 @@ export const Category = () => {
     {
       key: 'sidebar top',
       children: (
-        <Box mt={3}>
-          <Box mt={2}>
-            <Sidebar item elevated>
-              {body && (
-                <SidebarContent>
-                  <HtmlContent html={body} />
-                </SidebarContent>
-              )}
-              {hosts && !!hosts.length && (
-                <SidebarList
-                  data={hosts.map((item: IPriApiResource) => ({
-                    ...item,
-                    avatar: item.image
-                  }))}
-                  subheader={<ListSubheader>Hosted by</ListSubheader>}
-                />
-              )}
-              {sponsors && !!sponsors.length && (
-                <SidebarList
-                  data={sponsors}
-                  subheader={<ListSubheader>Supported by</ListSubheader>}
-                />
-              )}
-              {children && !!children.length && (
-                <SidebarList
-                  data={children}
-                  subheader={
-                    <SidebarHeader>
-                      <Typography variant="h2">
-                        <ListAltRounded /> Subcategories
-                      </Typography>
-                    </SidebarHeader>
-                  }
-                />
-              )}
-            </Sidebar>
-          </Box>
+        <>
+          <Sidebar item elevated>
+            {body && (
+              <SidebarContent>
+                <HtmlContent html={body} />
+              </SidebarContent>
+            )}
+            {hosts && !!hosts.length && (
+              <SidebarList
+                data={hosts.map((item: IPriApiResource) => ({
+                  ...item,
+                  avatar: item.image
+                }))}
+                subheader={<ListSubheader>Hosted by</ListSubheader>}
+              />
+            )}
+            {sponsors && !!sponsors.length && (
+              <SidebarList
+                data={sponsors}
+                subheader={<ListSubheader>Supported by</ListSubheader>}
+              />
+            )}
+            {children && !!children.length && (
+              <SidebarList
+                data={children}
+                subheader={
+                  <SidebarHeader>
+                    <Typography variant="h2">
+                      <ListAltRounded /> Subcategories
+                    </Typography>
+                  </SidebarHeader>
+                }
+              />
+            )}
+          </Sidebar>
           {ctaSidebarTop && (
-            <Box mt={3}>
+            <>
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarTop} />
               </Hidden>
               <Hidden xsDown mdUp>
                 <CtaRegion data={ctaSidebarTop} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     },
     {
       key: 'sidebar bottom',
       children: (
-        <Box mt={3}>
+        <>
           <SidebarLatestStories />
           {ctaSidebarBottom && (
-            <Box mt={3}>
+            <>
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarBottom} />
               </Hidden>
               <Hidden xsDown mdUp>
                 <CtaRegion data={ctaSidebarBottom} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     }
   ];
@@ -308,7 +308,12 @@ export const Category = () => {
         image={bannerImage}
         logo={logo}
       />
-      <LandingPage main={mainElements} sidebar={sidebarElements} />
+      <LandingPage
+        main={mainElements}
+        sidebar={sidebarElements}
+        mt={3}
+        gridGap={8}
+      />
     </>
   );
 };

--- a/components/pages/Category/Category.tsx
+++ b/components/pages/Category/Category.tsx
@@ -160,10 +160,10 @@ export const Category = () => {
         <Box mt={3}>
           {featuredStory && <StoryCard data={featuredStory} feature priority />}
           {featuredStories && (
-            <StoryCardGrid data={featuredStories[1]} mt={2} />
+            <StoryCardGrid data={featuredStories[1]} mt={0} />
           )}
           {ctaInlineTop && (
-            <Box mt={3}>
+            <Box mt={1} mb={1}>
               <Hidden xsDown>
                 <CtaRegion data={ctaInlineTop} />
               </Hidden>
@@ -178,12 +178,12 @@ export const Category = () => {
     {
       key: 'main bottom',
       children: (
-        <Box mt={3}>
+        <Box mt={0}>
           {stories &&
             stories
               .reduce((a, p) => [...a, ...p], [])
-              .map((item: IPriApiResource, index: number) => (
-                <Box mt={index ? 2 : 0} key={item.id}>
+              .map((item: IPriApiResource) => (
+                <Box mt={0} key={item.id}>
                   <StoryCard
                     data={item}
                     feature={
@@ -194,7 +194,7 @@ export const Category = () => {
                 </Box>
               ))}
           {next && (
-            <Box mt={3}>
+            <Box mt={1}>
               <Button
                 variant="contained"
                 size="large"
@@ -210,7 +210,7 @@ export const Category = () => {
             </Box>
           )}
           {ctaInlineBottom && (
-            <Box mt={3}>
+            <Box mt={1} mb={1}>
               <Hidden xsDown>
                 <CtaRegion data={ctaInlineBottom} />
               </Hidden>

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -197,7 +197,7 @@ export const Homepage = () => {
     {
       key: 'sidebar bottom',
       children: (
-        <Box>
+        <>
           {categoriesMenu && (
             <Sidebar item elevated>
               <SidebarHeader>
@@ -208,7 +208,7 @@ export const Homepage = () => {
               <SidebarList data={categoriesMenu} />
             </Sidebar>
           )}
-        </Box>
+        </>
       )
     },
     {

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -122,49 +122,50 @@ export const Homepage = () => {
     {
       key: 'main top',
       children: (
-        <Box mt={3}>
-          <StoryCard data={featuredStory} feature priority />
-          <StoryCardGrid data={featuredStories[1]} mt={0} />
+        <>
+          <Box display="grid" gridTemplateColumns="1fr" gridGap={8}>
+            <StoryCard data={featuredStory} feature priority />
+            <StoryCardGrid data={featuredStories[1]} gridGap={8} />
+          </Box>
           {inlineTop && (
-            <Box mt={1} mb={1}>
+            <>
               <Hidden xsDown>
                 <CtaRegion data={inlineTop} />
               </Hidden>
               <Hidden smUp>
                 <SidebarCta data={inlineTop} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     },
     {
       key: 'main bottom',
       children: (
-        <Box mt={0}>
+        <>
           {stories
             .reduce((a, p) => [...a, ...p], [])
             .map((item: IPriApiResource) => (
-              <Box mt={0} key={item.id}>
-                <StoryCard
-                  data={item}
-                  feature={
-                    item.displayTemplate && item.displayTemplate !== 'standard'
-                  }
-                />
-              </Box>
+              <StoryCard
+                data={item}
+                feature={
+                  item.displayTemplate && item.displayTemplate !== 'standard'
+                }
+                key={item.id}
+              />
             ))}
           {inlineBottom && (
-            <Box mt={1} mb={1}>
+            <>
               <Hidden xsDown>
                 <CtaRegion data={inlineBottom} />
               </Hidden>
               <Hidden smUp>
                 <SidebarCta data={inlineBottom} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     }
   ];
@@ -173,52 +174,50 @@ export const Homepage = () => {
     {
       key: 'sidebar top',
       children: (
-        <Box mt={3}>
+        <>
           <SidebarEpisode data={latestEpisode} label="Latest Edition" />
           {sidebarTop && (
-            <Box mt={3}>
+            <>
               <Hidden only="sm">
                 <SidebarCta data={sidebarTop} />
               </Hidden>
               <Hidden xsDown mdUp>
                 <CtaRegion data={sidebarTop} />
               </Hidden>
-            </Box>
+            </>
           )}
           {categoriesMenu && (
-            <Box mt={3}>
-              <Sidebar item elevated>
-                <SidebarHeader>
-                  <Typography variant="h2">
-                    <StyleRounded /> Categories
-                  </Typography>
-                </SidebarHeader>
-                <SidebarList data={categoriesMenu} />
-              </Sidebar>
-            </Box>
+            <Sidebar item elevated>
+              <SidebarHeader>
+                <Typography variant="h2">
+                  <StyleRounded /> Categories
+                </Typography>
+              </SidebarHeader>
+              <SidebarList data={categoriesMenu} />
+            </Sidebar>
           )}
-        </Box>
+        </>
       )
     },
     {
       key: 'sidebar bottom',
       children: (
-        <Box mt={3}>
+        <>
           <SidebarLatestStories
             data={latestStories[1]}
             label="Latest from our partners"
           />
           {sidebarBottom && (
-            <Box mt={3}>
+            <>
               <Hidden only="sm">
                 <SidebarCta data={sidebarBottom} />
               </Hidden>
               <Hidden xsDown mdUp>
                 <CtaRegion data={sidebarBottom} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     }
   ];
@@ -266,7 +265,12 @@ export const Homepage = () => {
     <>
       <MetaTags data={metatags} />
       <Plausible subject={{ type: 'homepage', id: null }} />
-      <LandingPage main={mainElements} sidebar={sidebarElements} />
+      <LandingPage
+        main={mainElements}
+        sidebar={sidebarElements}
+        mt={3}
+        gridGap={8}
+      />
     </>
   );
 };

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -181,25 +181,23 @@ export const Homepage = () => {
             <>
               <Hidden only="sm">
                 <SidebarCta data={sidebarTop} />
-              </Hidden>
-              <Box mt={3}>
                 <SidebarLatestStories
                   data={latestStories[1]}
                   label="Latest from our partners"
                 />
-              </Box>
+              </Hidden>
               <Hidden xsDown mdUp>
                 <CtaRegion data={sidebarTop} />
               </Hidden>
             </>
           )}
-        </Box>
+        </>
       )
     },
     {
       key: 'sidebar bottom',
       children: (
-        <Box mt={3}>
+        <Box>
           {categoriesMenu && (
             <Sidebar item elevated>
               <SidebarHeader>
@@ -210,17 +208,13 @@ export const Homepage = () => {
               <SidebarList data={categoriesMenu} />
             </Sidebar>
           )}
-        </>
+        </Box>
       )
     },
     {
       key: 'sidebar bottom',
       children: (
         <>
-          <SidebarLatestStories
-            data={latestStories[1]}
-            label="Latest from our partners"
-          />
           {sidebarBottom && (
             <>
               <Hidden only="sm">

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -124,9 +124,9 @@ export const Homepage = () => {
       children: (
         <Box mt={3}>
           <StoryCard data={featuredStory} feature priority />
-          <StoryCardGrid data={featuredStories[1]} mt={2} />
+          <StoryCardGrid data={featuredStories[1]} mt={0} />
           {inlineTop && (
-            <Box mt={3}>
+            <Box mt={1} mb={1}>
               <Hidden xsDown>
                 <CtaRegion data={inlineTop} />
               </Hidden>
@@ -141,11 +141,11 @@ export const Homepage = () => {
     {
       key: 'main bottom',
       children: (
-        <Box mt={3}>
+        <Box mt={0}>
           {stories
             .reduce((a, p) => [...a, ...p], [])
-            .map((item: IPriApiResource, index: number) => (
-              <Box mt={index ? 2 : 0} key={item.id}>
+            .map((item: IPriApiResource) => (
+              <Box mt={0} key={item.id}>
                 <StoryCard
                   data={item}
                   feature={
@@ -155,7 +155,7 @@ export const Homepage = () => {
               </Box>
             ))}
           {inlineBottom && (
-            <Box mt={3}>
+            <Box mt={1} mb={1}>
               <Hidden xsDown>
                 <CtaRegion data={inlineBottom} />
               </Hidden>

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -176,7 +176,7 @@ export const Homepage = () => {
       key: 'sidebar top',
       children: (
         <>
-          <SidebarEpisode data={latestEpisode} label="Latest Edition" />
+          <SidebarEpisode data={latestEpisode} label="Latest Episode" />
           {sidebarTop && (
             <>
               <Hidden only="sm">

--- a/components/pages/Program/Program.tsx
+++ b/components/pages/Program/Program.tsx
@@ -201,60 +201,59 @@ export const Program = () => {
     {
       key: 'main top',
       children: (
-        <Box mt={3}>
+        <>
           {body && !hasContentLinks && (
             <Box className={classes.body}>
               <HtmlContent html={body} />
             </Box>
           )}
           {!isEpisodesView && (
-            <>
+            <Box display="grid" gridGap={8}>
               {featuredStory && (
                 <StoryCard data={featuredStory} feature priority />
               )}
               {featuredStories && (
-                <StoryCardGrid data={featuredStories[1]} mt={0} />
+                <StoryCardGrid data={featuredStories[1]} gridGap={8} />
               )}
-            </>
+            </Box>
           )}
           {isEpisodesView && (
             <EpisodeCard data={latestEpisode} label="Latest Edition" />
           )}
           {ctaInlineTop && (
-            <Box mt={1} mb={1}>
+            <>
               <Hidden xsDown>
                 <CtaRegion data={ctaInlineTop} />
               </Hidden>
               <Hidden smUp>
                 <SidebarCta data={ctaInlineTop} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     },
     {
       key: 'main bottom',
       children: (
-        <Box mt={0}>
+        <>
           {!isEpisodesView && (
             <>
               {stories &&
                 stories
                   .reduce((a, p) => [...a, ...p], [])
                   .map((item: IPriApiResource) => (
-                    <Box mt={0} key={item.id}>
-                      <StoryCard
-                        data={item}
-                        feature={
-                          item.displayTemplate &&
-                          item.displayTemplate !== 'standard'
-                        }
-                      />
-                    </Box>
+                    <StoryCard
+                      data={item}
+                      feature={
+                        item.displayTemplate &&
+                        item.displayTemplate !== 'standard'
+                      }
+                      key={item.id}
+                    />
                   ))}
               {next && (
-                <Box mt={0}>
+                <Box>
                   <Button
                     variant="contained"
                     size="large"
@@ -277,12 +276,10 @@ export const Program = () => {
               {episodes
                 .reduce((a, p) => [...a, ...p], [])
                 .map((item: IPriApiResource) => (
-                  <Box mt={0} key={item.id}>
-                    <EpisodeCard data={item} />
-                  </Box>
+                  <EpisodeCard data={item} key={item.id} />
                 ))}
               {episodesNext && (
-                <Box mt={3}>
+                <Box>
                   <Button
                     variant="contained"
                     size="large"
@@ -301,16 +298,16 @@ export const Program = () => {
             </>
           )}
           {ctaInlineBottom && (
-            <Box mt={1} mb={1}>
+            <>
               <Hidden xsDown>
                 <CtaRegion data={ctaInlineBottom} />
               </Hidden>
               <Hidden smUp>
                 <SidebarCta data={ctaInlineBottom} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     }
   ];
@@ -319,63 +316,61 @@ export const Program = () => {
     {
       key: 'sidebar top',
       children: (
-        <Box mt={3}>
+        <>
           {latestEpisode && !isEpisodesView && (
             <SidebarEpisode data={latestEpisode} label="Latest Edition" />
           )}
-          <Box mt={2}>
-            <Sidebar item elevated>
-              {body && hasContentLinks && (
-                <SidebarContent>
-                  <HtmlContent html={body} />
-                </SidebarContent>
-              )}
-              {hosts && !!hosts.length && (
-                <SidebarList
-                  data={hosts.map((item: IPriApiResource) => ({
-                    ...item,
-                    avatar: item.image
-                  }))}
-                  subheader={<ListSubheader>Hosted by</ListSubheader>}
-                />
-              )}
-              {sponsors && !!sponsors.length && (
-                <SidebarList
-                  data={sponsors}
-                  subheader={<ListSubheader>Supported by</ListSubheader>}
-                />
-              )}
-            </Sidebar>
-          </Box>
+          <Sidebar item elevated>
+            {body && hasContentLinks && (
+              <SidebarContent>
+                <HtmlContent html={body} />
+              </SidebarContent>
+            )}
+            {hosts && !!hosts.length && (
+              <SidebarList
+                data={hosts.map((item: IPriApiResource) => ({
+                  ...item,
+                  avatar: item.image
+                }))}
+                subheader={<ListSubheader>Hosted by</ListSubheader>}
+              />
+            )}
+            {sponsors && !!sponsors.length && (
+              <SidebarList
+                data={sponsors}
+                subheader={<ListSubheader>Supported by</ListSubheader>}
+              />
+            )}
+          </Sidebar>
           {ctaSidebarTop && (
-            <Box mt={3}>
+            <>
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarTop} />
               </Hidden>
               <Hidden xsDown mdUp>
                 <CtaRegion data={ctaSidebarTop} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     },
     {
       key: 'sidebar bottom',
       children: (
-        <Box mt={3}>
+        <>
           <SidebarLatestStories />
           {ctaSidebarBottom && (
-            <Box mt={3}>
+            <>
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarBottom} />
               </Hidden>
               <Hidden xsDown mdUp>
                 <CtaRegion data={ctaSidebarBottom} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     }
   ];
@@ -413,7 +408,12 @@ export const Program = () => {
           </Container>
         </AppBar>
       )}
-      <LandingPage main={mainElements} sidebar={sidebarElements} />
+      <LandingPage
+        main={mainElements}
+        sidebar={sidebarElements}
+        mt={3}
+        gridGap={8}
+      />
     </ThemeProvider>
   );
 };

--- a/components/pages/Program/Program.tsx
+++ b/components/pages/Program/Program.tsx
@@ -213,7 +213,7 @@ export const Program = () => {
                 <StoryCard data={featuredStory} feature priority />
               )}
               {featuredStories && (
-                <StoryCardGrid data={featuredStories[1]} mt={2} />
+                <StoryCardGrid data={featuredStories[1]} mt={0} />
               )}
             </>
           )}
@@ -221,7 +221,7 @@ export const Program = () => {
             <EpisodeCard data={latestEpisode} label="Latest Edition" />
           )}
           {ctaInlineTop && (
-            <Box mt={3}>
+            <Box mt={1} mb={1}>
               <Hidden xsDown>
                 <CtaRegion data={ctaInlineTop} />
               </Hidden>
@@ -236,14 +236,14 @@ export const Program = () => {
     {
       key: 'main bottom',
       children: (
-        <Box mt={3}>
+        <Box mt={0}>
           {!isEpisodesView && (
             <>
               {stories &&
                 stories
                   .reduce((a, p) => [...a, ...p], [])
-                  .map((item: IPriApiResource, index: number) => (
-                    <Box mt={index ? 2 : 0} key={item.id}>
+                  .map((item: IPriApiResource) => (
+                    <Box mt={0} key={item.id}>
                       <StoryCard
                         data={item}
                         feature={
@@ -254,7 +254,7 @@ export const Program = () => {
                     </Box>
                   ))}
               {next && (
-                <Box mt={3}>
+                <Box mt={0}>
                   <Button
                     variant="contained"
                     size="large"
@@ -276,8 +276,8 @@ export const Program = () => {
             <>
               {episodes
                 .reduce((a, p) => [...a, ...p], [])
-                .map((item: IPriApiResource, index: number) => (
-                  <Box mt={index ? 2 : 0} key={item.id}>
+                .map((item: IPriApiResource) => (
+                  <Box mt={0} key={item.id}>
                     <EpisodeCard data={item} />
                   </Box>
                 ))}
@@ -301,7 +301,7 @@ export const Program = () => {
             </>
           )}
           {ctaInlineBottom && (
-            <Box mt={3}>
+            <Box mt={1} mb={1}>
               <Hidden xsDown>
                 <CtaRegion data={ctaInlineBottom} />
               </Hidden>

--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -175,55 +175,54 @@ export const Term = () => {
     {
       key: 'main top',
       children: (
-        <Box mt={3}>
+        <>
           {!isEpisodesView && (
-            <>
+            <Box display="grid" gridGap={8}>
               {featuredStory && (
                 <StoryCard data={featuredStory} feature priority />
               )}
               {featuredStories && (
-                <StoryCardGrid data={featuredStories[1]} mt={2} />
+                <StoryCardGrid data={featuredStories[1]} gridGap={8} />
               )}
-            </>
+            </Box>
           )}
           {isEpisodesView && (
             <EpisodeCard data={latestEpisode} label="Latest Edition" />
           )}
           {ctaInlineTop && (
-            <Box mt={3}>
+            <>
               <Hidden xsDown>
                 <CtaRegion data={ctaInlineTop} />
               </Hidden>
               <Hidden smUp>
                 <SidebarCta data={ctaInlineTop} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     },
     {
       key: 'main bottom',
       children: (
-        <Box mt={3}>
+        <>
           {!isEpisodesView && (
             <>
               {stories &&
                 stories
                   .reduce((a, p) => [...a, ...p], [])
-                  .map((item: IPriApiResource, index: number) => (
-                    <Box mt={index ? 2 : 0} key={item.id}>
-                      <StoryCard
-                        data={item}
-                        feature={
-                          item.displayTemplate &&
-                          item.displayTemplate !== 'standard'
-                        }
-                      />
-                    </Box>
+                  .map((item: IPriApiResource) => (
+                    <StoryCard
+                      data={item}
+                      feature={
+                        item.displayTemplate &&
+                        item.displayTemplate !== 'standard'
+                      }
+                      key={item.id}
+                    />
                   ))}
               {next && (
-                <Box mt={3}>
+                <Box>
                   <Button
                     variant="contained"
                     size="large"
@@ -245,13 +244,11 @@ export const Term = () => {
             <>
               {episodes
                 .reduce((a, p) => [...a, ...p], [])
-                .map((item: IPriApiResource, index: number) => (
-                  <Box mt={index ? 2 : 0} key={item.id}>
-                    <EpisodeCard data={item} />
-                  </Box>
+                .map((item: IPriApiResource) => (
+                  <EpisodeCard data={item} key={item.id} />
                 ))}
               {episodesNext && (
-                <Box mt={3}>
+                <Box>
                   <Button
                     variant="contained"
                     size="large"
@@ -270,16 +267,16 @@ export const Term = () => {
             </>
           )}
           {ctaInlineBottom && (
-            <Box mt={3}>
+            <>
               <Hidden xsDown>
                 <CtaRegion data={ctaInlineBottom} />
               </Hidden>
               <Hidden smUp>
                 <SidebarCta data={ctaInlineBottom} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     }
   ];
@@ -288,7 +285,7 @@ export const Term = () => {
     {
       key: 'sidebar top',
       children: (
-        <Box mt={3}>
+        <>
           {latestEpisode && !isEpisodesView && (
             <SidebarEpisode
               data={{
@@ -299,34 +296,34 @@ export const Term = () => {
             />
           )}
           {ctaSidebarTop && (
-            <Box mt={3}>
+            <>
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarTop} />
               </Hidden>
               <Hidden xsDown mdUp>
                 <CtaRegion data={ctaSidebarTop} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     },
     {
       key: 'sidebar bottom',
       children: (
-        <Box mt={3}>
+        <>
           <SidebarLatestStories />
           {ctaSidebarBottom && (
-            <Box mt={3}>
+            <>
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarBottom} />
               </Hidden>
               <Hidden xsDown mdUp>
                 <CtaRegion data={ctaSidebarBottom} />
               </Hidden>
-            </Box>
+            </>
           )}
-        </Box>
+        </>
       )
     }
   ];
@@ -352,7 +349,12 @@ export const Term = () => {
           </Container>
         </AppBar>
       )}
-      <LandingPage main={mainElements} sidebar={sidebarElements} />
+      <LandingPage
+        main={mainElements}
+        sidebar={sidebarElements}
+        mt={3}
+        gridGap={8}
+      />
     </>
   );
 };


### PR DESCRIPTION
- Updates story cards to reflect [latest designs](https://www.figma.com/file/25CsNYQyLs3xQ9Uw1sxOCC/the-world-from-prx-frontend-redesign?node-id=609%3A3331)
- Removes a lot of margin and padding. 

## To Review

- [ ] Use the Preview link: https://feat-story-card-updates.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Go to the homepage and note the new card layout (r/n on live api, all the stories are using the featured template)
- [ ] View in smaller screens ensure layout still makes sense
- [ ] Click on a category, note that page reflects the new layout (try and look for a story using the standard template)
- [ ] Go to a program page and ensure the new card layouts are reflected
- [ ] Click on the episodes tab, note how the episode cards don't have margin between them as well. 
