### PR TITLE
#342: fetch data w/ homepage data

### DIFF
--- a/lib/fetch/app/fetchApp.ts
+++ b/lib/fetch/app/fetchApp.ts
@@ -22,7 +22,6 @@ export const fetchApp = async (): Promise<IApp> => {
     drawerTopNav,
     footerNav,
     headerNav,
-    quickLinks,
     latestStories
   ] = await Promise.all([
     fetchPriApiQueryMenu('menu-tw-main-nav'),
@@ -30,7 +29,6 @@ export const fetchApp = async (): Promise<IApp> => {
     fetchPriApiQueryMenu('menu-tw-top-nav'),
     fetchPriApiQueryMenu('menu-tw-footer-nav'),
     fetchPriApiQueryMenu('menu-tw-header-nav'),
-    fetchPriApiQueryMenu('menu-the-world-quick-links'),
     fetchPriApiQuery('node--stories', {
       ...basicStoryParams,
       'filter[status]': 1,
@@ -46,8 +44,7 @@ export const fetchApp = async (): Promise<IApp> => {
       drawerSocialNav: parseMenu(drawerSocialNav),
       drawerTopNav: parseMenu(drawerTopNav),
       footerNav: parseMenu(footerNav),
-      headerNav: parseMenu(headerNav),
-      quickLinks: parseMenu(quickLinks)
+      headerNav: parseMenu(headerNav)
     }
   };
 

--- a/lib/fetch/homepage/fetchHomepage.ts
+++ b/lib/fetch/homepage/fetchHomepage.ts
@@ -2,6 +2,7 @@
  * Fetch homepage data from CMS API.
  */
 
+import { parseMenu } from '@lib/parse/menu';
 import {
   IPriApiCollectionResponse,
   IPriApiResourceResponse,
@@ -32,7 +33,7 @@ export const fetchHomepage = async (): Promise<PriApiResourceResponse> => {
       ...program,
       latestStories,
       menus: {
-        quickLinks
+        quickLinks: parseMenu(quickLinks)
       }
     }
   } as IPriApiResourceResponse;

--- a/lib/fetch/homepage/fetchHomepage.ts
+++ b/lib/fetch/homepage/fetchHomepage.ts
@@ -7,12 +7,12 @@ import {
   IPriApiResourceResponse,
   PriApiResourceResponse
 } from 'pri-api-library/types';
-import { fetchPriApiQuery } from '../api/fetchPriApi';
+import { fetchPriApiQuery, fetchPriApiQueryMenu } from '../api/fetchPriApi';
 import { basicStoryParams } from '../api/params';
 import { fetchProgram } from '../program';
 
 export const fetchHomepage = async (): Promise<PriApiResourceResponse> => {
-  const [program, latestStories] = await Promise.all([
+  const [program, latestStories, quickLinks] = await Promise.all([
     fetchProgram('3704').then(
       (resp: IPriApiResourceResponse) => resp && resp.data
     ),
@@ -23,13 +23,17 @@ export const fetchHomepage = async (): Promise<PriApiResourceResponse> => {
       'filter[program][operator]': '<>',
       sort: '-date_published',
       range: 10
-    }).then((resp: IPriApiCollectionResponse) => resp)
+    }).then((resp: IPriApiCollectionResponse) => resp),
+    fetchPriApiQueryMenu('menu-the-world-quick-links')
   ]);
 
   const resp = {
     data: {
       ...program,
-      latestStories
+      latestStories,
+      menus: {
+        quickLinks
+      }
     }
   } as IPriApiResourceResponse;
 

--- a/pages/api/app.ts
+++ b/pages/api/app.ts
@@ -14,7 +14,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     drawerTopNav,
     footerNav,
     headerNav,
-    quickLinks,
     latestStories
   ] = await Promise.all([
     fetchPriApiQueryMenu('menu-tw-main-nav'),
@@ -22,7 +21,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     fetchPriApiQueryMenu('menu-tw-top-nav'),
     fetchPriApiQueryMenu('menu-tw-footer-nav'),
     fetchPriApiQueryMenu('menu-tw-header-nav'),
-    fetchPriApiQueryMenu('menu-the-world-quick-links'),
     fetchPriApiQuery('node--stories', {
       ...basicStoryParams,
       'filter[status]': 1,
@@ -37,8 +35,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       drawerSocialNav: parseMenu(drawerSocialNav),
       drawerTopNav: parseMenu(drawerTopNav),
       footerNav: parseMenu(footerNav),
-      headerNav: parseMenu(headerNav),
-      quickLinks: parseMenu(quickLinks)
+      headerNav: parseMenu(headerNav)
     }
   };
 

--- a/pages/api/homepage.ts
+++ b/pages/api/homepage.ts
@@ -5,26 +5,33 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { IPriApiCollectionResponse } from 'pri-api-library/types';
 import { basicStoryParams } from '@lib/fetch/api/params';
-import { fetchApiProgram, fetchPriApiQuery } from '@lib/fetch';
+import {
+  fetchApiProgram,
+  fetchPriApiQuery,
+  fetchPriApiQueryMenu
+} from '@lib/fetch';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  // Program Data
-  const program = await fetchApiProgram('3704', req);
-
-  // Latest Non-TW stories
-  const latestStories = (await fetchPriApiQuery('node--stories', {
-    ...basicStoryParams,
-    'filter[status]': 1,
-    'filter[program][value]': 3704,
-    'filter[program][operator]': '<>',
-    sort: '-date_published',
-    range: 10
-  })) as IPriApiCollectionResponse;
+  const [program, latestStories, quickLinks] = await Promise.all([
+    fetchApiProgram('3704').then(resp => resp && resp.data),
+    fetchPriApiQuery('node--stories', {
+      ...basicStoryParams,
+      'filter[status]': 1,
+      'filter[program][value]': 3704,
+      'filter[program][operator]': '<>',
+      sort: '-date_published',
+      range: 10
+    }).then((resp: IPriApiCollectionResponse) => resp),
+    fetchPriApiQueryMenu('menu-the-world-quick-links')
+  ]);
 
   const apiResp = {
     data: {
       ...program,
-      latestStories
+      latestStories,
+      menus: {
+        quickLinks
+      }
     }
   };
 

--- a/pages/api/homepage.ts
+++ b/pages/api/homepage.ts
@@ -10,6 +10,7 @@ import {
   fetchPriApiQuery,
   fetchPriApiQueryMenu
 } from '@lib/fetch';
+import { parseMenu } from '@lib/parse/menu';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const [program, latestStories, quickLinks] = await Promise.all([
@@ -30,7 +31,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       ...program,
       latestStories,
       menus: {
-        quickLinks
+        quickLinks: parseMenu(quickLinks)
       }
     }
   };

--- a/store/actions/fetchHomepageData.ts
+++ b/store/actions/fetchHomepageData.ts
@@ -43,7 +43,8 @@ export const fetchHomepageData = (): ThunkAction<
       featuredStories,
       latestStories,
       stories,
-      episodes
+      episodes,
+      menus
     } = apiResp;
 
     dispatch({
@@ -82,6 +83,11 @@ export const fetchHomepageData = (): ThunkAction<
 
     dispatch({
       type: 'FETCH_HOMEPAGE_DATA_SUCCESS'
+    });
+
+    dispatch({
+      type: 'FETCH_MENUS_DATA_SUCCESS',
+      payload: menus
     });
 
     return { ...apiResp };


### PR DESCRIPTION
Closes #342

- Moves fetching of quick links menu from app data fetch to homepage data fetch.

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Ensure quick links menu is rendered immediately w/ other page content.
- [ ] Inspect XHR network traffic, and ensure `/api/app` doesn't return `quickLinks` in its menu data.
