### PR TITLE
394: WP GraphQL Page Data

### DIFF
--- a/components/pages/Page/Page.tsx
+++ b/components/pages/Page/Page.tsx
@@ -3,31 +3,16 @@
  * Component for Pages.
  */
 
-import type { RootState } from '@interfaces';
-import React, { useContext, useEffect, useState } from 'react';
-import { useStore } from 'react-redux';
+import type { IContentComponentProps, Page as PageType } from '@interfaces';
 import { Box, Container, Grid } from '@mui/material';
-import { AppContext } from '@contexts/AppContext';
 import { HtmlContent } from '@components/HtmlContent';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
-import { getDataByResource } from '@store/reducers';
 import { pageStyles } from './Page.styles';
 import { PageHeader } from './components/PageHeader';
 
-export const Page = () => {
-  const {
-    page: {
-      resource: { type, id }
-    }
-  } = useContext(AppContext);
-  const store = useStore<RootState>();
-  const [state, setState] = useState(store.getState());
-  const unsub = store.subscribe(() => {
-    setState(store.getState());
-  });
-  const data = getDataByResource(state, type, id);
-  const { metatags, title, body } = data || ({} as typeof data);
+export const Page = ({ data }: IContentComponentProps<PageType>) => {
+  const { id, seo, title, content } = data || {};
   const { classes } = pageStyles();
 
   // Plausible Events.
@@ -36,24 +21,22 @@ export const Page = () => {
   };
   const plausibleEvents: PlausibleEventArgs[] = [['Page', { props }]];
 
-  useEffect(
-    () => () => {
-      unsub();
-    },
-    [unsub]
-  );
-
   return (
     <>
-      <MetaTags data={metatags} />
-      <Plausible events={plausibleEvents} subject={{ type, id }} />
+      {seo && <MetaTags data={seo} />}
+      <Plausible
+        events={plausibleEvents}
+        subject={{ type: 'post--page', id }}
+      />
       <Container fixed>
         <Grid container>
           <Grid item xs={12}>
             <PageHeader data={data} />
-            <Box className={classes.body} my={2}>
-              <HtmlContent html={body} />
-            </Box>
+            {content && (
+              <Box className={classes.body} my={2}>
+                <HtmlContent html={content} />
+              </Box>
+            )}
           </Grid>
         </Grid>
       </Container>

--- a/components/pages/Page/components/PageHeader/PageHeader.tsx
+++ b/components/pages/Page/components/PageHeader/PageHeader.tsx
@@ -3,13 +3,12 @@
  * Component for page header.
  */
 
-import React from 'react';
+import type { Page } from '@interfaces';
 import { Box, Typography } from '@mui/material';
-import { IPriApiResource } from 'pri-api-library/types';
 import { pageHeaderStyles } from './PageHeader.styles';
 
 interface Props {
-  data: IPriApiResource;
+  data: Page;
 }
 
 export const PageHeader = ({ data }: Props) => {

--- a/components/pages/ResourceFetchDataMap.ts
+++ b/components/pages/ResourceFetchDataMap.ts
@@ -18,7 +18,7 @@ ResourceFetchDataMap.set('file--images', fetchImageData);
 ResourceFetchDataMap.set('file--videos', fetchVideoData);
 ResourceFetchDataMap.set('post--episode', fetchEpisodeData);
 ResourceFetchDataMap.set('node--newsletter_sign_ups', fetchNewsletterData);
-ResourceFetchDataMap.set('node--pages', fetchPageData);
+ResourceFetchDataMap.set('post--page', fetchPageData);
 ResourceFetchDataMap.set('node--people', fetchPersonData);
 ResourceFetchDataMap.set('node--programs', fetchProgramData);
 ResourceFetchDataMap.set('post--story', fetchStoryData);

--- a/lib/fetch/page/fetchGqlPage.ts
+++ b/lib/fetch/page/fetchGqlPage.ts
@@ -1,0 +1,37 @@
+/**
+ * Fetch Page data from CMS API.
+ *
+ * @param id Page identifier.
+ */
+
+import type { Page } from '@interfaces';
+import { gql } from '@apollo/client';
+import { gqlClient } from '@lib/fetch/api';
+
+const GET_PAGE = gql`
+  query getPage($id: ID!) {
+    page(id: $id) {
+      id
+      title
+      content
+    }
+  }
+`;
+
+export async function fetchGqlPage(id: string) {
+  const response = await gqlClient.query<{
+    page: Page;
+  }>({
+    query: GET_PAGE,
+    variables: {
+      id
+    }
+  });
+  const page = response?.data?.page;
+
+  if (!page) return undefined;
+
+  return page;
+}
+
+export default fetchGqlPage;

--- a/lib/fetch/page/index.ts
+++ b/lib/fetch/page/index.ts
@@ -1,1 +1,2 @@
+export * from './fetchGqlPage';
 export * from './fetchPage';

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -48,7 +48,7 @@ const ContentProxy = ({ type, data }: Props) => {
 
     case 'post--page':
     case 'node--pages':
-      return <DynamicPage />;
+      return <DynamicPage data={data} />;
 
     case 'term--contributor':
     case 'node--people':

--- a/store/actions/fetchPageData.ts
+++ b/store/actions/fetchPageData.ts
@@ -1,59 +1,40 @@
 /**
- * @file fetchAudioData.ts
+ * @file fetchGqlPage.ts
  *
- * Actions to fetch data for a audio resource.
+ * Fetch data for a page resource.
  */
 
-import { AnyAction } from 'redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import {
-  IPriApiResource,
-  IPriApiResourceResponse
-} from 'pri-api-library/types';
-import { RootState } from '@interfaces/state';
-import { fetchApiPage, fetchPage } from '@lib/fetch';
-import { getDataByResource } from '@store/reducers';
-import { fetchCtaRegionGroupData } from './fetchCtaRegionGroupData';
+import { fetchGqlPage } from '@lib/fetch';
 
-export const fetchPageData = (
-  id: string
-): ThunkAction<void, {}, {}, AnyAction> => async (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => RootState
-): Promise<IPriApiResource> => {
-  const state = getState();
-  const type = 'node--pages';
-  const isOnServer = typeof window === 'undefined';
-  let data = getDataByResource(state, type, id);
+export const fetchPageData = async (id: string) => {
+  const dataPromise = fetchGqlPage(id);
 
-  if (!data || !data.complete || isOnServer) {
-    dispatch({
-      type: 'FETCH_CONTENT_DATA_REQUEST',
-      payload: {
-        type,
-        id
-      }
-    });
+  // const ctaDataPromise = dispatch<any>(
+  //   fetchCtaRegionGroupData('tw_cta_regions_content')
+  // );
 
-    const dataPromise = (isOnServer ? fetchPage : fetchApiPage)(id).then(
-      (resp: IPriApiResourceResponse) => resp && resp.data
-    );
+  const page = await dataPromise;
+  // await ctaDataPromise;
 
-    const ctaDataPromise = dispatch<any>(
-      fetchCtaRegionGroupData('tw_cta_regions_content')
-    );
-
-    data = await dataPromise;
-    await ctaDataPromise;
-
-    dispatch({
-      type: 'FETCH_CONTENT_DATA_SUCCESS',
-      payload: {
-        ...data,
-        complete: true
-      }
-    });
+  if (page) {
+    // Set CTA filter props.
+    // dispatch({
+    //   type: 'SET_RESOURCE_CTA_FILTER_PROPS',
+    //   payload: {
+    //     filterProps: {
+    //       type,
+    //       id,
+    //       props: {
+    //         id,
+    //         categories: [
+    //           ...(story.categories?.nodes || []).map(({ id: tid }) => tid)
+    //         ].filter((v: any) => !!v),
+    //         program: story.programs?.nodes[0].id || null
+    //       }
+    //     }
+    //   } as ICtaFilterProps
+    // });
   }
 
-  return data;
+  return page;
 };


### PR DESCRIPTION
Closes #394 

- add fetcher for page gql data
- refactor page component for graphql data

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to http://localhost:3000/terms.

> ...then...

- [ ] Ensure page loads.
- [ ] Ensure page links in footer and menus work.
