### PR TITLE
388: Default Story w/ WP GraphQL Data

### DIFF
--- a/components/LedeVideo/LedeVideo.tsx
+++ b/components/LedeVideo/LedeVideo.tsx
@@ -11,7 +11,11 @@ import { useTheme } from '@mui/styles';
 import { ledeVideoStyles } from './LedeVideo.styles';
 
 export interface ILedeVideoProps {
-  data: any;
+  data: {
+    url: string;
+    description?: string;
+    credit?: string;
+  };
 }
 
 export const LedeVideo = ({ data }: ILedeVideoProps) => {

--- a/components/pages/Story/Story.tsx
+++ b/components/pages/Story/Story.tsx
@@ -35,8 +35,7 @@ export const Story = ({ data }: IContentComponentProps<Post>) => {
       pubdate: broadcastDate || date
     })
   };
-  const LayoutComponent =
-    (format && layoutComponentMap[format]) || layoutComponentMap.standard;
+  const LayoutComponent = layoutComponentMap.get(format || 'standard');
   const props = {
     Title: title,
     ...(storyFormats && { 'Story Format': storyFormats.nodes[0].name }),

--- a/components/pages/Story/layouts/default/Story.default.tsx
+++ b/components/pages/Story/layouts/default/Story.default.tsx
@@ -3,36 +3,36 @@
  * Component for default Story layout.
  */
 
-import type { IPriApiResource } from 'pri-api-library/types';
-import React, { useEffect, useState } from 'react';
+import type React from 'react';
+import type { ITagsProps } from '@components/Tags';
+import type {
+  IContentComponentProps,
+  Post_Additionalmedia as PostAdditionalMedia,
+  PostStory
+} from '@interfaces';
 import dynamic from 'next/dynamic';
 import { convertNodeToElement, Transform } from 'react-html-parser';
 import { DomElement } from 'htmlparser2';
-import { useStore } from 'react-redux';
 import { ThemeProvider } from '@mui/styles';
-import { Box, Container, Grid, Hidden } from '@mui/material';
+import { Box, Container, Grid } from '@mui/material';
 import { NoJsPlayer } from '@components/AudioPlayer/NoJsPlayer';
 import { Sidebar, SidebarLatestStories } from '@components/Sidebar';
 import { HtmlContent } from '@components/HtmlContent';
 import { enhanceImage } from '@components/HtmlContent/transforms';
-import { ITagsProps } from '@components/Tags';
-import { IContentComponentProps } from '@interfaces/content';
-import { ICtaRegionProps } from '@interfaces/cta';
-import { RootState } from '@interfaces/state';
-import { getCollectionData, getCtaRegionData } from '@store/reducers';
+// import { ICtaRegionProps } from '@interfaces/cta';
 import { useStoryStyles, storyTheme } from './Story.default.styles';
 import { IStoryRelatedLinksProps, StoryHeader, StoryLede } from './components';
 
-const CtaRegion = dynamic(
-  () => import('@components/CtaRegion').then((mod) => mod.CtaRegion) as any
-) as React.FC<ICtaRegionProps>;
+// const CtaRegion = dynamic(
+//   () => import('@components/CtaRegion').then((mod) => mod.CtaRegion) as any
+// ) as React.FC<ICtaRegionProps>;
 
-const SidebarCta = dynamic(
-  () =>
-    import('@components/Sidebar/SidebarCta').then(
-      (mod) => mod.SidebarCta
-    ) as any
-) as React.FC<ICtaRegionProps>;
+// const SidebarCta = dynamic(
+//   () =>
+//     import('@components/Sidebar/SidebarCta').then(
+//       (mod) => mod.SidebarCta
+//     ) as any
+// ) as React.FC<ICtaRegionProps>;
 
 const StoryRelatedLinks = dynamic(
   () =>
@@ -45,90 +45,73 @@ const Tags = dynamic(() =>
   import('@components/Tags').then((mod) => mod.Tags)
 ) as React.FC<ITagsProps>;
 
-interface StateProps extends RootState {}
+export interface IStoryDefaultProps {
+  data: PostStory;
+}
 
-type Props = StateProps & IContentComponentProps<IPriApiResource>;
-
-export const StoryDefault = ({ data }: Props) => {
+export const StoryDefault = ({ data }: IContentComponentProps<PostStory>) => {
   const {
-    type,
-    id,
-    audio,
-    body,
+    additionalMedia,
+    content,
     categories,
     primaryCategory,
     tags,
-    opencalaisCity,
-    opencalaisContinent,
-    opencalaisCountry,
-    opencalaisProvince,
-    opencalaisRegion,
-    opencalaisPerson
+    cities,
+    continents,
+    countries,
+    provincesOrStates,
+    regions,
+    people
   } = data;
-  const store = useStore<RootState>();
-  const [state, updateForce] = useState(store.getState());
-  const unsub = store.subscribe(() => {
-    updateForce(store.getState());
-  });
-  const relatedState =
-    primaryCategory &&
-    getCollectionData(
-      state,
-      primaryCategory.type,
-      primaryCategory.id as string,
-      'related'
-    );
-  const related =
-    relatedState &&
-    relatedState.items[1].filter((item) => item.id !== id).slice(0, 4);
-
-  // CTA data.
-  const ctaInlineMobile01 = getCtaRegionData(
-    state,
-    'tw_cta_region_content_inline_mobile_01',
-    type,
-    id as string
-  );
-  const ctaInlineMobile02 = getCtaRegionData(
-    state,
-    'tw_cta_region_content_inline_mobile_02',
-    type,
-    id as string
-  );
-  const ctaInlineEnd = getCtaRegionData(
-    state,
-    'tw_cta_region_content_inline_end',
-    type,
-    id as string
-  );
-  const ctaSidebarTop = getCtaRegionData(
-    state,
-    'tw_cta_region_content_sidebar_01',
-    type,
-    id as string
-  );
-  const ctaSidebarBottom = getCtaRegionData(
-    state,
-    'tw_cta_region_content_sidebar_02',
-    type,
-    id as string
-  );
-
+  const { audio } = additionalMedia as PostAdditionalMedia;
+  const related = primaryCategory?.nodes[0].posts?.nodes;
   const { classes } = useStoryStyles();
   const hasRelated = related && !!related.length;
-  const hasCategories = categories && !!categories.length;
+  const hasCategories = !!categories?.nodes?.length;
   const allTags = [
-    ...(tags || []),
-    ...(opencalaisCity || []),
-    ...(opencalaisContinent || []),
-    ...(opencalaisCountry || []),
-    ...(opencalaisProvince || []),
-    ...(opencalaisRegion || []),
-    ...(opencalaisPerson || [])
+    ...(tags?.nodes || []),
+    ...(cities?.nodes || []),
+    ...(continents?.nodes || []),
+    ...(countries?.nodes || []),
+    ...(provincesOrStates?.nodes || []),
+    ...(regions?.nodes || []),
+    ...(people?.nodes || [])
   ];
   const hasTags = !!allTags.length;
   let ctaMobile01Position: number;
   let ctaMobile02Position: number;
+
+  // // CTA data.
+  // const ctaInlineMobile01 = getCtaRegionData(
+  //   state,
+  //   'tw_cta_region_content_inline_mobile_01',
+  //   type,
+  //   id as string
+  // );
+  // const ctaInlineMobile02 = getCtaRegionData(
+  //   state,
+  //   'tw_cta_region_content_inline_mobile_02',
+  //   type,
+  //   id as string
+  // );
+  // const ctaInlineEnd = getCtaRegionData(
+  //   state,
+  //   'tw_cta_region_content_inline_end',
+  //   type,
+  //   id as string
+  // );
+  // const ctaSidebarTop = getCtaRegionData(
+  //   state,
+  //   'tw_cta_region_content_sidebar_01',
+  //   type,
+  //   id as string
+  // );
+  // const ctaSidebarBottom = getCtaRegionData(
+  //   state,
+  //   'tw_cta_region_content_sidebar_02',
+  //   type,
+  //   id as string
+  // );
 
   const insertCtaMobile01 = (
     node: DomElement,
@@ -147,11 +130,11 @@ export const StoryDefault = ({ data }: Props) => {
       return (
         <>
           {convertNodeToElement(node, index, transform)}
-          {ctaInlineMobile01 && (
+          {/* {ctaInlineMobile01 && (
             <Hidden mdUp>
               <CtaRegion data={ctaInlineMobile01} />
             </Hidden>
-          )}
+          )} */}
         </>
       );
     }
@@ -177,11 +160,11 @@ export const StoryDefault = ({ data }: Props) => {
       return (
         <>
           {convertNodeToElement(node, index, transform)}
-          {ctaInlineMobile02 && (
+          {/* {ctaInlineMobile02 && (
             <Hidden mdUp>
               <CtaRegion data={ctaInlineMobile02} />
             </Hidden>
-          )}
+          )} */}
         </>
       );
     }
@@ -209,36 +192,31 @@ export const StoryDefault = ({ data }: Props) => {
     }
   });
 
-  useEffect(
-    () => () => {
-      unsub();
-    },
-    [unsub]
-  );
-
   return (
     <ThemeProvider theme={storyTheme}>
       <Container fixed>
         <Grid container>
           <Grid item xs={12}>
             <StoryHeader data={data} />
-            {audio ? <NoJsPlayer url={audio.url} /> : null}
+            {audio?.sourceUrl ? <NoJsPlayer url={audio.sourceUrl} /> : null}
           </Grid>
           <Grid item xs={12}>
             <Box className={classes.main}>
               <Box className={classes.content}>
                 <StoryLede data={data} />
                 <Box className={classes.body} my={2}>
-                  <HtmlContent
-                    html={body}
-                    transforms={[
-                      insertCtaMobile01,
-                      insertCtaMobile02,
-                      enhanceImages
-                    ]}
-                  />
+                  {content && (
+                    <HtmlContent
+                      html={content}
+                      transforms={[
+                        insertCtaMobile01,
+                        insertCtaMobile02,
+                        enhanceImages
+                      ]}
+                    />
+                  )}
                 </Box>
-                {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />}
+                {/* {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />} */}
                 {hasRelated && (
                   <aside>
                     <header>
@@ -247,12 +225,14 @@ export const StoryDefault = ({ data }: Props) => {
                     <StoryRelatedLinks data={related} />
                   </aside>
                 )}
-                {hasCategories && <Tags data={categories} label="Categories" />}
+                {hasCategories && (
+                  <Tags data={categories.nodes} label="Categories" />
+                )}
                 {hasTags && <Tags data={allTags} label="Tags" />}
               </Box>
               <Sidebar container className={classes.sidebar}>
                 <SidebarLatestStories />
-                <Hidden smDown>
+                {/* <Hidden smDown>
                   {ctaSidebarTop && (
                     <Sidebar item stretch>
                       <SidebarCta data={ctaSidebarTop} />
@@ -263,7 +243,7 @@ export const StoryDefault = ({ data }: Props) => {
                       <SidebarCta data={ctaSidebarBottom} />
                     </Sidebar>
                   )}
-                </Hidden>
+                </Hidden> */}
               </Sidebar>
             </Box>
           </Grid>

--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -57,8 +57,6 @@ export const StoryHeader = ({ data }: Props) => {
   } as Partial<IAudioData>;
   const { classes } = storyHeaderStyles();
 
-  console.log(broadcastDate, date);
-
   if (contributors?.nodes.length) {
     bylines.push(['By', contributors.nodes]);
   }

--- a/components/pages/Story/layouts/default/components/StoryLede/StoryLede.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryLede/StoryLede.default.tsx
@@ -3,11 +3,14 @@
  * Component for default story lede.
  */
 
-import React from 'react';
+import type React from 'react';
+import type {
+  PostStory,
+  Post_Additionalmedia as PostAdditionalMedia
+} from '@interfaces';
+import type { ILedeImageProps } from '@components/LedeImage';
+import type { ILedeVideoProps } from '@components/LedeVideo';
 import dynamic from 'next/dynamic';
-import { IPriApiResource } from 'pri-api-library/types';
-import { ILedeImageProps } from '@components/LedeImage';
-import { ILedeVideoProps } from '@components/LedeVideo';
 
 const LedeImage = dynamic(
   () => import('@components/LedeImage').then((mod) => mod.LedeImage) as any
@@ -18,13 +21,15 @@ const LedeVideo = dynamic(
 ) as React.FC<ILedeVideoProps>;
 
 interface Props {
-  data: IPriApiResource;
+  data: PostStory;
 }
 
 export const StoryLede = ({ data }: Props) => {
-  const { image, video } = data;
+  const { featuredImage, additionalMedia } = data;
+  const image = featuredImage?.node;
+  const { video } = additionalMedia as PostAdditionalMedia;
 
-  if (video) return <LedeVideo data={video[0]} />;
+  if (video) return <LedeVideo data={{ url: video }} />;
 
   if (image) return <LedeImage data={image} />;
 

--- a/components/pages/Story/layouts/default/components/StoryRelatedLinks/StoryRelatedLinks.default.styles.ts
+++ b/components/pages/Story/layouts/default/components/StoryRelatedLinks/StoryRelatedLinks.default.styles.ts
@@ -12,6 +12,13 @@ export const storyRelatedLinksStyles = makeStyles()((theme) => ({
   title: {
     fontSize: 'inherit'
   },
+  link: {
+    position: 'absolute',
+    inset: 0,
+    overflow: 'hidden',
+    textIndent: '-2000vw'
+  },
+
   MuiCardActionAreaRoot: {
     display: 'flex',
     flexDirection: 'column',
@@ -24,6 +31,7 @@ export const storyRelatedLinksStyles = makeStyles()((theme) => ({
       color: theme.palette.primary.main
     }
   },
+
   MuiCardMediaRoot: {
     position: 'relative',
     paddingTop: `${100 / (16 / 9)}%`

--- a/components/pages/Story/layouts/default/components/StoryRelatedLinks/StoryRelatedLinks.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryRelatedLinks/StoryRelatedLinks.default.tsx
@@ -3,9 +3,8 @@
  * Component for default story related links.
  */
 
-import React from 'react';
+import type { PostStory } from '@interfaces';
 import Image from 'next/legacy/image';
-import { IPriApiResource } from 'pri-api-library/types';
 import {
   Card,
   CardActionArea,
@@ -18,7 +17,7 @@ import { ContentLink } from '@components/ContentLink';
 import { storyRelatedLinksStyles } from './StoryRelatedLinks.default.styles';
 
 export interface IStoryRelatedLinksProps {
-  data: IPriApiResource[];
+  data: PostStory[];
 }
 
 export const StoryRelatedLinks = ({
@@ -39,38 +38,41 @@ export const StoryRelatedLinks = ({
       classes={{ root: classes.root }}
     >
       {related.map((story) => {
-        const { id: storyId, title, image } = story;
+        const { id: storyId, title, featuredImage, link } = story;
+        const image = featuredImage?.node;
         return (
-          <Grid item display="grid" lg={3} sm={6} xs={12} key={storyId}>
-            <Card square elevation={1}>
-              <CardActionArea
-                component={ContentLink}
-                url={story.link}
-                classes={{ root: classes.MuiCardActionAreaRoot }}
-              >
-                {image && (
-                  <CardMedia classes={{ root: classes.MuiCardMediaRoot }}>
-                    <Image
-                      src={image.url}
-                      alt={image.alt}
-                      layout="fill"
-                      objectFit="cover"
-                      sizes={sizes}
-                    />
-                  </CardMedia>
-                )}
-                <CardContent>
-                  <Typography
-                    variant="h5"
-                    component="h2"
-                    className={classes.title}
-                  >
-                    {title}
-                  </Typography>
-                </CardContent>
-              </CardActionArea>
-            </Card>
-          </Grid>
+          link && (
+            <Grid item display="grid" md={3} sm={6} xs={12} key={storyId}>
+              <Card square elevation={1}>
+                <CardActionArea
+                  LinkComponent={ContentLink}
+                  classes={{ root: classes.MuiCardActionAreaRoot }}
+                >
+                  {image?.sourceUrl && (
+                    <CardMedia classes={{ root: classes.MuiCardMediaRoot }}>
+                      <Image
+                        src={image.sourceUrl}
+                        alt={image.altText || ''}
+                        layout="fill"
+                        objectFit="cover"
+                        sizes={sizes}
+                      />
+                    </CardMedia>
+                  )}
+                  <CardContent>
+                    <Typography
+                      variant="h5"
+                      component="h2"
+                      className={classes.title}
+                    >
+                      {title}
+                    </Typography>
+                    <ContentLink url={link || ''} className={classes.link} />
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Grid>
+          )
         );
       })}
     </Grid>

--- a/components/pages/Story/layouts/feature/Story.feature.tsx
+++ b/components/pages/Story/layouts/feature/Story.feature.tsx
@@ -6,6 +6,7 @@
 import type React from 'react';
 import type { ITagsProps } from '@components/Tags';
 import type {
+  IContentComponentProps,
   Post_Additionalmedia as PostAdditionalMedia,
   PostStory
 } from '@interfaces';
@@ -30,11 +31,7 @@ const Tags = dynamic(() =>
   import('@components/Tags').then((mod) => mod.Tags)
 ) as React.FC<ITagsProps>;
 
-export interface IStoryFeaturedProps {
-  data: PostStory;
-}
-
-export const StoryFeatured = ({ data }: IStoryFeaturedProps) => {
+export const StoryFeatured = ({ data }: IContentComponentProps<PostStory>) => {
   const {
     additionalMedia,
     content,

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -65,6 +65,8 @@ export const StoryHeader = ({ data }: Props) => {
   const hasFooter = hasCaption;
   const { classes, cx } = storyHeaderStyles();
 
+  console.log(broadcastDate, date);
+
   if (contributors?.nodes.length) {
     bylines.push(['By', contributors.nodes]);
   }
@@ -123,10 +125,7 @@ export const StoryHeader = ({ data }: Props) => {
                     component="div"
                     className={classes.date}
                   >
-                    <Moment
-                      format="MMMM D, YYYY · h:mm A z"
-                      tz="America/New_York"
-                    >
+                    <Moment format="MMMM D, YYYY" tz="America/New_York">
                       {broadcastDate || date}
                     </Moment>
                   </Typography>

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -65,8 +65,6 @@ export const StoryHeader = ({ data }: Props) => {
   const hasFooter = hasCaption;
   const { classes, cx } = storyHeaderStyles();
 
-  console.log(broadcastDate, date);
-
   if (contributors?.nodes.length) {
     bylines.push(['By', contributors.nodes]);
   }

--- a/components/pages/Story/layouts/index.ts
+++ b/components/pages/Story/layouts/index.ts
@@ -3,10 +3,9 @@ import dynamic from 'next/dynamic';
 const DynamicStoryDefault = dynamic(() => import('./default') as any);
 const DynamicStoryFeature = dynamic(() => import('./feature') as any);
 
-const layoutComponentMap = {
-  full: DynamicStoryFeature,
-  feature_full: DynamicStoryFeature,
-  standard: DynamicStoryDefault
-};
+const layoutComponentMap = new Map();
+layoutComponentMap.set('full', DynamicStoryFeature);
+layoutComponentMap.set('feature_full', DynamicStoryFeature);
+layoutComponentMap.set('standard', DynamicStoryDefault);
 
 export { layoutComponentMap };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { RootState } from '@interfaces/state';
+import type { IContentComponentProxyProps } from '@interfaces';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useStore, Provider } from 'react-redux';
 import { AppProps } from 'next/app';
@@ -27,7 +28,6 @@ import { AppPlayer } from '@components/AppPlayer/AppPlayer';
 import { getUiPlayerOpen, getUiPlayerPlaylistOpen } from '@store/reducers';
 import { Playlist } from '@components/Player/components';
 import createEmotionCache from '@lib/generate/cache/emotion/createEmotionCache';
-import { IContentComponentProxyProps } from '@interfaces';
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();


### PR DESCRIPTION
Closes #388
Blocked by #385 

- Refactor default story page to use WP GraphQL API data

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to http://localhost:3000/stories/2023-05-12/us-ambassador-ukraine-says-she-sees-no-break-support-war-there.

> ...then...

- [x] Ensure page renders
- [ ] Try other default story URL's (Look up story on live site, then use title to find story and its URL at tw-theme-the-world.pantheonsite.io/wp-admin 
- [x] DO NOT expect sidebar content to render
- [x] DO NOT expect body content to be styles completely
- [x] DO NOT expect audio to work
- [x] DO NOT expect landing page links to work
- [x] DO NOT expect navigation menus to be shown
- [x] DO NOT expect search to work
