### PR TITLE
372: Fix search result pagination

### DIFF
--- a/lib/fetch/api/fetchApi.ts
+++ b/lib/fetch/api/fetchApi.ts
@@ -555,12 +555,7 @@ export const fetchApiSearch = (
   q: string,
   label: string,
   start: string | number
-) => {
-  let url = format({
-    pathname: `query/search/${label}/${q}`,
-    query: {
-      ...(start && { start })
-    }
-  });
-  return fetchApi(url) as Promise<customsearch_v1.Schema$Search>;
-};
+) =>
+  fetchApi(`query/search/${label}/${q}`, undefined, {
+    ...(start && { start: `${start}` })
+  }) as Promise<customsearch_v1.Schema$Search>;


### PR DESCRIPTION
Closes #372

- Fixes a bug in paginated search queries encoding query string params into search term value.

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Open search dialog and search for something.
- [x] Load more results several more times and ensure the added results are not repeated.
