### PR TITLE
HOTFIX: Get cookies on server so CTA's don't render after they were closed

### DIFF
--- a/components/AppCtaBanner/AppCtaBanner.tsx
+++ b/components/AppCtaBanner/AppCtaBanner.tsx
@@ -11,7 +11,7 @@ import { Box, Container, IconButton } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { CloseSharp } from '@material-ui/icons';
 import { AppContext } from '@contexts/AppContext';
-import { getCtaRegionData } from '@store/reducers';
+import { getCookies, getCtaRegionData } from '@store/reducers';
 import { appCtaBannerStyles, appCtaBannerTheme } from './AppCtaBanner.styles';
 import { ctaTypeComponentMap } from './components';
 
@@ -24,7 +24,8 @@ export const AppCtaBanner = () => {
     }
   } = useContext(AppContext);
   const banner = getCtaRegionData(state, 'tw_cta_region_site_banner', type, id);
-  const shownMessage = getShownMessage(banner, true);
+  const cookies = getCookies(state);
+  const shownMessage = getShownMessage(banner, cookies);
   const { type: msgType } = shownMessage || {};
   const CtaMessageComponent = ctaTypeComponentMap[msgType] || null;
   const [closed, setClosed] = useState(false);

--- a/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
+++ b/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
@@ -11,7 +11,7 @@ import { ThemeProvider } from '@material-ui/core/styles';
 import { CloseSharp } from '@material-ui/icons';
 import { AppContext } from '@contexts/AppContext';
 import { getShownMessage, setCtaCookie } from '@lib/cta';
-import { getCtaRegionData } from '@store/reducers';
+import { getCookies, getCtaRegionData } from '@store/reducers';
 import {
   appCtaLoadUnderStyles,
   appCtaLoadUnderTheme
@@ -35,7 +35,8 @@ export const AppCtaLoadUnder = () => {
     type,
     id
   );
-  const shownMessage = getShownMessage(banner, true);
+  const cookies = getCookies(state);
+  const shownMessage = getShownMessage(banner, cookies);
   const { type: msgType } = shownMessage || {};
   const CtaMessageComponent = ctaTypeComponentMap[msgType] || null;
   const [closed, setClosed] = useState(false);

--- a/components/CtaRegion/CtaRegion.tsx
+++ b/components/CtaRegion/CtaRegion.tsx
@@ -11,7 +11,7 @@ import { ctaRegionTheme } from './CtaRegion.styles';
 import { ctaTypeComponentMap } from './components';
 
 export const CtaRegion = ({ data }: ICtaRegionProps) => {
-  const shownMessage = getShownMessage(data, true);
+  const shownMessage = getShownMessage(data);
   const { type } = shownMessage || {};
   const CtaMessageComponent = ctaTypeComponentMap[type] || null;
 

--- a/components/Sidebar/SidebarCta/SidebarCta.tsx
+++ b/components/Sidebar/SidebarCta/SidebarCta.tsx
@@ -11,7 +11,7 @@ import { sidebarCtaTheme } from './SidebarCta.styles';
 import { ctaTypeComponentMap } from './components';
 
 export const SidebarCta = ({ data }: ICtaRegionProps) => {
-  const shownMessage = getShownMessage(data, true);
+  const shownMessage = getShownMessage(data);
   const { type } = shownMessage;
   const CtaMessageComponent = ctaTypeComponentMap[type] || null;
 

--- a/interfaces/state/ctaRegionGroupData.interface.ts
+++ b/interfaces/state/ctaRegionGroupData.interface.ts
@@ -12,6 +12,10 @@ export interface CtaRegionGroupData {
   [k: string]: ICtaMessage[];
 }
 
+export interface Cookies {
+  [k: string]: string;
+}
+
 export interface CtaRegionGroupFilterProps {
   id: string;
   type: string;
@@ -23,7 +27,7 @@ export interface CtaRegionGroupFilterProps {
 
 export interface CtaRegionGroupDataState {
   data?: CtaRegionGroupData;
-
+  cookies?: Cookies;
   filterProps?: CtaRegionGroupFilterProps;
 }
 
@@ -32,5 +36,6 @@ export interface CtaRegionGroupAction extends AnyAction {
     ctaRegionData?: CtaRegionGroupDataState;
     data?: CtaRegionGroupData;
     filterProps?: CtaRegionGroupFilterProps;
+    cookies?: Cookies;
   };
 }

--- a/lib/cta/getShownMessage.ts
+++ b/lib/cta/getShownMessage.ts
@@ -2,8 +2,8 @@
  * @file getShownMessage.ts
  */
 
-import cookie from 'react-cookies';
 import { ICtaMessage } from '@interfaces/cta';
+import { Cookies } from '@interfaces/state';
 import { getCookieKey } from './getCookieKey';
 
 /**
@@ -17,17 +17,17 @@ import { getCookieKey } from './getCookieKey';
  */
 export const getShownMessage = (
   messages: ICtaMessage[],
-  ignoreCookie: boolean = false
+  cookies?: Cookies
 ): ICtaMessage => {
   let message = null;
 
   if (messages) {
-    message = ignoreCookie
+    message = !cookies
       ? [...messages].shift()
       : messages.reduce((result, msg) => {
           const { name, hash } = msg;
           const cookieName = getCookieKey(name);
-          const hashOld = cookie.load(cookieName);
+          const hashOld = cookies[cookieName];
           if (!result && (!hashOld || hashOld !== hash)) {
             return msg;
           }

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -131,6 +131,13 @@ export const getServerSideProps = wrapper.getServerSideProps(
         const fetchData = getResourceFetchData(resourceType);
 
         if (fetchData) {
+          store.dispatch<any>({
+            type: 'SET_COOKIES',
+            payload: {
+              cookies: req.cookies
+            }
+          });
+
           const data = await store.dispatch(fetchData(resourceId, req, res));
 
           await store.dispatch<any>(fetchAppData());

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,8 +15,15 @@ const IndexPage = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(
-  store => async ({ res }) => {
+  store => async ({ res, req }) => {
     const data = await store.dispatch<any>(fetchHomepageData());
+
+    store.dispatch<any>({
+      type: 'SET_COOKIES',
+      payload: {
+        cookies: req.cookies
+      }
+    });
 
     await store.dispatch<any>(fetchAppData());
 
@@ -28,6 +35,7 @@ export const getServerSideProps = wrapper.getServerSideProps(
     return {
       props: {
         type: 'homepage',
+        cookies: req.cookies,
         dataHash: crypto
           .createHash('sha256')
           .update(JSON.stringify(data))

--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -44,6 +44,7 @@ const ContentProxy = ({ type }: Props) => {
 export const getServerSideProps = wrapper.getServerSideProps(
   store => async ({
     res,
+    req,
     params: { slug }
   }): Promise<GetServerSidePropsResult<any>> => {
     let resourceId: string;
@@ -96,6 +97,13 @@ export const getServerSideProps = wrapper.getServerSideProps(
       const fetchData = getResourceFetchData(resourceType);
 
       if (fetchData) {
+        store.dispatch<any>({
+          type: 'SET_COOKIES',
+          payload: {
+            cookies: req.cookies
+          }
+        });
+
         const data = await store.dispatch(fetchData(resourceId, res));
 
         await store.dispatch<any>(fetchAppData());

--- a/store/reducers/ctaRegionGroupData.ts
+++ b/store/reducers/ctaRegionGroupData.ts
@@ -22,6 +22,15 @@ export const ctaRegionGroupData = (
     case HYDRATE:
       return { ...state, ...action.payload.ctaRegionData };
 
+    case 'SET_COOKIES':
+      return {
+        ...state,
+        cookies: {
+          ...(state.cookies || {}),
+          ...(action.payload.cookies || {})
+        }
+      };
+
     case 'FETCH_CTA_REGION_GROUP_DATA_SUCCESS':
       return {
         ...state,
@@ -44,6 +53,9 @@ export const ctaRegionGroupData = (
       return state;
   }
 };
+
+export const getCookies = (state: CtaRegionGroupDataState = {}) =>
+  state.cookies;
 
 export const getCtaRegionData = (
   state: CtaRegionGroupDataState = {},

--- a/store/reducers/index.ts
+++ b/store/reducers/index.ts
@@ -104,6 +104,8 @@ export const getCtaRegionData = (
     type,
     id
   );
+export const getCookies = (state: RootState) =>
+  fromCtaRegionGroupData.getCookies(state.ctaRegionData);
 
 export const getMenusData = (state: RootState, menu: string) =>
   fromMenusData.getMenusData(state.menusData, menu);


### PR DESCRIPTION
- add cookies to cta store
- update message filtering to use store cookies
- update cta components to pass cookies from store to message getter update pages to add cookies to store

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run 'yarn build
- [x] Run `yarn start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure sites loads
- [x] If you see a CTA banner, close it.
- [x] Reload page.
- [x] Ensure site loads without any weird styling issues.
- [x] Navigate to another page.
- [x] Ensure CTA remains closed.
- [x] Clear your cookies.
- [x] Reload page.
- [x] Ensure CTA is shown again.
