### PR TITLE
#329 Quick Links Menu

### DIFF
--- a/components/QuickLinks/QuickLinks.styles.ts
+++ b/components/QuickLinks/QuickLinks.styles.ts
@@ -16,6 +16,7 @@ export const QuickLinksTheme = (theme: Theme) =>
       MuiBreadcrumbs: {
         root: {
           display: 'flex',
+          position: 'relative',
           justifyContent: 'center',
           overflow: 'hidden',
           maxHeight: theme.typography.pxToRem(theme.spacing(6)),

--- a/components/QuickLinks/QuickLinks.styles.ts
+++ b/components/QuickLinks/QuickLinks.styles.ts
@@ -1,0 +1,39 @@
+/**
+ * @file QuickLinks.style.ts
+ * Styles for QuickLinks.
+ */
+
+import {
+  createMuiTheme,
+  createStyles,
+  makeStyles,
+  Theme
+} from '@material-ui/core/styles';
+import { addCssColorAlpha } from '@lib/parse/color';
+
+export const QuickLinksTheme = (theme: Theme) =>
+  createMuiTheme(theme, {
+    overrides: {
+      MuiButton: {
+        text: {
+          color: theme.palette.primary.contrastText,
+          fontWeight: theme.typography.fontWeightBold,
+          '&:hover, &:focus': {
+            backgroundColor: addCssColorAlpha(
+              theme.palette.primary.contrastText,
+              0.1
+            )
+          }
+        }
+      }
+    }
+  });
+
+export const QuickLinksStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      columnGap: theme.typography.pxToRem(theme.spacing(1))
+    }
+  })
+);

--- a/components/QuickLinks/QuickLinks.styles.ts
+++ b/components/QuickLinks/QuickLinks.styles.ts
@@ -9,21 +9,18 @@ import {
   makeStyles,
   Theme
 } from '@material-ui/core/styles';
-import { addCssColorAlpha } from '@lib/parse/color';
 
 export const QuickLinksTheme = (theme: Theme) =>
   createMuiTheme(theme, {
     overrides: {
-      MuiButton: {
-        text: {
-          color: theme.palette.primary.contrastText,
-          fontWeight: theme.typography.fontWeightBold,
-          '&:hover, &:focus': {
-            backgroundColor: addCssColorAlpha(
-              theme.palette.primary.contrastText,
-              0.1
-            )
-          }
+      MuiBreadcrumbs: {
+        root: {
+          display: 'flex',
+          justifyContent: 'center',
+          overflow: 'hidden',
+          maxHeight: theme.typography.pxToRem(theme.spacing(6)),
+          marginTop: theme.typography.pxToRem(theme.spacing(1)),
+          marginBottom: theme.typography.pxToRem(theme.spacing(-3))
         }
       }
     }
@@ -32,8 +29,31 @@ export const QuickLinksTheme = (theme: Theme) =>
 export const QuickLinksStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
+      textAlign: 'center'
+    },
+    container: {
       display: 'flex',
-      columnGap: theme.typography.pxToRem(theme.spacing(1))
+      justifyContent: 'center'
+    },
+    label: {
+      display: 'flex'
+    },
+    link: {
+      color: theme.palette.primary.main,
+      '&:is(a)': {
+        display: 'flex',
+        alignItems: 'center',
+        textDecoration: 'none',
+        fontWeight: 'bold',
+        minHeight: '48px',
+        minWidth: '48px',
+        '&:hover': {
+          textDecoration: 'underline'
+        }
+      },
+      '&:visited': {
+        color: theme.palette.primary.main
+      }
     }
   })
 );

--- a/components/QuickLinks/QuickLinks.tsx
+++ b/components/QuickLinks/QuickLinks.tsx
@@ -1,0 +1,94 @@
+/**
+ * @file QuickLinks.tsx
+ * Component for app header nav.
+ */
+
+import React from 'react';
+import { useStore } from 'react-redux';
+import Button from '@material-ui/core/Button';
+import Hidden from '@material-ui/core/Hidden';
+import IconButton from '@material-ui/core/IconButton';
+import { ThemeProvider } from '@material-ui/core/styles';
+import { FavoriteSharp } from '@material-ui/icons';
+import { handleButtonClick } from '@lib/routing';
+import { getMenusData } from '@store/reducers';
+import { QuickLinksTheme } from './QuickLinks.styles';
+
+const iconComponentMap = new Map();
+iconComponentMap.set('heart', FavoriteSharp);
+
+const renderIcon = (icon: string) => {
+  const IconComponent = iconComponentMap.get(icon);
+  return IconComponent ? <IconComponent /> : null;
+};
+
+export const QuickLinks = () => {
+  const store = useStore();
+  const quickLinks = getMenusData(store.getState(), 'quickLinks');
+
+  return (
+    (quickLinks?.length && (
+      <ThemeProvider theme={QuickLinksTheme}>
+        {quickLinks.map(
+          ({ color, icon, name, url, key, attributes, itemLinkClass }) => (
+            <React.Fragment key={key}>
+              <Hidden xsDown>
+                <Button
+                  component="a"
+                  href={url.href}
+                  onClick={handleButtonClick(url)}
+                  variant={
+                    /\bbtn-(text|link)\b/.test(itemLinkClass)
+                      ? 'text'
+                      : 'contained'
+                  }
+                  color={color || 'default'}
+                  disableRipple
+                  disableElevation
+                  {...(icon && { startIcon: renderIcon(icon) })}
+                  {...attributes}
+                >
+                  {name}
+                </Button>
+              </Hidden>
+              <Hidden smUp>
+                {icon ? (
+                  <IconButton
+                    component="a"
+                    href={url.href}
+                    onClick={handleButtonClick(url)}
+                    aria-label={name}
+                    color={color || 'default'}
+                    size="small"
+                    disableRipple
+                    {...attributes}
+                  >
+                    {renderIcon(icon)}
+                  </IconButton>
+                ) : (
+                  <Button
+                    component="a"
+                    href={url.href}
+                    onClick={handleButtonClick(url)}
+                    variant="text"
+                    color={color || 'default'}
+                    size="small"
+                    disableRipple
+                    disableElevation
+                    {...attributes}
+                    {...(icon && {
+                      startIcon: renderIcon(icon)
+                    })}
+                  >
+                    {name}
+                  </Button>
+                )}
+              </Hidden>
+            </React.Fragment>
+          )
+        )}
+      </ThemeProvider>
+    )) ||
+    null
+  );
+};

--- a/components/QuickLinks/QuickLinks.tsx
+++ b/components/QuickLinks/QuickLinks.tsx
@@ -1,94 +1,58 @@
 /**
  * @file QuickLinks.tsx
- * Component for app header nav.
+ * Component for links to content page.
  */
 
 import React from 'react';
 import { useStore } from 'react-redux';
-import Button from '@material-ui/core/Button';
-import Hidden from '@material-ui/core/Hidden';
-import IconButton from '@material-ui/core/IconButton';
+import { Label } from '@material-ui/icons';
+import { Breadcrumbs, Container, Link } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
-import { FavoriteSharp } from '@material-ui/icons';
+import { isLocalUrl } from '@lib/parse/url';
 import { handleButtonClick } from '@lib/routing';
 import { getMenusData } from '@store/reducers';
-import { QuickLinksTheme } from './QuickLinks.styles';
-
-const iconComponentMap = new Map();
-iconComponentMap.set('heart', FavoriteSharp);
-
-const renderIcon = (icon: string) => {
-  const IconComponent = iconComponentMap.get(icon);
-  return IconComponent ? <IconComponent /> : null;
-};
+import { QuickLinksStyles, QuickLinksTheme } from './QuickLinks.styles';
 
 export const QuickLinks = () => {
   const store = useStore();
   const quickLinks = getMenusData(store.getState(), 'quickLinks');
+  const classes = QuickLinksStyles({});
 
   return (
-    (quickLinks?.length && (
-      <ThemeProvider theme={QuickLinksTheme}>
-        {quickLinks.map(
-          ({ color, icon, name, url, key, attributes, itemLinkClass }) => (
-            <React.Fragment key={key}>
-              <Hidden xsDown>
-                <Button
-                  component="a"
-                  href={url.href}
+    <ThemeProvider theme={QuickLinksTheme}>
+      {quickLinks && (
+        <Container>
+          <Breadcrumbs separator=" " aria-label="Quick Links">
+            <Label
+              color="secondary"
+              aria-hidden="true"
+              className={classes.label}
+            />
+            {quickLinks.map(({ name, url, key, attributes }) =>
+              isLocalUrl(url.href) ? (
+                <Link
+                  href={url.pathname}
                   onClick={handleButtonClick(url)}
-                  variant={
-                    /\bbtn-(text|link)\b/.test(itemLinkClass)
-                      ? 'text'
-                      : 'contained'
-                  }
-                  color={color || 'default'}
-                  disableRipple
-                  disableElevation
-                  {...(icon && { startIcon: renderIcon(icon) })}
+                  key={key}
+                  className={classes.link}
                   {...attributes}
                 >
                   {name}
-                </Button>
-              </Hidden>
-              <Hidden smUp>
-                {icon ? (
-                  <IconButton
-                    component="a"
-                    href={url.href}
-                    onClick={handleButtonClick(url)}
-                    aria-label={name}
-                    color={color || 'default'}
-                    size="small"
-                    disableRipple
-                    {...attributes}
-                  >
-                    {renderIcon(icon)}
-                  </IconButton>
-                ) : (
-                  <Button
-                    component="a"
-                    href={url.href}
-                    onClick={handleButtonClick(url)}
-                    variant="text"
-                    color={color || 'default'}
-                    size="small"
-                    disableRipple
-                    disableElevation
-                    {...attributes}
-                    {...(icon && {
-                      startIcon: renderIcon(icon)
-                    })}
-                  >
-                    {name}
-                  </Button>
-                )}
-              </Hidden>
-            </React.Fragment>
-          )
-        )}
-      </ThemeProvider>
-    )) ||
-    null
+                </Link>
+              ) : (
+                <a
+                  href={url.href}
+                  className={classes.link}
+                  key={key}
+                  {...attributes}
+                >
+                  {name}
+                </a>
+              )
+            )}
+          </Breadcrumbs>
+        </Container>
+      )}
+    </ThemeProvider>
   );
 };

--- a/components/QuickLinks/index.ts
+++ b/components/QuickLinks/index.ts
@@ -1,0 +1,1 @@
+export * from './QuickLinks';

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -125,7 +125,7 @@ export const Homepage = () => {
       children: (
         <Box mt={3}>
           <StoryCard data={featuredStory} feature priority />
-          <StoryCardGrid data={featuredStories[1]} mt={0} />
+          <StoryCardGrid data={featuredStories[1]} mt={2} />
           {inlineTop && (
             <Box mt={3}>
               <Hidden xsDown>
@@ -145,8 +145,8 @@ export const Homepage = () => {
         <Box mt={3}>
           {stories
             .reduce((a, p) => [...a, ...p], [])
-            .map((item: IPriApiResource) => (
-              <Box mt={0} key={item.id}>
+            .map((item: IPriApiResource, index: number) => (
+              <Box mt={index ? 2 : 0} key={item.id}>
                 <StoryCard
                   data={item}
                   feature={

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -19,6 +19,7 @@ import {
   SidebarLatestStories,
   SidebarList
 } from '@components/Sidebar';
+import { QuickLinks } from '@components/QuickLinks';
 import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
 import { SidebarEpisode } from '@components/Sidebar/SidebarEpisode';
@@ -123,10 +124,11 @@ export const Homepage = () => {
       key: 'main top',
       children: (
         <Box mt={3}>
+          <QuickLinks />
           <StoryCard data={featuredStory} feature priority />
-          <StoryCardGrid data={featuredStories[1]} mt={2} />
+          <StoryCardGrid data={featuredStories[1]} mt={0} />
           {inlineTop && (
-            <Box mt={3}>
+            <Box mt={1} mb={1}>
               <Hidden xsDown>
                 <CtaRegion data={inlineTop} />
               </Hidden>
@@ -141,11 +143,11 @@ export const Homepage = () => {
     {
       key: 'main bottom',
       children: (
-        <Box mt={3}>
+        <Box mt={0}>
           {stories
             .reduce((a, p) => [...a, ...p], [])
-            .map((item: IPriApiResource, index: number) => (
-              <Box mt={index ? 2 : 0} key={item.id}>
+            .map((item: IPriApiResource) => (
+              <Box mt={0} key={item.id}>
                 <StoryCard
                   data={item}
                   feature={
@@ -155,7 +157,7 @@ export const Homepage = () => {
               </Box>
             ))}
           {inlineBottom && (
-            <Box mt={3}>
+            <Box mt={1} mb={1}>
               <Hidden xsDown>
                 <CtaRegion data={inlineBottom} />
               </Hidden>

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -124,7 +124,6 @@ export const Homepage = () => {
       key: 'main top',
       children: (
         <Box mt={3}>
-          <QuickLinks />
           <StoryCard data={featuredStory} feature priority />
           <StoryCardGrid data={featuredStories[1]} mt={0} />
           {inlineTop && (
@@ -268,6 +267,7 @@ export const Homepage = () => {
     <>
       <MetaTags data={metatags} />
       <Plausible subject={{ type: 'homepage', id: null }} />
+      <QuickLinks />
       <LandingPage main={mainElements} sidebar={sidebarElements} />
     </>
   );

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -156,7 +156,7 @@ export const Homepage = () => {
               </Box>
             ))}
           {inlineBottom && (
-            <Box mt={1} mb={1}>
+            <Box mt={3}>
               <Hidden xsDown>
                 <CtaRegion data={inlineBottom} />
               </Hidden>

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -127,7 +127,7 @@ export const Homepage = () => {
           <StoryCard data={featuredStory} feature priority />
           <StoryCardGrid data={featuredStories[1]} mt={0} />
           {inlineTop && (
-            <Box mt={1} mb={1}>
+            <Box mt={3}>
               <Hidden xsDown>
                 <CtaRegion data={inlineTop} />
               </Hidden>
@@ -142,7 +142,7 @@ export const Homepage = () => {
     {
       key: 'main bottom',
       children: (
-        <Box mt={0}>
+        <Box mt={3}>
           {stories
             .reduce((a, p) => [...a, ...p], [])
             .map((item: IPriApiResource) => (

--- a/lib/fetch/app/fetchApp.ts
+++ b/lib/fetch/app/fetchApp.ts
@@ -22,6 +22,7 @@ export const fetchApp = async (): Promise<IApp> => {
     drawerTopNav,
     footerNav,
     headerNav,
+    quickLinks,
     latestStories
   ] = await Promise.all([
     fetchPriApiQueryMenu('menu-tw-main-nav'),
@@ -29,6 +30,7 @@ export const fetchApp = async (): Promise<IApp> => {
     fetchPriApiQueryMenu('menu-tw-top-nav'),
     fetchPriApiQueryMenu('menu-tw-footer-nav'),
     fetchPriApiQueryMenu('menu-tw-header-nav'),
+    fetchPriApiQueryMenu('menu-the-world-quick-links'),
     fetchPriApiQuery('node--stories', {
       ...basicStoryParams,
       'filter[status]': 1,
@@ -44,7 +46,8 @@ export const fetchApp = async (): Promise<IApp> => {
       drawerSocialNav: parseMenu(drawerSocialNav),
       drawerTopNav: parseMenu(drawerTopNav),
       footerNav: parseMenu(footerNav),
-      headerNav: parseMenu(headerNav)
+      headerNav: parseMenu(headerNav),
+      quickLinks: parseMenu(quickLinks)
     }
   };
 

--- a/pages/api/app.ts
+++ b/pages/api/app.ts
@@ -14,6 +14,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     drawerTopNav,
     footerNav,
     headerNav,
+    quickLinks,
     latestStories
   ] = await Promise.all([
     fetchPriApiQueryMenu('menu-tw-main-nav'),
@@ -21,6 +22,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     fetchPriApiQueryMenu('menu-tw-top-nav'),
     fetchPriApiQueryMenu('menu-tw-footer-nav'),
     fetchPriApiQueryMenu('menu-tw-header-nav'),
+    fetchPriApiQueryMenu('menu-the-world-quick-links'),
     fetchPriApiQuery('node--stories', {
       ...basicStoryParams,
       'filter[status]': 1,
@@ -35,7 +37,8 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       drawerSocialNav: parseMenu(drawerSocialNav),
       drawerTopNav: parseMenu(drawerTopNav),
       footerNav: parseMenu(footerNav),
-      headerNav: parseMenu(headerNav)
+      headerNav: parseMenu(headerNav),
+      quickLinks: parseMenu(quickLinks)
     }
   };
 


### PR DESCRIPTION
Closes #329

-  Adds a menu to the top of the homepage for pointing folks to things that matter to TW's team

## To Review

- [x] Use the Preview link https://feat-quick-links-menu.d2mc541hyaqum0.amplifyapp.com/

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Note there's a menu, its only on the homepage
- [x] Responsive check (items get cut as the screen gets smaller
