### PR TITLE
406: WP GraphQL Homepage Data

### DIFF
--- a/components/QuickLinks/QuickLinks.tsx
+++ b/components/QuickLinks/QuickLinks.tsx
@@ -3,24 +3,24 @@
  * Component for links to content page.
  */
 
-import type { RootState } from '@interfaces';
+import type { IButton } from '@interfaces';
 import React from 'react';
-import { useStore } from 'react-redux';
 import { parse } from 'url';
 import { Label } from '@mui/icons-material';
 import { Breadcrumbs, Container, Link } from '@mui/material';
 import { isLocalUrl } from '@lib/parse/url';
 import { handleButtonClick } from '@lib/routing';
-import { getMenusData } from '@store/reducers';
 import { QuickLinksStyles } from './QuickLinks.styles';
 
-export const QuickLinks = () => {
-  const store = useStore<RootState>();
-  const quickLinks = getMenusData(store.getState(), 'quickLinks');
+type QuickLinksProps = {
+  data: IButton[];
+};
+
+export const QuickLinks = ({ data }: QuickLinksProps) => {
   const { classes } = QuickLinksStyles();
 
   return (
-    (quickLinks && (
+    (data && (
       <Container>
         <Breadcrumbs
           classes={{ root: classes.MuiBreadcrumbsRoot }}
@@ -33,7 +33,7 @@ export const QuickLinks = () => {
             aria-hidden="true"
             className={classes.label}
           />
-          {quickLinks
+          {data
             .map(({ url, ...other }) => ({ ...other, url: parse(url) }))
             .map(({ name, url, key, attributes }) =>
               isLocalUrl(url.href) ? (

--- a/interfaces/api/generated.ts
+++ b/interfaces/api/generated.ts
@@ -14866,6 +14866,8 @@ export type RootQueryToPostConnectionWhereArgs = {
   parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
   password?: InputMaybe<Scalars['String']['input']>;
+  /** Filter by post objects that do not have the specified programs. */
+  programNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show Posts based on a keyword search */
   search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */

--- a/interfaces/content/homepage.interface.ts
+++ b/interfaces/content/homepage.interface.ts
@@ -2,11 +2,17 @@
  * Define homepage data interfaces and types.
  */
 
+import { Program } from '@interfaces/api';
 import { IButton } from '@interfaces/button';
 import { IProgram } from './program.interface';
-import { IStory } from './story.interface';
+import { IStory, PostStory } from './story.interface';
 
 export interface IHomepage extends IProgram {
   latestStories: IStory[];
   menus: { [k: string]: IButton[] };
 }
+
+export type Homepage = Program & {
+  latestStories: PostStory[];
+  menus: { [k: string]: IButton[] };
+};

--- a/lib/fetch/api/graphql/fragments/index.ts
+++ b/lib/fetch/api/graphql/fragments/index.ts
@@ -1,4 +1,5 @@
 export * from './audio.fragment';
 export * from './image.fragment';
+export * from './menu.fragment';
 export * from './post.fragment';
 export * from './seo.fragment';

--- a/lib/fetch/api/graphql/fragments/menu.fragment.ts
+++ b/lib/fetch/api/graphql/fragments/menu.fragment.ts
@@ -1,0 +1,21 @@
+import { gql } from '@apollo/client';
+
+export const MENU_ITEM_PROPS = gql`
+  fragment MenuItemProps on MenuItem {
+    id
+    parentId
+    label
+    url
+  }
+`;
+
+export const MENU_PROPS = gql`
+  fragment MenuProps on Menu {
+    menuItems {
+      nodes {
+        ...MenuItemProps
+      }
+    }
+  }
+  ${MENU_ITEM_PROPS}
+`;

--- a/lib/fetch/app/fetchGqlApp.ts
+++ b/lib/fetch/app/fetchGqlApp.ts
@@ -7,31 +7,12 @@ import { gql } from '@apollo/client';
 import { gqlClient } from '@lib/fetch/api';
 import { parseMenu } from '@lib/parse/menu';
 import { STORY_CARD_PROPS } from '../story';
-
-const MENU_ITEM_PROPS = gql`
-  fragment MenuItemProps on MenuItem {
-    id
-    parentId
-    label
-    url
-  }
-`;
-
-const MENU_PROPS = gql`
-  fragment MenuProps on Menu {
-    menuItems {
-      nodes {
-        ...MenuItemProps
-      }
-    }
-  }
-  ${MENU_ITEM_PROPS}
-`;
+import { MENU_PROPS } from '../api/graphql';
 
 const GET_APP = gql`
   query getApp {
     program(id: "the-world", idType: SLUG) {
-      posts(first: 10) {
+      posts(first: 10, where: { orderby: { field: DATE, order: DESC } }) {
         nodes {
           ...StoryCardProps
         }

--- a/lib/fetch/category/fetchGqlCategoryPosts.ts
+++ b/lib/fetch/category/fetchGqlCategoryPosts.ts
@@ -19,7 +19,11 @@ const GET_CATEGORY_POSTS = gql`
   ) {
     category(id: $id) {
       id
-      posts(first: $pageSize, after: $cursor, where: { notIn: $exclude }) {
+      posts(
+        first: $pageSize
+        after: $cursor
+        where: { notIn: $exclude, orderby: { field: DATE, order: DESC } }
+      ) {
         pageInfo {
           hasNextPage
           endCursor

--- a/lib/fetch/homepage/fetchGqlHomepage.ts
+++ b/lib/fetch/homepage/fetchGqlHomepage.ts
@@ -1,0 +1,101 @@
+/**
+ * Fetch Homepage data from CMS API.
+ *
+ * @param id Homepage identifier.
+ */
+
+import type {
+  Homepage,
+  Maybe,
+  Menu,
+  Program,
+  RootQueryToPostConnection
+} from '@interfaces';
+import { gql } from '@apollo/client';
+import { gqlClient } from '@lib/fetch/api';
+import {
+  IMAGE_PROPS,
+  MENU_PROPS,
+  POST_CARD_PROPS
+} from '@lib/fetch/api/graphql';
+import { parseMenu } from '@lib/parse/menu';
+
+const GET_HOMEPAGE = gql`
+  query getHomepage($id: ID!, $idType: ProgramIdType) {
+    program(id: $id, idType: $idType) {
+      id
+      landingPage {
+        featuredPosts {
+          ... on Post {
+            ...PostCardProps
+          }
+        }
+      }
+    }
+    quickLinks: menu(id: "homepage-quick-links", idType: SLUG) {
+      ...MenuProps
+    }
+  }
+  ${POST_CARD_PROPS}
+  ${IMAGE_PROPS}
+  ${MENU_PROPS}
+`;
+
+const GET_HOMEPAGE_LATEST_STORIES = gql`
+  query getHomepage($id: ID!) {
+    posts(
+      first: 10
+      where: { programNotIn: [$id], orderby: { field: DATE, order: DESC } }
+    ) {
+      nodes {
+        id
+        link
+        title
+        additionalMedia {
+          audio {
+            id
+          }
+        }
+      }
+    }
+  }
+`;
+
+export async function fetchGqlHomepage() {
+  const response = await gqlClient.query<{
+    program: Maybe<Program>;
+    quickLinks: Maybe<Menu>;
+  }>({
+    query: GET_HOMEPAGE,
+    variables: {
+      id: 'the-world',
+      idType: 'SLUG'
+    }
+  });
+  const homepage = response?.data.program;
+  const quickLinksMenu = response?.data.quickLinks?.menuItems?.nodes;
+
+  if (!homepage) return undefined;
+
+  // Get latest stories NOT from The World.
+  const latestStoriesResponse = await gqlClient.query<{
+    posts: Maybe<RootQueryToPostConnection>;
+    quickLinks: Maybe<Menu>;
+  }>({
+    query: GET_HOMEPAGE_LATEST_STORIES,
+    variables: {
+      id: homepage.id
+    }
+  });
+  const latestStories = latestStoriesResponse?.data?.posts?.nodes;
+
+  return {
+    ...homepage,
+    ...(!!latestStories?.length && { latestStories }),
+    menus: {
+      ...(quickLinksMenu && { quickLinks: parseMenu(quickLinksMenu) })
+    }
+  } as Homepage;
+}
+
+export default fetchGqlHomepage;

--- a/lib/fetch/homepage/fetchGqlHomepage.ts
+++ b/lib/fetch/homepage/fetchGqlHomepage.ts
@@ -42,7 +42,7 @@ const GET_HOMEPAGE = gql`
 `;
 
 const GET_HOMEPAGE_LATEST_STORIES = gql`
-  query getHomepage($id: ID!) {
+  query getHomepageLatestStories($id: ID!) {
     posts(
       first: 10
       where: { programNotIn: [$id], orderby: { field: DATE, order: DESC } }

--- a/lib/fetch/homepage/index.ts
+++ b/lib/fetch/homepage/index.ts
@@ -1,1 +1,2 @@
+export * from './fetchGqlHomepage';
 export * from './fetchHomepage';

--- a/lib/fetch/program/fetchGqlProgramEpisodes.ts
+++ b/lib/fetch/program/fetchGqlProgramEpisodes.ts
@@ -20,7 +20,11 @@ const GET_PROGRAM_EPISODES = gql`
   ) {
     program(id: $id) {
       id
-      episodes(first: $pageSize, after: $cursor, where: { notIn: $exclude }) {
+      episodes(
+        first: $pageSize
+        after: $cursor
+        where: { notIn: $exclude, orderby: { field: DATE, order: DESC } }
+      ) {
         pageInfo {
           hasNextPage
           endCursor

--- a/lib/fetch/program/fetchGqlProgramPosts.ts
+++ b/lib/fetch/program/fetchGqlProgramPosts.ts
@@ -19,7 +19,11 @@ const GET_PROGRAM_POSTS = gql`
   ) {
     program(id: $id) {
       id
-      posts(first: $pageSize, after: $cursor, where: { notIn: $exclude }) {
+      posts(
+        first: $pageSize
+        after: $cursor
+        where: { notIn: $exclude, orderby: { field: DATE, order: DESC } }
+      ) {
         pageInfo {
           hasNextPage
           endCursor

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,42 +3,33 @@
  * Exports the Home component.
  */
 
-import React from 'react';
-import crypto from 'crypto';
+import type {
+  Homepage as HomepageType,
+  IContentComponentProps
+} from '@interfaces';
 import { Homepage } from '@components/pages/Homepage';
 import { wrapper } from '@store/configureStore';
 import { fetchHomepageData } from '@store/actions/fetchHomepageData';
 import { fetchAppData } from '@store/actions/fetchAppData';
 
-const IndexPage = () => <Homepage />;
+const IndexPage = ({ data }: IContentComponentProps<HomepageType>) => (
+  <Homepage data={data} />
+);
 
 export const getServerSideProps = wrapper.getServerSideProps(
   (store) =>
-    async ({ res, req }) => {
-      const data = await store.dispatch<any>(fetchHomepageData());
-
-      store.dispatch<any>({
-        type: 'SET_COOKIES',
-        payload: {
-          cookies: req.cookies
-        }
-      });
-
-      await store.dispatch<any>(fetchAppData());
-
-      res.setHeader(
-        'Cache-Control',
-        `public, s-maxage=${60 * 60}, stale-while-revalidate=${60 * 5}`
-      );
+    async ({ req }) => {
+      const [data, appData] = await Promise.all([
+        store.dispatch<any>(fetchHomepageData()),
+        fetchAppData()
+      ]);
 
       return {
         props: {
           type: 'homepage',
           cookies: req.cookies,
-          dataHash: crypto
-            .createHash('sha256')
-            .update(JSON.stringify(data))
-            .digest('hex')
+          data,
+          appData
         }
       };
     }

--- a/store/actions/fetchProgramData.ts
+++ b/store/actions/fetchProgramData.ts
@@ -23,11 +23,12 @@ export const fetchProgramData =
     dispatch: ThunkDispatch<{}, {}, AnyAction>,
     getState: () => RootState
   ) => {
-    const state = getState();
     const type = 'term--program';
     const program = await fetchGqlProgram(id, idType);
 
     if (program) {
+      const state = getState();
+
       // const ctaDataPromise = dispatch<any>(
       //   fetchCtaRegionGroupData('tw_cta_regions_landing')
       // );


### PR DESCRIPTION
Closes #406 

- fetch homepage data from wp graphql api
- update collection queries to order items by date (newest to oldest)

## To Review

- [x] Checkout and update `feat/102-the-world-theme` branch in your lando env.
- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure homepage loads.
- [x] Ensure Expected stories are shown.
- [x] Ensure expected featured stories are featured.
- [x] Ensure latest episode is shown.
- [x] Ensure latest stories in sidebar are NOT from The World program. (Latest changes in lando env branch make this possible.)
- [x] Ensure quick links nav shows expected links. (Make sure to add menu items in WP if they are missing.)
- [x] Visit program and category pages and ensure posts and episodes are ordered correctly by date.
