### PR TITLE
HOTFIX: CTA category targeting

### DIFF
--- a/components/CtaRegion/components/CtaMessageInfo/CtaMessageInfo.tsx
+++ b/components/CtaRegion/components/CtaMessageInfo/CtaMessageInfo.tsx
@@ -31,7 +31,7 @@ export const CtaMessageInfo = ({ data }: ICtaMessageProps) => {
     <Card elevation={0}>
       {heading && <CardHeader title={heading} />}
       {message && (
-        <CardContent>
+        <CardContent sx={{ '&:last-child': { paddingBlockEnd: 0 } }}>
           <Typography component="div" variant="body1">
             <HtmlContent html={message} />
           </Typography>

--- a/lib/cta/filterCtaMessages.ts
+++ b/lib/cta/filterCtaMessages.ts
@@ -31,15 +31,16 @@ export const filterCtaMessages = (filterProps: ICtaFilterProps) => (
 
   // Check Category Targets.
   if (targetCategories?.length) {
-    const filterPropsCategories = filterProps?.categories || [];
+    const filterPropsCategories = [...(new Set([...(filterProps?.categories || [])]))];
+    const targetCategoriesUnique = [...(new Set([...targetCategories]))];
     const combinedCategories = new Set([
-      ...targetCategories,
+      ...targetCategoriesUnique,
       ...filterPropsCategories
     ]);
 
     categoriesMatched =
-      [...combinedCategories].length !==
-      targetCategories.length + filterPropsCategories.length;
+      [...combinedCategories].length ===
+      filterPropsCategories.length;
   }
 
   // Check Program Target.


### PR DESCRIPTION
- fix cta filtering of category targeting messages
- remove end padding from info cta content

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to http://localhost:3000/categories/planet-hip-hop.

> ...then...

- [x] Ensure playlist CTA is shown on page.
- [x] Visit a story shown on landing page. Ensure playlist CTA is shown after the story content.
- [x] Visit any story NOT in the Planet Hip Hop category.
- [x] Ensure the playlist CTA is not shown after the story content.
- [x] Note extra padding after playlist CTA content is no longer present.
