### PR TITLE
363: Add volume controls

### DIFF
--- a/components/AppPlayer/AppPlayer.styles.ts
+++ b/components/AppPlayer/AppPlayer.styles.ts
@@ -31,6 +31,9 @@ export const appPlayerStyles = makeStyles((theme: Theme) =>
       alignItems: 'center',
       justifyContent: 'center',
       gap: theme.typography.pxToRem(theme.spacing(0.25)),
+      [theme.breakpoints.down('sm')]: {
+        justifySelf: 'start'
+      },
       '&:last-child': {
         justifySelf: 'end'
       }
@@ -69,6 +72,11 @@ export const appPlayerStyles = makeStyles((theme: Theme) =>
     queueControls: {},
     autoplayButton: {
       [theme.breakpoints.down(400)]: {
+        display: 'none'
+      }
+    },
+    volume: {
+      [theme.breakpoints.down('xs')]: {
         display: 'none'
       }
     }

--- a/components/AppPlayer/AppPlayer.tsx
+++ b/components/AppPlayer/AppPlayer.tsx
@@ -15,7 +15,8 @@ import {
   ReplayButton,
   TimeInfo,
   TogglePlaylistButton,
-  TrackInfo
+  TrackInfo,
+  VolumeControls
 } from '@components/Player/components';
 import {
   AppBar,
@@ -138,6 +139,13 @@ export const AppPlayer = () => {
           </Box>
 
           <Box className={styles.controls}>
+            <VolumeControls
+              className={styles.volume}
+              muteButtonProps={{
+                classes: buttonClasses,
+                color: 'inherit'
+              }}
+            />
             <AutoplayButton className={styles.autoplayButton} />
             <TogglePlaylistButton
               classes={buttonClasses}

--- a/components/Player/components/VolumeControls/VolumeControls.styles.ts
+++ b/components/Player/components/VolumeControls/VolumeControls.styles.ts
@@ -1,0 +1,33 @@
+/**
+ * @file VolumeControls.style.ts
+ * Styles and theme for VolumeControls.
+ */
+
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+export const useVolumeControlsStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'grid',
+      gridTemplateColumns: '1fr min-content',
+      gap: theme.typography.pxToRem(theme.spacing(1)),
+      alignItems: 'center',
+      width: '150px'
+    },
+    track: {
+      transition: theme.transitions.create('opacity', {
+        duration: theme.transitions.duration.short,
+        easing: theme.transitions.easing.sharp
+      }),
+      '@media (hover: hover)': {
+        opacity: 0,
+        ':hover > &': {
+          opacity: 1
+        }
+      }
+    },
+    iconRoot: {
+      fontSize: 'inherit'
+    }
+  })
+);

--- a/components/Player/components/VolumeControls/VolumeControls.tsx
+++ b/components/Player/components/VolumeControls/VolumeControls.tsx
@@ -1,0 +1,100 @@
+/**
+ * @file VolumeControls.tsx
+ * Play progress bar control.
+ */
+
+import React, { useCallback, useContext } from 'react';
+import { PlayerContext } from '../../contexts';
+import { useVolumeControlsStyles } from './VolumeControls.styles';
+import {
+  Box,
+  BoxProps,
+  IconButton,
+  IconButtonProps,
+  Slider,
+  Tooltip
+} from '@material-ui/core';
+import {
+  VolumeDownSharp,
+  VolumeMuteSharp,
+  VolumeOffSharp,
+  VolumeUpSharp
+} from '@material-ui/icons';
+import clsx from 'clsx';
+
+export interface IVolumeControlsProps extends BoxProps {
+  muteButtonProps?: Partial<IconButtonProps>;
+}
+
+export const VolumeControls: React.FC<IVolumeControlsProps> = ({
+  className,
+  muteButtonProps,
+  ...other
+}: IVolumeControlsProps) => {
+  const { audioElm, state, setVolume, toggleMute } = useContext(PlayerContext);
+  const { volume, muted } = state;
+  const styles = useVolumeControlsStyles({});
+  const rootClassName = clsx(styles.root, className);
+  const iconClasses = {
+    root: styles.iconRoot
+  };
+  let VolumeIcon = VolumeUpSharp;
+
+  if (volume === 0) {
+    VolumeIcon = VolumeMuteSharp;
+  } else if (volume < 0.5) {
+    VolumeIcon = VolumeDownSharp;
+  }
+
+  /**
+   * Update player progress visuals.
+   */
+  const updateVolume = useCallback(
+    (newVolume?: number) => {
+      const { volume: v } = audioElm;
+      const updatedVolume = newVolume || newVolume === 0 ? newVolume : v;
+
+      setVolume(updatedVolume);
+    },
+    [audioElm]
+  );
+
+  /**
+   * Update volume based on slider position.
+   */
+  const handleSliderChange = (
+    e: React.ChangeEvent<{}>,
+    newValue: number | number[]
+  ) => {
+    updateVolume(newValue as number);
+  };
+
+  const handleMuteClick = () => {
+    toggleMute();
+  };
+
+  if (!audioElm) return null;
+
+  return (
+    <Box {...other} className={rootClassName}>
+      <Slider
+        className={styles.track}
+        max={1}
+        step={0.01}
+        value={volume}
+        onChange={handleSliderChange}
+        aria-label="Volume Slider"
+      />
+
+      <Tooltip title={muted ? 'Unmute' : 'Mute'} placement="top" arrow>
+        <IconButton {...muteButtonProps} onClick={handleMuteClick}>
+          {muted ? (
+            <VolumeOffSharp classes={iconClasses} />
+          ) : (
+            <VolumeIcon classes={iconClasses} />
+          )}
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+};

--- a/components/Player/components/VolumeControls/index.ts
+++ b/components/Player/components/VolumeControls/index.ts
@@ -1,0 +1,1 @@
+export * from './VolumeControls';

--- a/components/Player/components/index.ts
+++ b/components/Player/components/index.ts
@@ -12,3 +12,4 @@ export * from './ReplayButton';
 export * from './TimeInfo';
 export * from './TogglePlaylistButton';
 export * from './TrackInfo';
+export * from './VolumeControls';

--- a/pages/api/program/[id]/episodes/[page].ts
+++ b/pages/api/program/[id]/episodes/[page].ts
@@ -11,7 +11,7 @@ import { fetchPriApiItem, fetchPriApiQuery } from '@lib/fetch/api';
 import { basicEpisodeParams } from '@lib/fetch/api/params';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  const { id, page = '1', range = 10, exclude } = req.query;
+  const { id, page = '1', range = 5, exclude } = req.query;
 
   if (id) {
     const program = (await fetchPriApiItem(

--- a/pages/api/term/[id]/episodes/[page].ts
+++ b/pages/api/term/[id]/episodes/[page].ts
@@ -11,7 +11,7 @@ import { fetchPriApiItem, fetchPriApiQuery } from '@lib/fetch/api';
 import { basicEpisodeParams } from '@lib/fetch/api/params';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  const { id, page = '1', range = 10, exclude } = req.query;
+  const { id, page = '1', range = 5, exclude } = req.query;
 
   if (id) {
     const term = (await fetchPriApiItem(


### PR DESCRIPTION
Closes #363 

- add volume controls to app player
- fixes episode pagination on landing pages (first load more should load next 5 episodes)

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Play some audio.
- [x] Adjust volume using volume slider.
- [x] Mute and unmute audio with mute button.
- [x] Ensure volume controls update when keyboard shortcuts are used (`-`, `=`, `m`).
- [x] Refresh and ensure previous volume setting was preserved.
- [x] Inspect and switch to responsive view.
- [x] Ensure volume slider is visible without hover on touch devices.
- [x] Ensure volume is shown on device widths that make sense.
- [x] Go to The World program's episode page and load more episodes.
- [x] Ensure the expected 5 previous episodes are loaded.
