### PR TITLE
HOTFIX: Fix podtrac audio URL's when playing audio

### DIFF
--- a/lib/generate/string/generateAudioUrl.spec.ts
+++ b/lib/generate/string/generateAudioUrl.spec.ts
@@ -21,5 +21,15 @@ describe('lib/generate/string', () => {
 
       expect(result).toMatch('https://foo.com/bar.mp3?_from=theworld.org');
     });
+
+    test('should convert `www.prodtrac.com` to `dts.prodtrac.com.', () => {
+      const result = generateAudioUrl(
+        'https://www.podtrac.com/pts/redirect.mp3/foo.com/bar.mp3'
+      );
+
+      expect(result).toMatch(
+        'https://dts.podtrac.com/redirect.mp3/foo.com/bar.mp3?_from=theworld.org'
+      );
+    });
   });
 });

--- a/lib/generate/string/generateAudioUrl.ts
+++ b/lib/generate/string/generateAudioUrl.ts
@@ -11,6 +11,12 @@ export const generateAudioUrl = (audioUrl: string) => {
     : audioUrl;
   const url = new URL(audioUrlWithProtocol);
 
+  // Fix for deprecated podtrac redirect URL pattern.
+  if (url.href.startsWith('https://www.podtrac.com/pts')) {
+    url.host = 'dts.podtrac.com';
+    url.pathname = url.pathname.replace(/^\/pts/, '');
+  }
+
   if (!url.searchParams.get('_from')) {
     url.searchParams.set('_from', 'theworld.org');
   }

--- a/lib/parse/audio/audioData.ts
+++ b/lib/parse/audio/audioData.ts
@@ -26,12 +26,8 @@ export const parseAudioData = (
   } = data;
   const { canonical } = metatags || {};
   const { duration } = metadata || {};
-  const {
-    imageUrl,
-    title: fallbackTitle,
-    linkResource,
-    queuedFrom
-  } = fallbackProps || {};
+  const { imageUrl, title: fallbackTitle, linkResource, queuedFrom } =
+    fallbackProps || {};
   const broadcastDate =
     audioBroadcastDate ||
     linkResource?.broadcastDate ||
@@ -39,7 +35,7 @@ export const parseAudioData = (
     linkResource?.datePublished;
   const dataString =
     broadcastDate &&
-    ((d) => {
+    (d => {
       const timeStamp = parseInt(d, 10) * 1000;
       const date = new Date(timeStamp);
       return date.toLocaleDateString(undefined, { dateStyle: 'medium' });


### PR DESCRIPTION
- When parsing audio data to be played, replace `http://www.podtrac.com/pts/redirect.mp3` with `http://dts.podtrac.com/redirect.mp3`

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Ensure audio plays.
