### PR TITLE
#344: Make relative src url's absolute for images in body content

### DIFF
--- a/components/HtmlContent/transforms/enhanceImage.tsx
+++ b/components/HtmlContent/transforms/enhanceImage.tsx
@@ -25,7 +25,10 @@ export const enhanceImage = (getImageWidths: IImageWidthsFunc) => (
       .map(([q, w]) => (q ? `(${q}) ${w}` : w))
       .join(', ');
     const { attribs } = node;
-    const { class: className, width, height, ...otherAttribs } = attribs;
+    const { class: className, width, height, src, ...otherAttribs } = attribs;
+    const absoluteSrc = /^\/[^/]/.test(src)
+      ? `https://theworld.org${src}`
+      : src;
     let wrapperClass: string;
 
     switch (true) {
@@ -45,6 +48,7 @@ export const enhanceImage = (getImageWidths: IImageWidthsFunc) => (
       <div className={wrapperClass} key={attribs.src}>
         <Image
           {...otherAttribs}
+          src={absoluteSrc}
           width={width || 16}
           height={height || 9}
           layout="responsive"
@@ -54,6 +58,7 @@ export const enhanceImage = (getImageWidths: IImageWidthsFunc) => (
     ) : (
       <Image
         {...otherAttribs}
+        src={absoluteSrc}
         width={width || 16}
         height={height || 9}
         layout="responsive"

--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,7 @@ module.exports = withPlausibleProxy({
   },
   images: {
     domains: [
+      'theworld.org',
       'media.pri.org',
       'www.pri.org',
       'pri9.lndo.site',


### PR DESCRIPTION
Closes #344

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Go to this story: `stories/2010-02-05/miracle-babies-mexico-city-25-years-later`
- [ ] Ensure images in the body are loaded.
