### PR TITLE
#358: Switch to SSR

### DIFF
--- a/components/AppCtaBanner/AppCtaBanner.tsx
+++ b/components/AppCtaBanner/AppCtaBanner.tsx
@@ -7,7 +7,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useStore } from 'react-redux';
 import classNames from 'classnames/bind';
 import { getShownMessage, setCtaCookie } from '@lib/cta';
-import { Box, Container, IconButton, NoSsr } from '@material-ui/core';
+import { Box, Container, IconButton } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { CloseSharp } from '@material-ui/icons';
 import { AppContext } from '@contexts/AppContext';
@@ -57,33 +57,31 @@ export const AppCtaBanner = () => {
     CtaMessageComponent &&
     shownMessage &&
     !closed && (
-      <NoSsr>
-        <ThemeProvider theme={appCtaBannerTheme}>
-          <Box
-            component="aside"
-            className={cx('root')}
-            display="flex"
-            alignItems="center"
-            minHeight={230}
-            px={2}
-            py={2}
-          >
-            <Container maxWidth="md">
-              <CtaMessageComponent data={shownMessage} onClose={handleClose} />
-            </Container>
-            <Box position="absolute" top={0} right={0}>
-              <IconButton
-                aria-label="close"
-                color="inherit"
-                disableRipple
-                onClick={handleClose}
-              >
-                <CloseSharp />
-              </IconButton>
-            </Box>
+      <ThemeProvider theme={appCtaBannerTheme}>
+        <Box
+          component="aside"
+          className={cx('root')}
+          display="flex"
+          alignItems="center"
+          minHeight={230}
+          px={2}
+          py={2}
+        >
+          <Container maxWidth="md">
+            <CtaMessageComponent data={shownMessage} onClose={handleClose} />
+          </Container>
+          <Box position="absolute" top={0} right={0}>
+            <IconButton
+              aria-label="close"
+              color="inherit"
+              disableRipple
+              onClick={handleClose}
+            >
+              <CloseSharp />
+            </IconButton>
           </Box>
-        </ThemeProvider>
-      </NoSsr>
+        </Box>
+      </ThemeProvider>
     )
   );
 };

--- a/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
+++ b/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
@@ -6,7 +6,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { useStore } from 'react-redux';
 import classNames from 'classnames/bind';
-import { Box, Container, IconButton, NoSsr } from '@material-ui/core';
+import { Box, Container, IconButton } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { CloseSharp } from '@material-ui/icons';
 import { AppContext } from '@contexts/AppContext';
@@ -60,32 +60,30 @@ export const AppCtaLoadUnder = () => {
     CtaMessageComponent &&
     shownMessage &&
     !closed && (
-      <NoSsr>
-        <ThemeProvider theme={appCtaLoadUnderTheme}>
-          <Box
-            component="aside"
-            className={cx('root')}
-            position="fixed"
-            bottom={0}
-            width="100%"
-            px={4}
-          >
-            <Container className={cx('container')} maxWidth="lg">
-              <CtaMessageComponent data={shownMessage} onClose={handleClose} />
-            </Container>
-            <Box position="absolute" top={0} right={0}>
-              <IconButton
-                aria-label="close"
-                color="inherit"
-                disableRipple
-                onClick={handleClose}
-              >
-                <CloseSharp />
-              </IconButton>
-            </Box>
+      <ThemeProvider theme={appCtaLoadUnderTheme}>
+        <Box
+          component="aside"
+          className={cx('root')}
+          position="fixed"
+          bottom={0}
+          width="100%"
+          px={4}
+        >
+          <Container className={cx('container')} maxWidth="lg">
+            <CtaMessageComponent data={shownMessage} onClose={handleClose} />
+          </Container>
+          <Box position="absolute" top={0} right={0}>
+            <IconButton
+              aria-label="close"
+              color="inherit"
+              disableRipple
+              onClick={handleClose}
+            >
+              <CloseSharp />
+            </IconButton>
           </Box>
-        </ThemeProvider>
-      </NoSsr>
+        </Box>
+      </ThemeProvider>
     )
   );
 };

--- a/components/CtaRegion/CtaRegion.tsx
+++ b/components/CtaRegion/CtaRegion.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { NoSsr, ThemeProvider } from '@material-ui/core';
+import { ThemeProvider } from '@material-ui/core';
 import { ICtaRegionProps } from '@interfaces/cta';
 import { getShownMessage } from '@lib/cta';
 import { ctaRegionTheme } from './CtaRegion.styles';
@@ -18,11 +18,9 @@ export const CtaRegion = ({ data }: ICtaRegionProps) => {
   return (
     data &&
     CtaMessageComponent && (
-      <NoSsr>
-        <ThemeProvider theme={ctaRegionTheme}>
-          <CtaMessageComponent data={{ ...shownMessage }} />
-        </ThemeProvider>
-      </NoSsr>
+      <ThemeProvider theme={ctaRegionTheme}>
+        <CtaMessageComponent data={{ ...shownMessage }} />
+      </ThemeProvider>
     )
   );
 };

--- a/components/Sidebar/SidebarCta/SidebarCta.tsx
+++ b/components/Sidebar/SidebarCta/SidebarCta.tsx
@@ -4,7 +4,6 @@
  */
 
 import React from 'react';
-import { NoSsr } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { ICtaRegionProps } from '@interfaces/cta';
 import { getShownMessage } from '@lib/cta';
@@ -19,11 +18,9 @@ export const SidebarCta = ({ data }: ICtaRegionProps) => {
   return (
     data &&
     CtaMessageComponent && (
-      <NoSsr>
-        <ThemeProvider theme={sidebarCtaTheme}>
-          <CtaMessageComponent data={{ ...shownMessage }} />
-        </ThemeProvider>
-      </NoSsr>
+      <ThemeProvider theme={sidebarCtaTheme}>
+        <CtaMessageComponent data={{ ...shownMessage }} />
+      </ThemeProvider>
     )
   );
 };

--- a/components/pages/Audio/Audio.tsx
+++ b/components/pages/Audio/Audio.tsx
@@ -4,9 +4,7 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { Box, Container, Grid } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { AudioPlayer } from '@components/AudioPlayer';
@@ -15,9 +13,7 @@ import { AppContext } from '@contexts/AppContext';
 import { HtmlContent } from '@components/HtmlContent';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
-import { RootState } from '@interfaces/state';
 import { parseUtcDate } from '@lib/parse/date';
-import { fetchAudioData } from '@store/actions/fetchAudioData';
 import { getDataByResource, getCtaRegionData } from '@store/reducers';
 import { audioStyles, audioTheme } from './Audio.styles';
 import { AudioHeader } from './components/AudioHeader';
@@ -123,18 +119,4 @@ export const Audio = () => {
       </Container>
     </ThemeProvider>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<void> => {
-  const type = 'file--audio';
-  const data = getDataByResource(getState(), type, id);
-
-  if (!data) {
-    await dispatch<any>(fetchAudioData(id));
-  }
 };

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -5,9 +5,7 @@
 
 import React, { useContext, useEffect, useState } from 'react';
 import classNames from 'classnames/bind';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import { Box, Button, Hidden, Typography } from '@material-ui/core';
 import { EqualizerRounded, PublicRounded } from '@material-ui/icons';
@@ -29,9 +27,7 @@ import {
 import { StoryCard } from '@components/StoryCard';
 import { fetchApiPersonAudio, fetchApiPersonStories } from '@lib/fetch';
 import { AppContext } from '@contexts/AppContext';
-import { RootState } from '@interfaces/state';
 import { appendResourceCollection } from '@store/actions/appendResourceCollection';
-import { fetchPersonData } from '@store/actions/fetchPersonData';
 import {
   getCollectionData,
   getCtaRegionData,
@@ -310,21 +306,4 @@ export const Bio = () => {
       <LandingPage main={mainElements} sidebar={sidebarElements} />
     </>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<void> => {
-  const type = 'node--people';
-  const state = getState();
-  const data = getDataByResource(state, type, id);
-
-  // Get missing content data.
-  if (!data?.complete) {
-    // Get content data.
-    await dispatch<any>(fetchPersonData(id));
-  }
 };

--- a/components/pages/Category/Category.tsx
+++ b/components/pages/Category/Category.tsx
@@ -4,9 +4,7 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
   Box,
@@ -34,9 +32,7 @@ import { LandingPageHeader } from '@components/LandingPageHeader';
 import { MetaTags } from '@components/MetaTags';
 import { SidebarContent } from '@components/Sidebar/SidebarContent';
 import { AppContext } from '@contexts/AppContext';
-import { RootState } from '@interfaces/state';
 import { appendResourceCollection } from '@store/actions/appendResourceCollection';
-import { fetchCategoryData } from '@store/actions/fetchCategoryData';
 import {
   getCollectionData,
   getCtaRegionData,
@@ -307,21 +303,4 @@ export const Category = () => {
       />
     </>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<void> => {
-  const type = 'taxonomy_term--categories';
-  const state = getState();
-  const data = getDataByResource(state, type, id);
-
-  // Get missing content data.
-  if (!data) {
-    // Get content data.
-    await dispatch<any>(fetchCategoryData(id));
-  }
 };

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -4,9 +4,7 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
   Box,
@@ -36,9 +34,8 @@ import { SpotifyPlayer } from '@components/SpotifyPlayer';
 import { StoryCard } from '@components/StoryCard';
 import { CtaRegion } from '@components/CtaRegion';
 import { AppContext } from '@contexts/AppContext';
-import { RootState, UiAction } from '@interfaces/state';
+import { UiAction } from '@interfaces/state';
 import { parseUtcDate } from '@lib/parse/date';
-import { appendResourceCollection } from '@store/actions/appendResourceCollection';
 import { fetchEpisodeData } from '@store/actions/fetchEpisodeData';
 import {
   getDataByResource,
@@ -349,23 +346,4 @@ export const Episode = () => {
       </Container>
     </ThemeProvider>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<void> => {
-  const type = 'node--episodes';
-  const data = getDataByResource(getState(), type, id);
-
-  if (!data) {
-    await dispatch<any>(fetchEpisodeData(id));
-    const { stories } = getDataByResource(getState(), type, id);
-
-    if (stories) {
-      dispatch(appendResourceCollection(stories, type, id, 'stories'));
-    }
-  }
 };

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -4,9 +4,7 @@
  */
 import React, { useContext, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import { Box, Hidden, Typography } from '@material-ui/core';
 import StyleRounded from '@material-ui/icons/StyleRounded';
@@ -24,7 +22,6 @@ import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
 import { SidebarEpisode } from '@components/Sidebar/SidebarEpisode';
 import { ICtaRegionProps } from '@interfaces/cta';
-import { fetchHomepageData } from '@store/actions/fetchHomepageData';
 import {
   getCollectionData,
   getCtaRegionData,
@@ -274,11 +271,4 @@ export const Homepage = () => {
       />
     </>
   );
-};
-
-export const fetchData = (): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>
-): Promise<void> => {
-  // Fetch App Data
-  await dispatch<any>(fetchHomepageData());
 };

--- a/components/pages/Image/Image.tsx
+++ b/components/pages/Image/Image.tsx
@@ -4,9 +4,7 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { Box, Container, Grid } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { CtaRegion } from '@components/CtaRegion';
@@ -15,7 +13,6 @@ import { HtmlContent } from '@components/HtmlContent';
 import { LedeImage } from '@components/LedeImage';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
-import { RootState } from '@interfaces/state';
 import { fetchAudioData } from '@store/actions/fetchAudioData';
 import { getDataByResource, getCtaRegionData } from '@store/reducers';
 import { imageStyles, imageTheme } from './Image.styles';
@@ -93,18 +90,4 @@ export const Image = () => {
       </Container>
     </ThemeProvider>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<void> => {
-  const type = 'file--images';
-  const data = getDataByResource(getState(), type, id);
-
-  if (!data) {
-    await dispatch<any>(fetchAudioData(id));
-  }
 };

--- a/components/pages/Newsletter/Newsletter.tsx
+++ b/components/pages/Newsletter/Newsletter.tsx
@@ -5,8 +5,6 @@
 import React, { useContext, useState, useEffect } from 'react';
 import { useStore } from 'react-redux';
 import classNames from 'classnames/bind';
-import { AnyAction } from 'redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import {
   Box,
   Container,
@@ -22,7 +20,6 @@ import { MetaTags } from '@components/MetaTags';
 import { NewsletterForm } from '@components/NewsletterForm';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
 import { IPriApiNewsletter } from '@interfaces/newsletter';
-import { RootState } from '@interfaces/state';
 import { parseNewsletterOptions } from '@lib/parse/cta';
 import { fetchNewsletterData } from '@store/actions/fetchNewsletterData';
 import { getDataByResource } from '@store/reducers';
@@ -158,19 +155,4 @@ export const Newsletter = () => {
       </ThemeProvider>
     </>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-) => {
-  const type = 'node--newsletter_sign_ups';
-  const data = getDataByResource(getState(), type, id);
-
-  if (!data) {
-    // Get content data.
-    await dispatch<any>(fetchNewsletterData(id));
-  }
 };

--- a/components/pages/Page/Page.tsx
+++ b/components/pages/Page/Page.tsx
@@ -4,16 +4,13 @@
  */
 
 import React, { useContext, useEffect } from 'react';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { Box, Container, Grid } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { AppContext } from '@contexts/AppContext';
 import { HtmlContent } from '@components/HtmlContent';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
-import { RootState } from '@interfaces/state';
 import { fetchPageData } from '@store/actions/fetchPageData';
 import { getDataByResource } from '@store/reducers';
 import { pageStyles, pageTheme } from './Page.styles';
@@ -68,18 +65,4 @@ export const Page = () => {
       </Container>
     </ThemeProvider>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<void> => {
-  const type = 'node--pages';
-  const data = getDataByResource(getState(), type, id);
-
-  if (!data) {
-    await dispatch<any>(fetchPageData(id));
-  }
 };

--- a/components/pages/Program/Program.tsx
+++ b/components/pages/Program/Program.tsx
@@ -5,9 +5,7 @@
 
 import React, { useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
   AppBar,
@@ -39,9 +37,7 @@ import { fetchApiProgramEpisodes, fetchApiProgramStories } from '@lib/fetch';
 import { LandingPageHeader } from '@components/LandingPageHeader';
 import { EpisodeCard } from '@components/EpisodeCard';
 import { AppContext } from '@contexts/AppContext';
-import { RootState } from '@interfaces/state';
 import { appendResourceCollection } from '@store/actions/appendResourceCollection';
-import { fetchProgramData } from '@store/actions/fetchProgramData';
 import {
   getCollectionData,
   getCtaRegionData,
@@ -98,15 +94,11 @@ export const Program = () => {
     id,
     'featured story'
   );
-  const featuredStory = featuredStoryState.items[1][0];
-  const { items: featuredStories } = getCollectionData(
-    state,
-    type,
-    id,
-    'featured stories'
-  );
+  const featuredStory = featuredStoryState?.items[1][0];
+  const { items: featuredStories } =
+    getCollectionData(state, type, id, 'featured stories') || {};
   const storiesState = getCollectionData(state, type, id, 'stories');
-  const { items: stories, page, next, count } = storiesState;
+  const { items: stories, page, next, count } = storiesState || {};
   const hasStories = count > 0;
   const episodesState = getCollectionData(state, type, id, 'episodes');
   const {
@@ -409,21 +401,4 @@ export const Program = () => {
       />
     </ThemeProvider>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<void> => {
-  const type = 'node--programs';
-  const state = getState();
-  const data = getDataByResource(state, type, id);
-
-  // Get missing content data.
-  if (!data) {
-    // Get content data.
-    await dispatch<any>(fetchProgramData(id));
-  }
 };

--- a/components/pages/Story/Story.tsx
+++ b/components/pages/Story/Story.tsx
@@ -3,15 +3,12 @@
  * Component for Story.
  */
 import React, { useContext, useEffect, useState } from 'react';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { AppContext } from '@contexts/AppContext';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
-import { RootState, UiAction } from '@interfaces/state';
+import { UiAction } from '@interfaces/state';
 import { parseUtcDate } from '@lib/parse/date';
-import { fetchStoryData } from '@store/actions/fetchStoryData';
 import { getDataByResource } from '@store/reducers';
 import { layoutComponentMap } from './layouts';
 
@@ -150,19 +147,4 @@ export const Story = () => {
       <LayoutComponent data={data} />
     </>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<void> => {
-  const type = 'node--stories';
-  const data = getDataByResource(getState(), type, id);
-
-  if (!data) {
-    // Get content data.
-    await dispatch<any>(fetchStoryData(id));
-  }
 };

--- a/components/pages/Team/Team.tsx
+++ b/components/pages/Team/Team.tsx
@@ -6,9 +6,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import classNames from 'classnames/bind';
 import { UrlWithParsedQuery } from 'url';
 import { IPriApiResource } from 'pri-api-library/types';
@@ -28,7 +26,6 @@ import { MetaTags } from '@components/MetaTags';
 import { Plausible } from '@components/Plausible';
 import { AppContext } from '@contexts/AppContext';
 import { generateLinkHrefForContent } from '@lib/routing';
-import { fetchTeamData } from '@store/actions/fetchTeamData';
 import { getCollectionData } from '@store/reducers';
 import { teamStyles, teamTheme } from './Team.styles';
 import { TeamHeader } from './components/TeamHeader';
@@ -152,12 +149,4 @@ export const Team = () => {
       </Container>
     </ThemeProvider>
   );
-};
-
-export const fetchData = (): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>
-): Promise<any> => {
-  const data = await dispatch<any>(fetchTeamData());
-
-  return data;
 };

--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -4,9 +4,7 @@
  */
 import React, { useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { IPriApiResource } from 'pri-api-library/types';
 import {
   AppBar,
@@ -29,9 +27,7 @@ import { LandingPageHeader } from '@components/LandingPageHeader';
 import { MetaTags } from '@components/MetaTags';
 import { SidebarEpisode } from '@components/Sidebar/SidebarEpisode';
 import { AppContext } from '@contexts/AppContext';
-import { RootState } from '@interfaces/state';
 import { appendResourceCollection } from '@store/actions/appendResourceCollection';
-import { fetchTermData } from '@store/actions/fetchTermData';
 import {
   getCollectionData,
   getCtaRegionData,
@@ -349,21 +345,4 @@ export const Term = () => {
       />
     </>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<void> => {
-  const type = 'taxonomy_term--terms';
-  const state = getState();
-  const data = getDataByResource(state, type, id);
-
-  // Get missing content data.
-  if (!data) {
-    // Get content data.
-    await dispatch<any>(fetchTermData(id));
-  }
 };

--- a/components/pages/Video/Video.tsx
+++ b/components/pages/Video/Video.tsx
@@ -4,9 +4,7 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
-import { AnyAction } from 'redux';
 import { useStore } from 'react-redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { Box, Container, Grid } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { LedeVideo } from '@components/LedeVideo';
@@ -15,7 +13,6 @@ import { AppContext } from '@contexts/AppContext';
 import { HtmlContent } from '@components/HtmlContent';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
-import { RootState } from '@interfaces/state';
 import { fetchVideoData } from '@store/actions/fetchVideoData';
 import { getDataByResource, getCtaRegionData } from '@store/reducers';
 import { videoStyles, videoTheme } from './Video.styles';
@@ -92,18 +89,4 @@ export const Video = () => {
       </Container>
     </ThemeProvider>
   );
-};
-
-export const fetchData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<void> => {
-  const type = 'file--videos';
-  const data = getDataByResource(getState(), type, id);
-
-  if (!data) {
-    await dispatch<any>(fetchVideoData(id));
-  }
 };

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,8 +1,12 @@
 customHeaders:
-  - pattern: '**/*'
+  - pattern: '/_next/static/**/*'
     headers:
       - key: 'Cache-Control'
-        value: 'public, max-age=3600, s-maxage=300, stale-while-revalidate'
+        value: 'public, max-age=31536000, immutable'
+  - pattern: '**'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=300'
       - key: 'Strict-Transport-Security'
         value: 'max-age=63072000; includeSubDomains; preload'
       - key: 'X-Frame-Options'

--- a/lib/fetch/app/fetchApp.ts
+++ b/lib/fetch/app/fetchApp.ts
@@ -3,9 +3,11 @@
  */
 
 import { IButton } from '@interfaces';
-import { parseMenu } from '@lib/parse/menu';
+// import { parseMenu } from '@lib/parse/menu';
 import { IPriApiCollectionResponse } from 'pri-api-library/types';
-import { fetchPriApiQuery, fetchPriApiQueryMenu } from '../api/fetchPriApi';
+import {
+  fetchPriApiQuery /* fetchPriApiQueryMenu */
+} from '../api/fetchPriApi';
 import { basicStoryParams } from '../api/params';
 
 export interface IApp {
@@ -17,18 +19,18 @@ export interface IApp {
 
 export const fetchApp = async (): Promise<IApp> => {
   const [
-    drawerMainNav,
-    drawerSocialNav,
-    drawerTopNav,
-    footerNav,
-    headerNav,
+    // drawerMainNav,
+    // drawerSocialNav,
+    // drawerTopNav,
+    // footerNav,
+    // headerNav,
     latestStories
   ] = await Promise.all([
-    fetchPriApiQueryMenu('menu-tw-main-nav'),
-    fetchPriApiQueryMenu('menu-tw-social-nav'),
-    fetchPriApiQueryMenu('menu-tw-top-nav'),
-    fetchPriApiQueryMenu('menu-tw-footer-nav'),
-    fetchPriApiQueryMenu('menu-tw-header-nav'),
+    // fetchPriApiQueryMenu('menu-tw-main-nav'),
+    // fetchPriApiQueryMenu('menu-tw-social-nav'),
+    // fetchPriApiQueryMenu('menu-tw-top-nav'),
+    // fetchPriApiQueryMenu('menu-tw-footer-nav'),
+    // fetchPriApiQueryMenu('menu-tw-header-nav'),
     fetchPriApiQuery('node--stories', {
       ...basicStoryParams,
       'filter[status]': 1,
@@ -40,11 +42,11 @@ export const fetchApp = async (): Promise<IApp> => {
   const resp = {
     latestStories,
     menus: {
-      drawerMainNav: parseMenu(drawerMainNav),
-      drawerSocialNav: parseMenu(drawerSocialNav),
-      drawerTopNav: parseMenu(drawerTopNav),
-      footerNav: parseMenu(footerNav),
-      headerNav: parseMenu(headerNav)
+      // drawerMainNav: parseMenu(drawerMainNav),
+      // drawerSocialNav: parseMenu(drawerSocialNav),
+      // drawerTopNav: parseMenu(drawerTopNav),
+      // footerNav: parseMenu(footerNav),
+      // headerNav: parseMenu(headerNav)
     }
   };
 

--- a/lib/fetch/app/fetchApp.ts
+++ b/lib/fetch/app/fetchApp.ts
@@ -3,11 +3,9 @@
  */
 
 import { IButton } from '@interfaces';
-// import { parseMenu } from '@lib/parse/menu';
+import { parseMenu } from '@lib/parse/menu';
 import { IPriApiCollectionResponse } from 'pri-api-library/types';
-import {
-  fetchPriApiQuery /* fetchPriApiQueryMenu */
-} from '../api/fetchPriApi';
+import { fetchPriApiQuery, fetchPriApiQueryMenu } from '../api/fetchPriApi';
 import { basicStoryParams } from '../api/params';
 
 export interface IApp {
@@ -19,18 +17,18 @@ export interface IApp {
 
 export const fetchApp = async (): Promise<IApp> => {
   const [
-    // drawerMainNav,
-    // drawerSocialNav,
-    // drawerTopNav,
-    // footerNav,
-    // headerNav,
+    drawerMainNav,
+    drawerSocialNav,
+    drawerTopNav,
+    footerNav,
+    headerNav,
     latestStories
   ] = await Promise.all([
-    // fetchPriApiQueryMenu('menu-tw-main-nav'),
-    // fetchPriApiQueryMenu('menu-tw-social-nav'),
-    // fetchPriApiQueryMenu('menu-tw-top-nav'),
-    // fetchPriApiQueryMenu('menu-tw-footer-nav'),
-    // fetchPriApiQueryMenu('menu-tw-header-nav'),
+    fetchPriApiQueryMenu('menu-tw-main-nav'),
+    fetchPriApiQueryMenu('menu-tw-social-nav'),
+    fetchPriApiQueryMenu('menu-tw-top-nav'),
+    fetchPriApiQueryMenu('menu-tw-footer-nav'),
+    fetchPriApiQueryMenu('menu-tw-header-nav'),
     fetchPriApiQuery('node--stories', {
       ...basicStoryParams,
       'filter[status]': 1,
@@ -42,11 +40,11 @@ export const fetchApp = async (): Promise<IApp> => {
   const resp = {
     latestStories,
     menus: {
-      // drawerMainNav: parseMenu(drawerMainNav),
-      // drawerSocialNav: parseMenu(drawerSocialNav),
-      // drawerTopNav: parseMenu(drawerTopNav),
-      // footerNav: parseMenu(footerNav),
-      // headerNav: parseMenu(headerNav)
+      drawerMainNav: parseMenu(drawerMainNav),
+      drawerSocialNav: parseMenu(drawerSocialNav),
+      drawerTopNav: parseMenu(drawerTopNav),
+      footerNav: parseMenu(footerNav),
+      headerNav: parseMenu(headerNav)
     }
   };
 

--- a/lib/fetch/program/fetchProgram.ts
+++ b/lib/fetch/program/fetchProgram.ts
@@ -70,7 +70,7 @@ export const fetchProgram = async (
     }
 
     if (params?.v === 'episodes') {
-      const stories = await fetchProgramStories(program, 1, 5).then(
+      const stories = await fetchProgramStories(program, 1, 1).then(
         (resp: IPriApiCollectionResponse) => resp
       );
       const storiesData = [...stories.data];

--- a/lib/fetch/program/fetchProgram.ts
+++ b/lib/fetch/program/fetchProgram.ts
@@ -70,11 +70,11 @@ export const fetchProgram = async (
     }
 
     if (params?.v === 'episodes') {
-      const stories = await fetchProgramStories(program, 1, 1).then(
+      const stories = await fetchProgramStories(program, 1, 5).then(
         (resp: IPriApiCollectionResponse) => resp
       );
       const storiesData = [...stories.data];
-      const episodes = await fetchProgramEpisodes(program).then(
+      const episodes = await fetchProgramEpisodes(program, 1, 5).then(
         (resp: IPriApiCollectionResponse) => resp
       );
 

--- a/lib/fetch/program/fetchProgram.ts
+++ b/lib/fetch/program/fetchProgram.ts
@@ -17,7 +17,7 @@ import { fetchProgramStories } from './fetchProgramStories';
 
 export const fetchProgram = async (
   id: string,
-  params: ParsedUrlQuery
+  params?: ParsedUrlQuery
 ): Promise<PriApiResourceResponse> => {
   const programParams = {
     include: [
@@ -35,8 +35,6 @@ export const fetchProgram = async (
     id as string,
     programParams
   ).then((resp: IPriApiResourceResponse) => resp && resp.data);
-
-  console.log(params);
 
   if (program) {
     const { featuredStories } = program;

--- a/lib/fetch/program/fetchProgram.ts
+++ b/lib/fetch/program/fetchProgram.ts
@@ -9,15 +9,17 @@ import {
   IPriApiResourceResponse,
   IPriApiCollectionResponse
 } from 'pri-api-library/types';
+import { ParsedUrlQuery } from 'querystring';
 import { fetchPriApiItem } from '../api/fetchPriApi';
 import { basicStoryParams } from '../api/params';
 import { fetchProgramEpisodes } from './fetchProgramEpisodes';
 import { fetchProgramStories } from './fetchProgramStories';
 
 export const fetchProgram = async (
-  id: string
+  id: string,
+  params: ParsedUrlQuery
 ): Promise<PriApiResourceResponse> => {
-  const params = {
+  const programParams = {
     include: [
       'banner_image',
       'hosts.image',
@@ -31,43 +33,73 @@ export const fetchProgram = async (
   const program = await fetchPriApiItem(
     'node--programs',
     id as string,
-    params
+    programParams
   ).then((resp: IPriApiResourceResponse) => resp && resp.data);
+
+  console.log(params);
 
   if (program) {
     const { featuredStories } = program;
-    const [stories, episodes] = await Promise.all([
-      fetchProgramStories(program).then(
-        (resp: IPriApiCollectionResponse) => resp
-      ),
-      fetchProgramEpisodes(program).then(
-        (resp: IPriApiCollectionResponse) => resp
-      )
-    ]);
-    const storiesData = [...stories.data];
 
-    // Build response object.
-    const resp = {
-      data: {
-        ...program,
-        featuredStory: featuredStories
-          ? featuredStories.shift()
-          : storiesData.shift(),
-        featuredStories: featuredStories
-          ? [
-              ...featuredStories,
-              ...storiesData.splice(0, 4 - featuredStories.length)
-            ]
-          : storiesData.splice(0, 4),
-        stories: {
-          ...stories,
-          data: storiesData
-        },
-        episodes
-      }
-    } as IPriApiResourceResponse;
+    if (!params?.v || params.v !== 'episodes') {
+      const stories = await fetchProgramStories(program).then(
+        (resp: IPriApiCollectionResponse) => resp
+      );
+      const storiesData = [...stories.data];
+      const episodes = await fetchProgramEpisodes(program, 1, 1).then(
+        (resp: IPriApiCollectionResponse) => resp
+      );
 
-    return resp;
+      return {
+        data: {
+          ...program,
+          featuredStory: featuredStories
+            ? featuredStories.shift()
+            : storiesData.shift(),
+          featuredStories: featuredStories
+            ? [
+                ...featuredStories,
+                ...storiesData.splice(0, 4 - featuredStories.length)
+              ]
+            : storiesData.splice(0, 4),
+          stories: {
+            ...stories,
+            data: storiesData
+          },
+          episodes
+        }
+      } as IPriApiResourceResponse;
+    }
+
+    if (params?.v === 'episodes') {
+      const stories = await fetchProgramStories(program, 1, 5).then(
+        (resp: IPriApiCollectionResponse) => resp
+      );
+      const storiesData = [...stories.data];
+      const episodes = await fetchProgramEpisodes(program).then(
+        (resp: IPriApiCollectionResponse) => resp
+      );
+
+      return {
+        data: {
+          ...program,
+          featuredStory: featuredStories
+            ? featuredStories.shift()
+            : storiesData.shift(),
+          featuredStories: featuredStories
+            ? [
+                ...featuredStories,
+                ...storiesData.splice(0, 4 - featuredStories.length)
+              ]
+            : storiesData.splice(0, 4),
+          stories: {
+            ...stories,
+            data: storiesData
+          },
+          episodes
+        }
+      } as IPriApiResourceResponse;
+    }
   }
 
   return false;

--- a/lib/parse/menu/parseMenu.spec.ts
+++ b/lib/parse/menu/parseMenu.spec.ts
@@ -92,7 +92,7 @@ describe('lib/parse/menu', () => {
         data[1].children[0].attributes.name
       );
       expect(result[1].children[0]).toHaveProperty('url');
-      expect(result[1].children[0].url.href).toEqual(
+      expect(result[1].children[0].url).toEqual(
         data[1].children[0].attributes.url
       );
     });

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { GetStaticPropsResult } from 'next';
+import { GetServerSidePropsResult } from 'next';
 import dynamic from 'next/dynamic';
 import crypto from 'crypto';
 import { IPriApiResource } from 'pri-api-library/types';
@@ -81,7 +81,7 @@ export const getServerSideProps = wrapper.getServerSideProps(
   store => async ({
     res,
     params: { alias }
-  }): Promise<GetStaticPropsResult<any>> => {
+  }): Promise<GetServerSidePropsResult<any>> => {
     let resourceId: string;
     let resourceType: string = 'homepage';
     let redirect: string;

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -80,11 +80,13 @@ const ContentProxy = ({ type }: Props) => {
 export const getServerSideProps = wrapper.getServerSideProps(
   store => async ({
     res,
-    params: { alias }
+    req,
+    params
   }): Promise<GetServerSidePropsResult<any>> => {
     let resourceId: string;
     let resourceType: string = 'homepage';
     let redirect: string;
+    const { alias } = params;
     const aliasPath = (alias as string[]).join('/');
     const rgxFileExt = /\.\w+$/;
 
@@ -129,7 +131,7 @@ export const getServerSideProps = wrapper.getServerSideProps(
         const fetchData = getResourceFetchData(resourceType);
 
         if (fetchData) {
-          const data = await store.dispatch(fetchData(resourceId, res));
+          const data = await store.dispatch(fetchData(resourceId, req, res));
 
           await store.dispatch<any>(fetchAppData());
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,21 +14,27 @@ const IndexPage = () => {
   return <Homepage />;
 };
 
-export const getStaticProps = wrapper.getStaticProps(store => async () => {
-  const data = await store.dispatch<any>(fetchHomepageData());
+export const getServerSideProps = wrapper.getServerSideProps(
+  store => async ({ res }) => {
+    const data = await store.dispatch<any>(fetchHomepageData());
 
-  await store.dispatch<any>(fetchAppData());
+    await store.dispatch<any>(fetchAppData());
 
-  return {
-    props: {
-      type: 'homepage',
-      dataHash: crypto
-        .createHash('sha256')
-        .update(JSON.stringify(data))
-        .digest('hex')
-    },
-    revalidate: parseInt(process.env.ISR_REVALIDATE || '1', 10)
-  };
-});
+    res.setHeader(
+      'Cache-Control',
+      `public, s-maxage=${60 * 60}, stale-while-revalidate=${60 * 5}`
+    );
+
+    return {
+      props: {
+        type: 'homepage',
+        dataHash: crypto
+          .createHash('sha256')
+          .update(JSON.stringify(data))
+          .digest('hex')
+      }
+    };
+  }
+);
 
 export default IndexPage;

--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -7,17 +7,11 @@ import React from 'react';
 import { GetStaticPropsResult } from 'next';
 import dynamic from 'next/dynamic';
 import crypto from 'crypto';
-import { UrlWithParsedQuery } from 'url';
-import {
-  IPriApiResource,
-  IPriApiResourceResponse
-} from 'pri-api-library/types';
+import { IPriApiResource } from 'pri-api-library/types';
 import { IContentComponentProxyProps } from '@interfaces/content';
 import { RootState } from '@interfaces/state';
 import { fetchAliasData } from '@store/actions/fetchAliasData';
 import { wrapper } from '@store';
-import { fetchHomepage } from '@lib/fetch';
-import { generateLinkHrefForContent } from '@lib/routing';
 import { getResourceFetchData } from '@lib/import/fetchData';
 import { fetchCtaRegionGroupData } from '@store/actions/fetchCtaRegionGroupData';
 import { fetchAppData } from '@store/actions/fetchAppData';
@@ -47,8 +41,11 @@ const ContentProxy = ({ type }: Props) => {
   }
 };
 
-export const getStaticProps = wrapper.getStaticProps(
-  store => async ({ params: { slug } }): Promise<GetStaticPropsResult<any>> => {
+export const getServerSideProps = wrapper.getServerSideProps(
+  store => async ({
+    res,
+    params: { slug }
+  }): Promise<GetStaticPropsResult<any>> => {
     let resourceId: string;
     let resourceType: string = 'homepage';
     let redirect: string;
@@ -99,12 +96,17 @@ export const getStaticProps = wrapper.getStaticProps(
       const fetchData = getResourceFetchData(resourceType);
 
       if (fetchData) {
-        const data = await store.dispatch(fetchData(resourceId));
+        const data = await store.dispatch(fetchData(resourceId, res));
 
         await store.dispatch<any>(fetchAppData());
 
         await store.dispatch<any>(
           fetchCtaRegionGroupData('tw_cta_regions_site')
+        );
+
+        res.setHeader(
+          'Cache-Control',
+          `public, s-maxage=${60 * 60 * 24}, stale-while-revalidate=${60 * 5}`
         );
 
         return {
@@ -115,8 +117,7 @@ export const getStaticProps = wrapper.getStaticProps(
               .createHash('sha256')
               .update(JSON.stringify(data))
               .digest('hex')
-          },
-          revalidate: parseInt(process.env.ISR_REVALIDATE || '1', 10)
+          }
         };
       }
     }
@@ -124,52 +125,5 @@ export const getStaticProps = wrapper.getStaticProps(
     return { notFound: true };
   }
 );
-
-export const getStaticPaths = async () => {
-  let paths = [];
-
-  // Check if env wants static pages built.
-  if (process.env.TW_STATIC_PREBUILD === 'BUILD') {
-    const [homepage] = await Promise.all([
-      fetchHomepage().then((resp: IPriApiResourceResponse) => resp && resp.data)
-    ]);
-    const { episodes } = homepage;
-    const resources = [
-      ...episodes.data
-        .reduce(
-          (acc: IPriApiResource[], { audio }) => [
-            ...acc,
-            ...((audio?.segments
-              ? [...audio.segments]
-              : []) as IPriApiResource[])
-          ],
-          [] as IPriApiResource[]
-        )
-        .filter((item: IPriApiResource) => item.type === 'file--audio')
-    ];
-    paths = [
-      ...resources
-        .map(resource => ({
-          params: {
-            slug: (generateLinkHrefForContent(
-              resource,
-              true
-            ) as UrlWithParsedQuery)?.pathname
-          }
-        }))
-        .filter(({ params: { slug } }) => !!slug?.length)
-        .map(({ params: { slug } }) => ({
-          params: {
-            slug: slug?.split('/').slice(1)
-          }
-        }))
-    ];
-  }
-
-  return {
-    paths,
-    fallback: 'blocking'
-  };
-};
 
 export default ContentProxy;

--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { GetStaticPropsResult } from 'next';
+import { GetServerSidePropsResult } from 'next';
 import dynamic from 'next/dynamic';
 import crypto from 'crypto';
 import { IPriApiResource } from 'pri-api-library/types';
@@ -45,7 +45,7 @@ export const getServerSideProps = wrapper.getServerSideProps(
   store => async ({
     res,
     params: { slug }
-  }): Promise<GetStaticPropsResult<any>> => {
+  }): Promise<GetServerSidePropsResult<any>> => {
     let resourceId: string;
     let resourceType: string = 'homepage';
     let redirect: string;

--- a/store/actions/fetchHomepageData.ts
+++ b/store/actions/fetchHomepageData.ts
@@ -89,7 +89,9 @@ export const fetchHomepageData = (): ThunkAction<
 
     dispatch(appendResourceCollection(stories, type, id, 'stories'));
 
-    dispatch(appendResourceCollection(episodes, type, id, 'episodes'));
+    if (episodes) {
+      dispatch(appendResourceCollection(episodes, type, id, 'episodes'));
+    }
 
     dispatch(appendResourceCollection(latestStories, type, id, 'latest'));
 

--- a/store/actions/fetchTermData.ts
+++ b/store/actions/fetchTermData.ts
@@ -5,6 +5,8 @@
  */
 import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import { parse } from 'url';
+import { IncomingMessage } from 'http';
 import {
   IPriApiResource,
   IPriApiResourceResponse
@@ -16,13 +18,15 @@ import { appendResourceCollection } from './appendResourceCollection';
 import { fetchCtaRegionGroupData } from './fetchCtaRegionGroupData';
 
 export const fetchTermData = (
-  id: string
+  id: string,
+  req: IncomingMessage
 ): ThunkAction<void, {}, {}, AnyAction> => async (
   dispatch: ThunkDispatch<{}, {}, AnyAction>,
   getState: () => RootState
 ): Promise<IPriApiResource> => {
   const state = getState();
   const type = 'taxonomy_term--terms';
+  const params = req?.url ? parse(req.url, true).query : null;
   const isOnServer = typeof window === 'undefined';
   let data = getDataByResource(state, type, id);
 
@@ -35,7 +39,7 @@ export const fetchTermData = (
       }
     });
 
-    data = await (isOnServer ? fetchTerm : fetchApiTerm)(id).then(
+    data = await (isOnServer ? fetchTerm(id, params) : fetchApiTerm(id)).then(
       (resp: IPriApiResourceResponse) => resp && resp.data
     );
     const {


### PR DESCRIPTION
Closes #358 

- Switches pages to use `getServerSideProps`
- Reduces the amount of data fetched on home, programs, and terms pages to get response payloads within CloudFront limits.
- Fixed some errors in tests
- Cleans up some unused code from previous data fetching patterns
- CTA messages should now actually render on the server (were still wrapped in NoSsr components)

## To Review

- [x] Go to https://feat-358-switch-to-ssr.d2mc541hyaqum0.amplifyapp.com/

> ...then...

- [x] Browse site and ensure all page types load. Be sure to do a refresh after navigating to a new page. Report any URL's that return a CloudFront error.
- [x] Ensure CTA messages are shown without any content shifts.
