### PR TITLE
382: Search media card styles

### DIFF
--- a/components/MediaCard/MediaCard.styles.ts
+++ b/components/MediaCard/MediaCard.styles.ts
@@ -3,15 +3,14 @@
  * Styles for media card.
  */
 
-import { alpha, createTheme, Theme } from '@mui/material/styles';
-import { openSans } from '@theme/fonts';
 import { makeStyles } from 'tss-react/mui';
 
 export const mediaCardStyles = makeStyles<{ isLoading: boolean }, 'feature'>()(
   (theme, { isLoading }, classes) => ({
     root: {},
     title: {
-      marginTop: theme.typography.pxToRem(8),
+      margin: 0,
+      lineHeight: 1.1,
       [theme.breakpoints.down('xs')]: {
         fontSize: theme.typography.pxToRem(16),
         [`.${classes.feature} &`]: {
@@ -39,108 +38,20 @@ export const mediaCardStyles = makeStyles<{ isLoading: boolean }, 'feature'>()(
     MuiCardActionAreaRoot: {
       display: 'grid',
       gridTemplateColumns: 'min-content 1fr',
-      gridGap: `${theme.spacing(2)}px`,
+      gridGap: theme.typography.pxToRem(8),
       alignItems: 'center',
-      padding: `${theme.spacing(2)}px`
+      padding: theme.typography.pxToRem(12)
     },
     MuiCardContentRoot: {
       overflow: 'hidden',
       padding: 0
     },
-    MuiCardMediaRoot: {},
+    MuiCardMediaRoot: {
+      color: theme.palette.primary.main
+    },
     feature: {},
     short: {},
     isLoading: {},
     noImage: {}
   })
 );
-
-export const mediaCardTheme = (theme: Theme) =>
-  createTheme(theme, {
-    typography: {
-      h5: {
-        lineHeight: 1.1
-      },
-      overline: {
-        display: 'block',
-        position: 'relative',
-        zIndex: 1,
-        fontFamily: openSans.style.fontFamily,
-        letterSpacing: 'unset',
-        textTransform: 'unset'
-      }
-    },
-    overrides: {
-      MuiButtonBase: {
-        root: {
-          fontSize: 'inherit',
-          lineHeight: 'inherit'
-        }
-      },
-      MuiCard: {
-        root: {
-          color: theme.palette.primary.main
-        }
-      },
-      MuiCardActions: {
-        root: {
-          margin: 0,
-          padding: 0
-        }
-      },
-      MuiCardContent: {
-        root: {
-          color: theme.palette.text.primary,
-          fontWeight: theme.typography.fontWeightBold
-        }
-      },
-      MuiCardMedia: {
-        root: {
-          position: 'relative',
-          overflow: 'hidden',
-          width: '100%'
-        }
-      },
-      MuiList: {
-        root: {
-          width: '100%'
-        },
-        padding: {
-          paddingTop: 0,
-          paddingBottom: theme.typography.pxToRem(16)
-        }
-      },
-      MuiListItem: {
-        root: {},
-        button: {
-          '&:hover': {
-            color: theme.palette.primary.main,
-            backgroundColor: alpha(
-              theme.palette.primary.main,
-              theme.palette.action.hoverOpacity
-            )
-          }
-        }
-      },
-      MuiListItemText: {
-        root: {
-          display: 'list-item',
-          listStyle: 'disc',
-          marginTop: 0,
-          marginBottom: 0,
-          marginLeft: theme.spacing(2),
-          color: theme.palette.grey[500]
-        },
-        primary: {
-          color: theme.palette.primary.main,
-          fontWeight: theme.typography.fontWeightBold,
-          lineHeight: 1
-        }
-      },
-      MuiTypography: {
-        gutterBottom: {
-          marginBottom: theme.typography.pxToRem(12)
-        }
-      }
-    }
-  });

--- a/components/MediaCard/MediaCard.tsx
+++ b/components/MediaCard/MediaCard.tsx
@@ -14,17 +14,15 @@ import {
   CardActionArea,
   CardContent,
   CardMedia,
-  Grid,
   LinearProgress,
   Typography
 } from '@mui/material';
-import { ThemeProvider } from '@mui/styles';
 import PlayCircleOutlineRounded from '@mui/icons-material/PlayCircleOutlineRounded';
 import ImageRounded from '@mui/icons-material/ImageRounded';
 import VideocamRounded from '@mui/icons-material/VideocamRounded';
 import { ContentLink } from '@components/ContentLink';
 import { generateLinkHrefForContent } from '@lib/routing';
-import { mediaCardStyles, mediaCardTheme } from './MediaCard.styles';
+import { mediaCardStyles } from './MediaCard.styles';
 
 const Moment = dynamic(() => import('react-moment')) as any;
 
@@ -72,59 +70,48 @@ export const MediaCard = ({ data }: MediaCardProps) => {
   }, [pathname, router.events]);
 
   return (
-    <ThemeProvider theme={mediaCardTheme}>
-      <Card
-        square
-        elevation={1}
-        className={cx({
-          [classes.isLoading]: isLoading
-        })}
-      >
-        <CardActionArea classes={{ root: classes.MuiCardActionAreaRoot }}>
-          {CardIcon && (
-            <CardMedia classes={{ root: classes.MuiCardMediaRoot }}>
-              <CardIcon style={{ fontSize: '5rem' }} />
-              <LinearProgress
-                className={classes.loadingBar}
-                color="secondary"
-                aria-label="Progress Bar"
-              />
-            </CardMedia>
-          )}
-          <CardContent classes={{ root: classes.MuiCardContentRoot }}>
-            {cardDate && (
-              <Grid
-                container
-                justifyContent="space-between"
-                spacing={1}
-                style={{ marginBottom: 0 }}
-              >
-                <Grid item xs="auto" zeroMinWidth>
-                  <Typography
-                    variant="subtitle2"
-                    component="span"
-                    color="textSecondary"
-                    noWrap
-                  >
-                    <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
-                      {cardDate}
-                    </Moment>
-                  </Typography>
-                </Grid>
-              </Grid>
-            )}
+    <Card
+      square
+      elevation={1}
+      className={cx(classes.root, {
+        [classes.isLoading]: isLoading
+      })}
+    >
+      <CardActionArea classes={{ root: classes.MuiCardActionAreaRoot }}>
+        {CardIcon && (
+          <CardMedia classes={{ root: classes.MuiCardMediaRoot }}>
+            <CardIcon style={{ fontSize: '5rem' }} />
+            <LinearProgress
+              className={classes.loadingBar}
+              color="secondary"
+              aria-label="Progress Bar"
+            />
+          </CardMedia>
+        )}
+        <CardContent classes={{ root: classes.MuiCardContentRoot }}>
+          {cardDate && (
             <Typography
-              variant="h5"
-              component="h2"
-              gutterBottom
-              className={classes.title}
+              variant="subtitle2"
+              component="span"
+              color="textSecondary"
+              noWrap
             >
-              {cardTitle}
+              <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
+                {cardDate}
+              </Moment>
             </Typography>
-          </CardContent>
-          <ContentLink data={data} className={cx('link')} />
-        </CardActionArea>
-      </Card>
-    </ThemeProvider>
+          )}
+          <Typography
+            variant="h5"
+            component="h2"
+            gutterBottom
+            className={classes.title}
+          >
+            {cardTitle}
+          </Typography>
+        </CardContent>
+        <ContentLink data={data} className={classes.link} />
+      </CardActionArea>
+    </Card>
   );
 };


### PR DESCRIPTION
Closes #382 

- Media cards in search results should look much better

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Search for `marco werman`.
- [ ] View media results.
- [ ] Ensure cards look good and whole card can be clicked to go to result's page.
