### PR TITLE
370: Search using proxy API from browser

### DIFF
--- a/components/AppSearch/AppSearch.tsx
+++ b/components/AppSearch/AppSearch.tsx
@@ -117,7 +117,11 @@ export const AppSearch = ({ static: staticPage, q = null }: AppSearchProps) => {
 
   const handleFilterChange = (e: object, value: any) => {
     setLabel(value);
-    dialogContentRef.current.scrollTo = 0;
+
+    if (staticPage || !dialogContentRef.current) return;
+
+    console.log(dialogContentRef.current.scrollTo);
+    dialogContentRef.current.scroll({ top: 0 });
   };
 
   useEffect(() => {

--- a/components/AppSearch/AppSearch.tsx
+++ b/components/AppSearch/AppSearch.tsx
@@ -120,7 +120,6 @@ export const AppSearch = ({ static: staticPage, q = null }: AppSearchProps) => {
 
     if (staticPage || !dialogContentRef.current) return;
 
-    console.log(dialogContentRef.current.scrollTo);
     dialogContentRef.current.scroll({ top: 0 });
   };
 

--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -3,20 +3,19 @@
  * Exports a mechanism that makes GET requests to API easier to manage.
  */
 
-import fetch from 'isomorphic-unfetch';
+import { customsearch_v1 } from 'googleapis';
+import { IncomingMessage } from 'http';
+import { ParsedUrlQuery } from 'querystring';
 import {
   IPriApiCollectionResponse,
   IPriApiResourceResponse
 } from 'pri-api-library/types';
-import { IncomingMessage } from 'http';
-import { ParsedUrlQuery } from 'querystring';
-import { parse, format } from 'url';
-import { customsearch_v1 } from 'googleapis';
 import {
   INewsletterOptions,
   INewsletterData,
   ICMApiCustomField
 } from '@interfaces/newsletter';
+import { parse, format } from 'url';
 
 /**
  * Method that simplifies GET requests.
@@ -556,19 +555,12 @@ export const fetchApiSearch = (
   q: string,
   label: string,
   start: string | number
-) =>
-  fetch(
-    format({
-      protocol: 'https',
-      hostname: 'search.theworld.org', // TODO: Update to `search.theworld.org` when DNS is ready.
-      pathname: 'query',
-      query: {
-        ...(q && { q }),
-        ...(label && { l: `${label}` }),
-        ...(start && { s: `${start}` }),
-        t: 'metatags-pubdate:d,date:d:s'
-      }
-    })
-  ).then(r => r.status === 200 && r.json()) as Promise<
-    customsearch_v1.Schema$Search
-  >;
+) => {
+  let url = format({
+    pathname: `query/search/${label}/${q}`,
+    query: {
+      ...(start && { start })
+    }
+  });
+  return fetchApi(url) as Promise<customsearch_v1.Schema$Search>;
+};

--- a/lib/fetch/query/fetchQuerySearch.ts
+++ b/lib/fetch/query/fetchQuerySearch.ts
@@ -1,0 +1,35 @@
+/**
+ * Query search server.
+ */
+
+import { customsearch_v1 } from 'googleapis';
+import { format } from 'url';
+
+/**
+ * Fetch search results from search server.
+ *
+ * @param q Search string.
+ * @param label Facet label.
+ * @param start Start of results to return.
+ * @returns Search results.
+ */
+export const fetchQuerySearch = (
+  q: string,
+  label: string,
+  start: string | number
+) =>
+  fetch(
+    format({
+      protocol: 'https',
+      hostname: 'search.theworld.org',
+      pathname: 'query',
+      query: {
+        ...(q && { q }),
+        ...(label && { l: `${label}` }),
+        ...(start && { s: `${start}` }),
+        t: 'metatags-pubdate:d,date:d:s'
+      }
+    })
+  ).then(r => r.status === 200 && r.json()) as Promise<
+    customsearch_v1.Schema$Search
+  >;

--- a/lib/fetch/query/index.ts
+++ b/lib/fetch/query/index.ts
@@ -1,1 +1,2 @@
 export * from './fetchQueryAlias';
+export * from './fetchQuerySearch';

--- a/pages/api/query/search/[label]/[q].ts
+++ b/pages/api/query/search/[label]/[q].ts
@@ -4,13 +4,13 @@
  */
 
 import { NextApiRequest, NextApiResponse } from 'next';
-import { fetchApiSearch } from '@lib/fetch/api';
+import { fetchQuerySearch } from '@lib/fetch';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { label, q, start } = req.query;
 
   if (q.length) {
-    const apiResp = await fetchApiSearch(
+    const apiResp = await fetchQuerySearch(
       q as string,
       label as string,
       start as string

--- a/store/actions/fetchSearchData.ts
+++ b/store/actions/fetchSearchData.ts
@@ -6,14 +6,14 @@
 
 import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import { parse } from 'url';
 import { IPriApiResource } from 'pri-api-library/types';
+import { parse } from 'url';
 import {
   RootState,
   searchFacetLabels,
   SearchFacetAll
 } from '@interfaces/state';
-import { fetchApiSearch } from '@lib/fetch';
+import { fetchApiSearch, fetchQuerySearch } from '@lib/fetch';
 import { getSearchData } from '@store/reducers';
 import { fetchBulkAliasData } from './fetchAliasData';
 import { fetchStoryData } from './fetchStoryData';
@@ -33,6 +33,8 @@ export const fetchSearchData = (
   const facets = label === 'all' ? searchFacetLabels : [label];
   const currentData = getSearchData(state, query) || {};
   const q = (query || '').toLowerCase().replace(/^\s+|\s+$/, '');
+  const isOnServer = typeof window === 'undefined';
+  const fetchFunc = isOnServer ? fetchQuerySearch : fetchApiSearch;
 
   // Map facet labels to data fetch for content type.
   const funcMap = new Map();
@@ -55,7 +57,7 @@ export const fetchSearchData = (
     const start: number = [...(facetData || [])].pop()?.queries?.nextPage?.[0]
       .startIndex;
 
-    return fetchApiSearch(query, l, start)
+    return fetchFunc(query, l, start)
       .then(data => ({
         l,
         data
@@ -77,6 +79,7 @@ export const fetchSearchData = (
       const reqs = aliasesData
         .map(([, { id, type }]): [
           string,
+          // eslint-disable-next-line no-unused-vars
           (id: string) => ThunkAction<void, {}, {}, AnyAction>
         ] => [id as string, funcMap.get(type)])
         .filter(([, fetchFunc]) => !!fetchFunc)


### PR DESCRIPTION
Closes #370 

- Ensure search requests use app API to proxy requests to the search server when fetch is done in the browser.

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Open network inspector and filter to Fetch/XHR requests.
- [x] Open search dialog and perform a search.
- [x] Ensure requests are made to `/api/query/search/your+search+term` and not to `search.theworld.org`.
