### PR TITLE
419: WP GraphQL Call To Action Data

### DIFF
--- a/components/AppCtaBanner/AppCtaBanner.styles.ts
+++ b/components/AppCtaBanner/AppCtaBanner.styles.ts
@@ -3,10 +3,10 @@
  * Styles for appCtaBanner.
  */
 
-import { Theme, alpha } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
-export const appCtaBannerStyles = makeStyles()((theme: Theme) => ({
+export const appCtaBannerStyles = makeStyles()((theme) => ({
   root: {
     backgroundColor: theme.palette.primary.dark,
     color: theme.palette.getContrastText(theme.palette.primary.dark),
@@ -43,7 +43,7 @@ export const appCtaBannerStyles = makeStyles()((theme: Theme) => ({
     },
 
     '.MuiCheckbox-root': {
-      color: 'inherit'
+      color: theme.palette.primary.contrastText
     },
 
     '.MuiFormControlLabel-root': {
@@ -51,7 +51,6 @@ export const appCtaBannerStyles = makeStyles()((theme: Theme) => ({
     },
 
     '.MuiFormControlLabel-label': {
-      paddingBottom: theme.spacing(0),
       textAlign: 'left',
 
       p: {

--- a/components/AppCtaBanner/AppCtaBanner.styles.ts
+++ b/components/AppCtaBanner/AppCtaBanner.styles.ts
@@ -3,77 +3,79 @@
  * Styles for appCtaBanner.
  */
 
-import { createTheme, Theme } from '@mui/material/styles';
+import { Theme, alpha } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
-
-export const appCtaBannerTheme = (theme: Theme) =>
-  createTheme(theme, {
-    typography: {
-      h2: {
-        color: theme.palette.primary.contrastText,
-        fontSize: '1.2rem'
-      },
-      body1: {
-        fontSize: '1rem',
-        lineHeight: 1.3
-      }
-    },
-    components: {
-      MuiButton: {
-        styleOverrides: {
-          containedPrimary: {
-            '&:hover': {
-              backgroundColor: theme.palette.secondary.main
-            }
-          }
-        }
-      },
-      MuiCheckbox: {
-        styleOverrides: {
-          root: {
-            color: 'inherit'
-          }
-        }
-      },
-      MuiFormControlLabel: {
-        styleOverrides: {
-          root: {
-            paddingLeft: theme.spacing(2)
-          },
-          label: {
-            paddingTop: theme.spacing(1),
-            paddingBottom: theme.spacing(0),
-            textAlign: 'left'
-          }
-        }
-      },
-      MuiIconButton: {
-        styleOverrides: {
-          root: {
-            '&:hover': {
-              backgroundColor: theme.palette.action.focus
-            }
-          }
-        }
-      },
-      MuiToolbar: {
-        styleOverrides: {
-          root: {
-            justifyContent: 'center',
-            marginTop: 0,
-            marginBottom: 0,
-            '& > * + *': {
-              marginLeft: theme.spacing(2)
-            }
-          }
-        }
-      }
-    }
-  });
 
 export const appCtaBannerStyles = makeStyles()((theme: Theme) => ({
   root: {
     backgroundColor: theme.palette.primary.dark,
-    color: theme.palette.getContrastText(theme.palette.primary.dark)
+    color: theme.palette.getContrastText(theme.palette.primary.dark),
+
+    '.MuiTypography-h2': {
+      color: theme.palette.primary.contrastText,
+      fontSize: '1.2rem'
+    },
+
+    '.MuiTypography-body1': {
+      fontSize: '1rem',
+      lineHeight: 1.3,
+
+      p: {
+        marginBlock: 0,
+        '& + &': {
+          marginBlockStart: theme.spacing(1)
+        }
+      },
+
+      a: {
+        color: theme.palette.secondary.main,
+        textDecoration: 'none',
+        '&:hover': {
+          textDecoration: 'underline'
+        }
+      }
+    },
+
+    '.MuiButton-containedPrimary': {
+      '&:hover': {
+        backgroundColor: theme.palette.secondary.main
+      }
+    },
+
+    '.MuiCheckbox-root': {
+      color: 'inherit'
+    },
+
+    '.MuiFormControlLabel-root': {
+      paddingLeft: theme.spacing(2)
+    },
+
+    '.MuiFormControlLabel-label': {
+      paddingBottom: theme.spacing(0),
+      textAlign: 'left',
+
+      p: {
+        marginBlock: 0
+      }
+    },
+
+    '.MuiButtonBase-root.Mui-disabled': {
+      color: alpha(theme.palette.primary.main, 0.6)
+    },
+
+    '.MuiIconButton-root': {
+      '&:hover': {
+        backgroundColor: theme.palette.action.focus
+      }
+    },
+
+    '.MuiToolbar-root': {
+      justifyContent: 'center',
+      marginTop: 0,
+      marginBottom: 0,
+      '& > * + *': {
+        marginLeft: theme.spacing(2)
+      }
+    }
   }
 }));

--- a/components/AppCtaBanner/AppCtaBanner.tsx
+++ b/components/AppCtaBanner/AppCtaBanner.tsx
@@ -8,11 +8,10 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useStore } from 'react-redux';
 import { getShownMessage, setCtaCookie } from '@lib/cta';
 import { Box, Container, IconButton } from '@mui/material';
-import { ThemeProvider } from '@mui/styles';
 import { CloseSharp } from '@mui/icons-material';
 import { AppContext } from '@contexts/AppContext';
 import { getCookies, getCtaRegionData } from '@store/reducers';
-import { appCtaBannerStyles, appCtaBannerTheme } from './AppCtaBanner.styles';
+import { appCtaBannerStyles } from './AppCtaBanner.styles';
 import { ctaTypeComponentMap } from './components';
 
 export const AppCtaBanner = () => {
@@ -21,8 +20,7 @@ export const AppCtaBanner = () => {
   const { page } = useContext(AppContext);
   const { resource } = page || {};
   const { type, id } = resource || {};
-  const banner =
-    getCtaRegionData(state, 'tw_cta_region_site_banner', type, id) || [];
+  const banner = getCtaRegionData(state, 'site-banner', type, id) || [];
   const cookies = getCookies(state);
   const shownMessage = getShownMessage(banner, cookies);
   const { type: msgType } = shownMessage || {};
@@ -57,30 +55,28 @@ export const AppCtaBanner = () => {
   );
 
   return CtaMessageComponent && shownMessage && !closed ? (
-    <ThemeProvider theme={appCtaBannerTheme}>
-      <Box
-        component="aside"
-        className={classes.root}
-        display="flex"
-        alignItems="center"
-        minHeight={230}
-        px={2}
-        py={2}
-      >
-        <Container maxWidth="md">
-          <CtaMessageComponent data={shownMessage} onClose={handleClose} />
-        </Container>
-        <Box position="absolute" top={0} right={0}>
-          <IconButton
-            aria-label="close"
-            color="inherit"
-            disableRipple
-            onClick={handleClose}
-          >
-            <CloseSharp />
-          </IconButton>
-        </Box>
+    <Box
+      component="aside"
+      className={classes.root}
+      display="flex"
+      alignItems="center"
+      minHeight={230}
+      px={2}
+      py={2}
+    >
+      <Container maxWidth="md">
+        <CtaMessageComponent data={shownMessage} onClose={handleClose} />
+      </Container>
+      <Box position="absolute" top={0} right={0}>
+        <IconButton
+          aria-label="close"
+          color="inherit"
+          disableRipple
+          onClick={handleClose}
+        >
+          <CloseSharp />
+        </IconButton>
       </Box>
-    </ThemeProvider>
+    </Box>
   ) : null;
 };

--- a/components/AppCtaBanner/components/AppCtaMessageDonation/AppCtaMessageDonation.tsx
+++ b/components/AppCtaBanner/components/AppCtaMessageDonation/AppCtaMessageDonation.tsx
@@ -4,13 +4,7 @@
  */
 
 import React from 'react';
-import {
-  Box,
-  Button,
-  Toolbar,
-  Typography,
-  ButtonProps
-} from '@mui/material';
+import { Box, Button, Toolbar, Typography, ButtonProps } from '@mui/material';
 import { HtmlContent } from '@components/HtmlContent';
 import { handleButtonClick } from '@lib/routing';
 import { IAppCtaMessageProps } from '../AppCtaMessage.interface';
@@ -43,7 +37,7 @@ export const AppCtaMessageDonation = ({
   };
 
   return (
-    <Box textAlign="center">
+    <Box textAlign="center" display="grid" gap={2}>
       {heading && <Typography variant="h2">{heading}</Typography>}
       {message && (
         <Typography component="div" variant="body1">

--- a/components/AppCtaBanner/components/AppCtaMessageInfo/AppCtaMessageInfo.tsx
+++ b/components/AppCtaBanner/components/AppCtaMessageInfo/AppCtaMessageInfo.tsx
@@ -4,13 +4,7 @@
  */
 
 import React from 'react';
-import {
-  Box,
-  Button,
-  Toolbar,
-  Typography,
-  ButtonProps
-} from '@mui/material';
+import { Box, Button, Toolbar, Typography, ButtonProps } from '@mui/material';
 import { HtmlContent } from '@components/HtmlContent';
 import { handleButtonClick } from '@lib/routing';
 import { IAppCtaMessageProps } from '../AppCtaMessage.interface';
@@ -40,7 +34,7 @@ export const AppCtaMessageInfo = ({ data, onClose }: IAppCtaMessageProps) => {
   };
 
   return (
-    <Box textAlign="center">
+    <Box textAlign="center" display="grid" gap={2}>
       {heading && <Typography variant="h2">{heading}</Typography>}
       {message && (
         <Typography component="div" variant="body1">

--- a/components/AppCtaBanner/components/AppCtaMessageNewsletter/AppCtaMessageNewsletter.tsx
+++ b/components/AppCtaBanner/components/AppCtaMessageNewsletter/AppCtaMessageNewsletter.tsx
@@ -46,7 +46,7 @@ export const AppCtaMessageNewsletter = ({
 
   return (
     <ThemeProvider theme={newsletterFormTheme}>
-      <Box textAlign="center">
+      <Box textAlign="center" display="grid" gap={2}>
         {heading && <Typography variant="h2">{heading}</Typography>}
         {message && (
           <Typography component="div" variant="body1">

--- a/components/AppCtaBanner/components/AppCtaMessageOptIn/AppCtaMessageOptIn.styles.ts
+++ b/components/AppCtaBanner/components/AppCtaMessageOptIn/AppCtaMessageOptIn.styles.ts
@@ -3,19 +3,15 @@
  * Styles for AppCtaMessageOptIn.
  */
 
-import { createTheme, Theme } from '@mui/material/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from 'tss-react/mui';
 import { blue } from '@theme/colors';
 
-export const appCtaMessageOptInTheme = (theme: Theme) =>
-  createTheme(theme, {
-    components: {
-      MuiPaper: {
-        styleOverrides: {
-          root: {
-            backgroundColor: blue[700],
-            color: theme.palette.getContrastText(blue[700])
-          }
-        }
-      }
+export const appCtaMessageOptInStyles = makeStyles()((theme: Theme) => ({
+  root: {
+    '.MuiPaper-root': {
+      backgroundColor: blue[700],
+      color: theme.palette.getContrastText(blue[700])
     }
-  });
+  }
+}));

--- a/components/AppCtaBanner/components/AppCtaMessageOptIn/AppCtaMessageOptIn.tsx
+++ b/components/AppCtaBanner/components/AppCtaMessageOptIn/AppCtaMessageOptIn.tsx
@@ -68,6 +68,7 @@ export const AppCtaMessageOptIn = ({ data, onClose }: IAppCtaMessageProps) => {
               checked={optedIn}
               onChange={handleOptInChange}
               name="optIn"
+              color="success"
             />
           }
           label={<HtmlContent html={optinLabel} />}

--- a/components/AppCtaBanner/components/AppCtaMessageOptIn/AppCtaMessageOptIn.tsx
+++ b/components/AppCtaBanner/components/AppCtaMessageOptIn/AppCtaMessageOptIn.tsx
@@ -12,17 +12,14 @@ import {
   Typography,
   ButtonProps,
   FormControlLabel,
-  Paper,
-  ThemeProvider
+  Paper
 } from '@mui/material';
 import { HtmlContent } from '@components/HtmlContent';
-import { handleButtonClick } from '@lib/routing';
 import { IAppCtaMessageProps } from '../AppCtaMessage.interface';
-import { appCtaMessageOptInTheme } from './AppCtaMessageOptIn.styles';
+import { appCtaMessageOptInStyles } from './AppCtaMessageOptIn.styles';
 
 export const AppCtaMessageOptIn = ({ data, onClose }: IAppCtaMessageProps) => {
   const { heading, message, optinLabel, action, dismiss } = data;
-  const hasActions = !!(action || dismiss);
   const [optedIn, setOptedIn] = useState(false);
   const actionAttrs: ButtonProps = {
     variant: 'contained',
@@ -30,15 +27,22 @@ export const AppCtaMessageOptIn = ({ data, onClose }: IAppCtaMessageProps) => {
     size: 'large',
     disabled: !optedIn
   };
-  const dismissAttrs: ButtonProps = !action
-    ? actionAttrs
-    : {
-        variant: 'outlined',
-        color: 'primary'
-      };
-  const handleActionClick = handleButtonClick(action?.url, () => {
+  const dismissAttrs: ButtonProps = {
+    variant: 'outlined',
+    color: 'primary',
+    size: 'large'
+  };
+  const { classes } = appCtaMessageOptInStyles();
+
+  const handleActionClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    event.preventDefault();
+
+    // TODO: Store user setting for optin in local storage or account settings.
+
     onClose();
-  });
+  };
   const handleDismissClick = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
@@ -50,41 +54,33 @@ export const AppCtaMessageOptIn = ({ data, onClose }: IAppCtaMessageProps) => {
   };
 
   return (
-    <ThemeProvider theme={appCtaMessageOptInTheme}>
-      <Box textAlign="center">
-        {heading && <Typography variant="h2">{heading}</Typography>}
-        {message && (
-          <Typography component="div" variant="body1">
-            <HtmlContent html={message} />
-          </Typography>
-        )}
-        <Paper>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={optedIn}
-                onChange={handleOptInChange}
-                name="optIn"
-              />
-            }
-            label={optinLabel}
-          />
-        </Paper>
-        {hasActions && (
-          <Toolbar>
-            {action && (
-              <Button {...actionAttrs} onClick={handleActionClick}>
-                {action.name}
-              </Button>
-            )}
-            {dismiss && (
-              <Button {...dismissAttrs} onClick={handleDismissClick}>
-                {dismiss.name}
-              </Button>
-            )}
-          </Toolbar>
-        )}
-      </Box>
-    </ThemeProvider>
+    <Box className={classes.root} textAlign="center" display="grid" gap={2}>
+      {heading && <Typography variant="h2">{heading}</Typography>}
+      {message && (
+        <Typography component="div" variant="body1">
+          <HtmlContent html={message} />
+        </Typography>
+      )}
+      <Paper>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={optedIn}
+              onChange={handleOptInChange}
+              name="optIn"
+            />
+          }
+          label={<HtmlContent html={optinLabel} />}
+        />
+      </Paper>
+      <Toolbar>
+        <Button {...actionAttrs} onClick={handleActionClick}>
+          {action?.name || 'Accept'}
+        </Button>
+        <Button {...dismissAttrs} onClick={handleDismissClick}>
+          {dismiss?.name || 'No Thanks'}
+        </Button>
+      </Toolbar>
+    </Box>
   );
 };

--- a/components/AppCtaLoadUnder/AppCtaLoadUnder.styles.ts
+++ b/components/AppCtaLoadUnder/AppCtaLoadUnder.styles.ts
@@ -3,81 +3,81 @@
  * Styles for AppCtaLoadUnder.
  */
 
-import { createTheme, Theme } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
-export const appCtaLoadUnderTheme = (theme: Theme) =>
-  createTheme(theme, {
-    typography: {
-      h2: {
-        color: theme.palette.primary.contrastText,
-        fontSize: '1.25rem'
-      },
-      body1: {
-        fontSize: '1rem',
-        lineHeight: 1.2
-      }
-    },
-    components: {
-      MuiButton: {
-        styleOverrides: {
-          containedPrimary: {
-            '&:hover': {
-              backgroundColor: theme.palette.secondary.main
-            }
-          }
-        }
-      },
-      MuiCheckbox: {
-        styleOverrides: {
-          root: {
-            color: 'inherit'
-          }
-        }
-      },
-      MuiFormControlLabel: {
-        styleOverrides: {
-          root: {
-            paddingLeft: theme.spacing(2)
-          },
-          label: {
-            paddingTop: theme.spacing(2),
-            paddingBottom: theme.spacing(2),
-            textAlign: 'left'
-          }
-        }
-      },
-      MuiIconButton: {
-        styleOverrides: {
-          root: {
-            '&:hover': {
-              backgroundColor: theme.palette.action.focus
-            }
-          }
-        }
-      },
-      MuiToolbar: {
-        styleOverrides: {
-          root: {
-            justifyContent: 'center',
-            '& > * + *': {
-              marginLeft: theme.spacing(2)
-            },
-            [theme.breakpoints.down('sm')]: {
-              marginTop: theme.spacing(1)
-            }
-          }
-        }
-      }
-    }
-  });
-
-export const appCtaLoadUnderStyles = makeStyles()(theme => ({
+export const appCtaLoadUnderStyles = makeStyles()((theme) => ({
   root: {
     position: 'relative',
     zIndex: theme.zIndex.drawer,
     backgroundColor: theme.palette.primary.dark,
-    color: theme.palette.getContrastText(theme.palette.primary.dark)
+    color: theme.palette.getContrastText(theme.palette.primary.dark),
+
+    '.MuiTypography-h2': {
+      color: theme.palette.primary.contrastText,
+      fontSize: '1.2rem'
+    },
+
+    '.MuiTypography-body1': {
+      fontSize: '1rem',
+      lineHeight: 1.3,
+
+      p: {
+        marginBlock: 0,
+        '& + &': {
+          marginBlockStart: theme.spacing(1)
+        }
+      },
+
+      a: {
+        color: theme.palette.secondary.main,
+        textDecoration: 'none',
+        '&:hover': {
+          textDecoration: 'underline'
+        }
+      }
+    },
+
+    '.MuiButton-containedPrimary': {
+      '&:hover': {
+        backgroundColor: theme.palette.secondary.main
+      }
+    },
+
+    '.MuiCheckbox-root': {
+      color: theme.palette.primary.contrastText
+    },
+
+    '.MuiFormControlLabel-root': {
+      paddingLeft: theme.spacing(2)
+    },
+
+    '.MuiFormControlLabel-label': {
+      textAlign: 'left',
+
+      p: {
+        marginBlock: 0
+      }
+    },
+
+    '.MuiButtonBase-root.Mui-disabled': {
+      color: alpha(theme.palette.primary.main, 0.6)
+    },
+
+    '.MuiIconButton-root': {
+      '&:hover': {
+        backgroundColor: theme.palette.action.focus
+      }
+    },
+
+    '.MuiToolbar-root': {
+      justifyContent: 'center',
+      marginTop: 0,
+      marginBottom: 0,
+      '& > * + *': {
+        marginLeft: theme.spacing(2)
+      }
+    }
   },
 
   container: {

--- a/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
+++ b/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
@@ -29,12 +29,7 @@ export const AppCtaLoadUnder = () => {
       resource: { type, id }
     }
   } = useContext(AppContext);
-  const banner = getCtaRegionData(
-    state,
-    'tw_cta_region_site_load_under',
-    type,
-    id
-  );
+  const banner = getCtaRegionData(state, 'site-load-under', type, id);
   const cookies = getCookies(state);
   const shownMessage = getShownMessage(banner, cookies);
   const { type: msgType } = shownMessage || {};
@@ -62,7 +57,7 @@ export const AppCtaLoadUnder = () => {
 
   return CtaMessageComponent && shownMessage && !closed ? (
     <ThemeProvider theme={appCtaLoadUnderTheme}>
-      <Box component="aside" className={classes.root} px={4} height={5}>
+      <Box component="aside" className={classes.root} px={4}>
         <Container className={classes.container} maxWidth="lg">
           <CtaMessageComponent data={shownMessage} onClose={handleClose} />
         </Container>

--- a/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
+++ b/components/AppCtaLoadUnder/AppCtaLoadUnder.tsx
@@ -7,15 +7,11 @@ import type { RootState } from '@interfaces';
 import React, { useContext, useEffect, useState } from 'react';
 import { useStore } from 'react-redux';
 import { Box, Container, IconButton } from '@mui/material';
-import { ThemeProvider } from '@mui/styles';
 import { CloseSharp } from '@mui/icons-material';
 import { AppContext } from '@contexts/AppContext';
 import { getShownMessage, setCtaCookie } from '@lib/cta';
 import { getCookies, getCtaRegionData } from '@store/reducers';
-import {
-  appCtaLoadUnderStyles,
-  appCtaLoadUnderTheme
-} from './AppCtaLoadUnder.styles';
+import { appCtaLoadUnderStyles } from './AppCtaLoadUnder.styles';
 import { ctaTypeComponentMap } from './components';
 
 export const AppCtaLoadUnder = () => {
@@ -56,22 +52,20 @@ export const AppCtaLoadUnder = () => {
   );
 
   return CtaMessageComponent && shownMessage && !closed ? (
-    <ThemeProvider theme={appCtaLoadUnderTheme}>
-      <Box component="aside" className={classes.root} px={4}>
-        <Container className={classes.container} maxWidth="lg">
-          <CtaMessageComponent data={shownMessage} onClose={handleClose} />
-        </Container>
-        <Box position="absolute" top={0} right={0}>
-          <IconButton
-            aria-label="close"
-            color="inherit"
-            disableRipple
-            onClick={handleClose}
-          >
-            <CloseSharp />
-          </IconButton>
-        </Box>
+    <Box component="aside" className={classes.root} px={4}>
+      <Container className={classes.container} maxWidth="lg">
+        <CtaMessageComponent data={shownMessage} onClose={handleClose} />
+      </Container>
+      <Box position="absolute" top={0} right={0}>
+        <IconButton
+          aria-label="close"
+          color="inherit"
+          disableRipple
+          onClick={handleClose}
+        >
+          <CloseSharp />
+        </IconButton>
       </Box>
-    </ThemeProvider>
+    </Box>
   ) : null;
 };

--- a/components/AppCtaLoadUnder/components/AppCtaMessageDonation/AppCtaMessageDonation.tsx
+++ b/components/AppCtaLoadUnder/components/AppCtaMessageDonation/AppCtaMessageDonation.tsx
@@ -5,13 +5,7 @@
 
 import React from 'react';
 import { handleButtonClick } from '@lib/routing';
-import {
-  Box,
-  Button,
-  Toolbar,
-  Typography,
-  ButtonProps
-} from '@mui/material';
+import { Box, Button, Toolbar, Typography, ButtonProps } from '@mui/material';
 import { HtmlContent } from '@components/HtmlContent';
 import { IAppCtaMessageProps } from '../AppCtaMessage.interface';
 
@@ -43,7 +37,7 @@ export const AppCtaMessageDonation = ({
   };
 
   return (
-    <Box textAlign="center">
+    <Box textAlign="center" display="grid" gap={1}>
       {heading && <Typography variant="h2">{heading}</Typography>}
       {message && (
         <Typography component="div" variant="body1">

--- a/components/AppCtaLoadUnder/components/AppCtaMessageInfo/AppCtaMessageInfo.tsx
+++ b/components/AppCtaLoadUnder/components/AppCtaMessageInfo/AppCtaMessageInfo.tsx
@@ -42,8 +42,8 @@ export const AppCtaMessageInfo = ({ data, onClose }: IAppCtaMessageProps) => {
 
   return (
     <Box textAlign="center">
-      <Grid container justifyContent="center" alignItems="center">
-        <Grid item sm={12} md={8}>
+      <Grid container justifyItems="center" alignItems="center">
+        <Grid item sm={12} md={hasActions ? 8 : 12} display="grid" gap={1}>
           {heading && <Typography variant="h2">{heading}</Typography>}
           {message && (
             <Typography component="div" variant="body1">
@@ -51,8 +51,8 @@ export const AppCtaMessageInfo = ({ data, onClose }: IAppCtaMessageProps) => {
             </Typography>
           )}
         </Grid>
-        <Grid item sm={12} md={4}>
-          {hasActions && (
+        {hasActions && (
+          <Grid item sm={12} md={4}>
             <Toolbar>
               {action && (
                 <Button {...actionAttrs} onClick={handleActionClick}>
@@ -65,8 +65,8 @@ export const AppCtaMessageInfo = ({ data, onClose }: IAppCtaMessageProps) => {
                 </Button>
               )}
             </Toolbar>
-          )}
-        </Grid>
+          </Grid>
+        )}
       </Grid>
     </Box>
   );

--- a/components/AppCtaLoadUnder/components/AppCtaMessageNewsletter/AppCtaMessageNewsletter.tsx
+++ b/components/AppCtaLoadUnder/components/AppCtaMessageNewsletter/AppCtaMessageNewsletter.tsx
@@ -49,7 +49,7 @@ export const AppCtaMessageNewsletter = ({
     <ThemeProvider theme={newsletterFormTheme}>
       <Box textAlign="center">
         <Grid container justifyContent="center" alignItems="center">
-          <Grid item sm={12} md={8}>
+          <Grid item sm={12} md={hasActions ? 8 : 12} display="grid" gap={1}>
             {heading && <Typography variant="h2">{heading}</Typography>}
             {message && (
               <Typography component="div" variant="body1">
@@ -57,8 +57,8 @@ export const AppCtaMessageNewsletter = ({
               </Typography>
             )}
           </Grid>
-          <Grid item sm={12} md={4}>
-            {hasActions && (
+          {hasActions && (
+            <Grid item sm={12} md={4}>
               <Toolbar>
                 {action && (
                   <Button {...actionAttrs} onClick={handleActionClick}>
@@ -71,8 +71,8 @@ export const AppCtaMessageNewsletter = ({
                   </Button>
                 )}
               </Toolbar>
-            )}
-          </Grid>
+            </Grid>
+          )}
         </Grid>
       </Box>
     </ThemeProvider>

--- a/components/AppCtaLoadUnder/components/AppCtaMessageOptIn/AppCtaMessageOptIn.tsx
+++ b/components/AppCtaLoadUnder/components/AppCtaMessageOptIn/AppCtaMessageOptIn.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useState } from 'react';
-import { handleButtonClick } from '@lib/routing';
 import {
   Box,
   Button,
@@ -25,7 +24,6 @@ import {
 
 export const AppCtaMessageOptIn = ({ data, onClose }: IAppCtaMessageProps) => {
   const { heading, message, optinLabel, action, dismiss } = data;
-  const hasActions = !!(action || dismiss);
   const [optedIn, setOptedIn] = useState(false);
   const { classes } = appCtaMessageOptInStyles();
   const actionAttrs: ButtonProps = {
@@ -37,9 +35,16 @@ export const AppCtaMessageOptIn = ({ data, onClose }: IAppCtaMessageProps) => {
     variant: 'outlined',
     color: 'primary'
   };
-  const handleActionClick = handleButtonClick(action?.url, () => {
+
+  const handleActionClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    event.preventDefault();
+
+    // TODO: Store user setting for optin in local storage or account settings.
+
     onClose();
-  });
+  };
   const handleDismissClick = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
@@ -52,7 +57,7 @@ export const AppCtaMessageOptIn = ({ data, onClose }: IAppCtaMessageProps) => {
 
   return (
     <ThemeProvider theme={appCtaMessageOptInTheme}>
-      <Box textAlign="center">
+      <Box textAlign="center" display="grid" gap={1}>
         {heading && <Typography variant="h2">{heading}</Typography>}
         {message && (
           <Typography component="div" variant="body1">
@@ -68,26 +73,21 @@ export const AppCtaMessageOptIn = ({ data, onClose }: IAppCtaMessageProps) => {
                     checked={optedIn}
                     onChange={handleOptInChange}
                     name="optIn"
+                    color="success"
                   />
                 }
                 label={<HtmlContent html={optinLabel} />}
               />
             </Paper>
           </Box>
-          {hasActions && (
-            <Toolbar>
-              {action && (
-                <Button {...actionAttrs} onClick={handleActionClick}>
-                  {action.name}
-                </Button>
-              )}
-              {dismiss && (
-                <Button {...dismissAttrs} onClick={handleDismissClick}>
-                  {dismiss.name}
-                </Button>
-              )}
-            </Toolbar>
-          )}
+          <Toolbar>
+            <Button {...actionAttrs} onClick={handleActionClick}>
+              {action?.name || 'Accept'}
+            </Button>
+            <Button {...dismissAttrs} onClick={handleDismissClick}>
+              {dismiss?.name || 'No Thanks'}
+            </Button>
+          </Toolbar>
         </Box>
       </Box>
     </ThemeProvider>

--- a/components/AppCtaLoadUnder/components/AppCtaMessageOptIn/AppCtaMessageOptIn.tsx
+++ b/components/AppCtaLoadUnder/components/AppCtaMessageOptIn/AppCtaMessageOptIn.tsx
@@ -70,7 +70,7 @@ export const AppCtaMessageOptIn = ({ data, onClose }: IAppCtaMessageProps) => {
                     name="optIn"
                   />
                 }
-                label={optinLabel}
+                label={<HtmlContent html={optinLabel} />}
               />
             </Paper>
           </Box>

--- a/components/AppFooter/AppFooter.tsx
+++ b/components/AppFooter/AppFooter.tsx
@@ -3,22 +3,22 @@
  * Component for links to content page.
  */
 
-import React, { useContext } from 'react';
+import type { RootState } from '@interfaces';
+import { useStore } from 'react-redux';
 import Image from 'next/legacy/image';
-import { parse } from 'url';
 import { Box, Breadcrumbs, Container, Divider, Link } from '@mui/material';
 import { isLocalUrl } from '@lib/parse/url';
 import { handleButtonClick } from '@lib/routing';
 import TwLogo from '@svg/tw-white.svg';
 import PrxLogo from '@svg/PRX-Logo-Horizontal-Color.svg';
 import GBHLogo from '@svg/GBH-Logo-Purple.svg';
-import { AppContext } from '@contexts/AppContext';
+import { getAppDataMenu } from '@store/reducers';
 import { appFooterStyles } from './AppFooter.styles';
 
 export const AppFooter = () => {
-  const { data } = useContext(AppContext);
-  const { menus } = data || {};
-  const { footerNav } = menus || {};
+  const store = useStore<RootState>();
+  const state = store.getState();
+  const footerNav = getAppDataMenu(state, 'footerNav');
   const copyrightDate = new Date().getFullYear();
   const { classes, cx } = appFooterStyles();
   const producedByLogoClasses = cx(classes.logo, classes.producedByLogo);
@@ -128,11 +128,14 @@ export const AppFooter = () => {
             classes={{ ol: classes.footerNavMuiOl }}
           >
             {footerNav
-              .map(({ url, ...other }) => ({ ...other, url: parse(url) }))
+              .map(({ url, ...other }) => ({
+                ...other,
+                url: new URL(url, 'https://theworld.org')
+              }))
               .map(({ name, url, key, attributes }) =>
                 isLocalUrl(url.href) ? (
                   <Link
-                    href={url.path || '/'}
+                    href={url.pathname || '/'}
                     onClick={handleButtonClick(url)}
                     key={key}
                     className={classes.link}

--- a/components/AppFooter/AppFooter.tsx
+++ b/components/AppFooter/AppFooter.tsx
@@ -3,7 +3,7 @@
  * Component for links to content page.
  */
 
-import type { RootState } from '@interfaces';
+import type { IButtonWithUrl, RootState } from '@interfaces';
 import { useStore } from 'react-redux';
 import Image from 'next/legacy/image';
 import { Box, Breadcrumbs, Container, Divider, Link } from '@mui/material';
@@ -128,6 +128,7 @@ export const AppFooter = () => {
             classes={{ ol: classes.footerNavMuiOl }}
           >
             {footerNav
+              .filter((v): v is IButtonWithUrl => !!v.url)
               .map(({ url, ...other }) => ({
                 ...other,
                 url: new URL(url, 'https://theworld.org')

--- a/components/AppHeader/AppHeaderNav/AppHeaderNav.tsx
+++ b/components/AppHeader/AppHeaderNav/AppHeaderNav.tsx
@@ -3,7 +3,12 @@
  * Component for app header nav.
  */
 
-import type { ButtonColors, IconButtonColors, RootState } from '@interfaces';
+import type {
+  ButtonColors,
+  IButtonWithUrl,
+  IconButtonColors,
+  RootState
+} from '@interfaces';
 import { Fragment } from 'react';
 import { useStore } from 'react-redux';
 import Button from '@mui/material/Button';
@@ -31,6 +36,7 @@ export const AppHeaderNav = () => {
   return headerNav?.length ? (
     <ThemeProvider theme={appHeaderNavTheme}>
       {headerNav
+        .filter((v): v is IButtonWithUrl => !!v.url)
         .map(({ url, ...other }) => ({
           ...other,
           url: new URL(url, 'https://theworld.org')

--- a/components/AppHeader/AppHeaderNav/AppHeaderNav.tsx
+++ b/components/AppHeader/AppHeaderNav/AppHeaderNav.tsx
@@ -3,16 +3,16 @@
  * Component for app header nav.
  */
 
-import React, { useContext } from 'react';
-import { parse } from 'url';
+import type { ButtonColors, IconButtonColors, RootState } from '@interfaces';
+import { Fragment } from 'react';
+import { useStore } from 'react-redux';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import { ThemeProvider } from '@mui/styles';
 import { FavoriteSharp } from '@mui/icons-material';
-import { ButtonColors, IconButtonColors } from '@interfaces';
 import { isLocalUrl } from '@lib/parse/url';
 import { handleButtonClick } from '@lib/routing';
-import { AppContext } from '@contexts/AppContext';
+import { getAppDataMenu } from '@store/reducers';
 import { appHeaderNavTheme } from './AppHeaderNav.styles';
 
 const iconComponentMap = new Map();
@@ -24,14 +24,17 @@ const renderIcon = (icon: string) => {
 };
 
 export const AppHeaderNav = () => {
-  const { data } = useContext(AppContext);
-  const { menus } = data || {};
-  const { headerNav } = menus || {};
+  const store = useStore<RootState>();
+  const state = store.getState();
+  const headerNav = getAppDataMenu(state, 'headerNav');
 
   return headerNav?.length ? (
     <ThemeProvider theme={appHeaderNavTheme}>
       {headerNav
-        .map(({ url, ...other }) => ({ ...other, url: parse(url || '') }))
+        .map(({ url, ...other }) => ({
+          ...other,
+          url: new URL(url, 'https://theworld.org')
+        }))
         .map(({ service, ...other }) => {
           if (!service) return other;
 
@@ -54,11 +57,11 @@ export const AppHeaderNav = () => {
         })
         .map(
           ({ color, icon, name, url, key, attributes, itemLinkClass = '' }) => (
-            <React.Fragment key={key}>
+            <Fragment key={key}>
               <Button
                 sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
                 component="a"
-                href={isLocalUrl(url.href) ? url.path || undefined : url.href}
+                href={isLocalUrl(url.href) ? url.pathname || '/' : url.href}
                 onClick={handleButtonClick(url)}
                 variant={
                   /\bbtn-(text|link)\b/.test(itemLinkClass)
@@ -106,7 +109,7 @@ export const AppHeaderNav = () => {
                   {name}
                 </Button>
               )}
-            </React.Fragment>
+            </Fragment>
           )
         )}
     </ThemeProvider>

--- a/components/AppHeader/DrawerMainNav/DrawerMainNav.tsx
+++ b/components/AppHeader/DrawerMainNav/DrawerMainNav.tsx
@@ -3,9 +3,10 @@
  * Component for app drawer top nav.
  */
 
-import React, { useContext, useState } from 'react';
+import type { IButton, RootState } from '@interfaces';
+import { useState } from 'react';
+import { useStore } from 'react-redux';
 import { handleButtonClick } from '@lib/routing';
-import { IButton } from '@interfaces';
 import {
   Box,
   Collapse,
@@ -15,7 +16,7 @@ import {
   ThemeProvider
 } from '@mui/material';
 import ExpandMore from '@mui/icons-material/ExpandMore';
-import { AppContext } from '@contexts/AppContext';
+import { getAppDataMenu } from '@store/reducers';
 import {
   drawerMainNavTheme,
   drawerMainNavStyles
@@ -26,9 +27,9 @@ export interface OpenStateMap {
 }
 
 export const DrawerMainNav = () => {
-  const { data } = useContext(AppContext);
-  const { menus } = data || {};
-  const { drawerMainNav } = menus || {};
+  const store = useStore<RootState>();
+  const state = store.getState();
+  const drawerMainNav = getAppDataMenu(state, 'drawerMainNav');
   const [{ open }, setState] = useState({
     open: drawerMainNav
       ? drawerMainNav.reduce(

--- a/components/AppHeader/DrawerMainNav/DrawerMainNav.tsx
+++ b/components/AppHeader/DrawerMainNav/DrawerMainNav.tsx
@@ -26,27 +26,27 @@ export interface OpenStateMap {
   [k: string]: boolean;
 }
 
+const genOpenStateMapKey = (button: IButton, index: number) =>
+  button.key || `${button.name}:${index}`;
+
 export const DrawerMainNav = () => {
   const store = useStore<RootState>();
   const state = store.getState();
   const drawerMainNav = getAppDataMenu(state, 'drawerMainNav');
   const [{ open }, setState] = useState({
     open: drawerMainNav
-      ? drawerMainNav.reduce(
-          (a: OpenStateMap, { children, key }: IButton): OpenStateMap => {
-            if (children) {
-              const b = {
-                ...a,
-                [key]: false
-              };
+      ? drawerMainNav.reduce((a: OpenStateMap, btn, index): OpenStateMap => {
+          if (btn.children) {
+            const b = {
+              ...a,
+              [genOpenStateMapKey(btn, index)]: false
+            };
 
-              return b;
-            }
+            return b;
+          }
 
-            return a;
-          },
-          {}
-        )
+          return a;
+        }, {})
       : {}
   });
   const { classes, cx } = drawerMainNavStyles();
@@ -64,8 +64,10 @@ export const DrawerMainNav = () => {
     (drawerMainNav && (
       <ThemeProvider theme={drawerMainNavTheme}>
         <List component="nav" className={classes.root} disablePadding>
-          {drawerMainNav.map(
-            ({ name, url, key, children }, index: number) =>
+          {drawerMainNav.map((btn, index: number) => {
+            const { name, url, children } = btn;
+            const key = genOpenStateMapKey(btn, index);
+            return (
               (children && (
                 <Box className={classes.accordion} key={key}>
                   <ListItemButton
@@ -109,7 +111,8 @@ export const DrawerMainNav = () => {
                   <ListItemText primary={name} />
                 </ListItemButton>
               )
-          )}
+            );
+          })}
         </List>
       </ThemeProvider>
     )) ||

--- a/components/AppHeader/DrawerSocialNav/DrawerSocialNav.tsx
+++ b/components/AppHeader/DrawerSocialNav/DrawerSocialNav.tsx
@@ -3,8 +3,8 @@
  * Component for app drawer social nav.
  */
 
-import { useContext } from 'react';
-import { parse } from 'url';
+import type { RootState } from '@interfaces';
+import { useStore } from 'react-redux';
 import { IconButton, Toolbar } from '@mui/material';
 import { isLocalUrl } from '@lib/parse/url';
 import {
@@ -14,7 +14,7 @@ import {
   Instagram,
   WhatsApp
 } from '@mui/icons-material';
-import { AppContext } from '@contexts/AppContext';
+import { getAppDataMenu } from '@store/reducers';
 import { drawerTopNavStyles } from './DrawerSocialNav.styles';
 
 const iconComponentMap = new Map();
@@ -31,16 +31,19 @@ const renderIcon = (icon: string, label: string) => {
 };
 
 export const DrawerSocialNav = () => {
-  const { data } = useContext(AppContext);
-  const { menus } = data || {};
-  const { drawerSocialNav } = menus || {};
+  const store = useStore<RootState>();
+  const state = store.getState();
+  const drawerSocialNav = getAppDataMenu(state, 'drawerSocialNav');
   const { classes } = drawerTopNavStyles();
 
   return (
     (drawerSocialNav && (
       <Toolbar className={classes.root}>
         {drawerSocialNav
-          .map(({ url, ...other }) => ({ ...other, url: parse(url) }))
+          .map(({ url, ...other }) => ({
+            ...other,
+            url: new URL(url, 'https://theworld.org')
+          }))
           .map(({ service, ...other }) => {
             if (!service) return other;
 
@@ -65,7 +68,7 @@ export const DrawerSocialNav = () => {
           .map(({ name, url, icon, key, title, attributes }) => (
             <IconButton
               color="inherit"
-              href={isLocalUrl(url.href) && url.path ? url.path : url.href}
+              href={isLocalUrl(url.href) ? url.pathname || '/' : url.href}
               target="_blank"
               rel="noopener noreferrer"
               key={key}

--- a/components/AppHeader/DrawerSocialNav/DrawerSocialNav.tsx
+++ b/components/AppHeader/DrawerSocialNav/DrawerSocialNav.tsx
@@ -3,7 +3,7 @@
  * Component for app drawer social nav.
  */
 
-import type { RootState } from '@interfaces';
+import type { IButtonWithUrl, RootState } from '@interfaces';
 import { useStore } from 'react-redux';
 import { IconButton, Toolbar } from '@mui/material';
 import { isLocalUrl } from '@lib/parse/url';
@@ -40,6 +40,7 @@ export const DrawerSocialNav = () => {
     (drawerSocialNav && (
       <Toolbar className={classes.root}>
         {drawerSocialNav
+          .filter((v): v is IButtonWithUrl => !!v.url)
           .map(({ url, ...other }) => ({
             ...other,
             url: new URL(url, 'https://theworld.org')

--- a/components/AppHeader/DrawerTopNav/DrawerTopNav.tsx
+++ b/components/AppHeader/DrawerTopNav/DrawerTopNav.tsx
@@ -3,18 +3,18 @@
  * Component for app drawer top nav.
  */
 
-import { useContext } from 'react';
-import { parse } from 'url';
+import type { RootState } from '@interfaces';
+import { useStore } from 'react-redux';
 import { Button, ButtonGroup } from '@mui/material';
 import { isLocalUrl } from '@lib/parse/url';
 import { handleButtonClick } from '@lib/routing';
-import { AppContext } from '@contexts/AppContext';
+import { getAppDataMenu } from '@store/reducers';
 import { drawerTopNavStyles } from './DrawerTopNav.styles';
 
 export const DrawerTopNav = () => {
-  const { data } = useContext(AppContext);
-  const { menus } = data || {};
-  const { drawerTopNav } = menus || {};
+  const store = useStore<RootState>();
+  const state = store.getState();
+  const drawerTopNav = getAppDataMenu(state, 'drawerTopNav');
   const { classes } = drawerTopNavStyles();
 
   return (
@@ -27,11 +27,14 @@ export const DrawerTopNav = () => {
         disableRipple
       >
         {drawerTopNav
-          .map(({ url, ...other }) => ({ ...other, url: parse(url) }))
+          .map(({ url, ...other }) => ({
+            ...other,
+            url: new URL(url, 'https://theworld.org')
+          }))
           .map(({ name, url, key, attributes }) => (
             <Button
               component="a"
-              href={isLocalUrl(url.href) ? url.path || '/' : url.href}
+              href={isLocalUrl(url.href) ? url.pathname || '/' : url.href}
               onClick={handleButtonClick(url)}
               key={key}
               disableRipple

--- a/components/AppHeader/DrawerTopNav/DrawerTopNav.tsx
+++ b/components/AppHeader/DrawerTopNav/DrawerTopNav.tsx
@@ -3,7 +3,7 @@
  * Component for app drawer top nav.
  */
 
-import type { RootState } from '@interfaces';
+import type { IButtonWithUrl, RootState } from '@interfaces';
 import { useStore } from 'react-redux';
 import { Button, ButtonGroup } from '@mui/material';
 import { isLocalUrl } from '@lib/parse/url';
@@ -27,6 +27,7 @@ export const DrawerTopNav = () => {
         disableRipple
       >
         {drawerTopNav
+          .filter((v): v is IButtonWithUrl => !!v.url)
           .map(({ url, ...other }) => ({
             ...other,
             url: new URL(url, 'https://theworld.org')

--- a/components/AppPlayer/AppPlayer.styles.ts
+++ b/components/AppPlayer/AppPlayer.styles.ts
@@ -21,7 +21,10 @@ export const appPlayerStyles = makeStyles()((theme) => ({
     display: 'grid',
     gridTemplateColumns: '0fr 1fr 0fr',
     justifyContent: 'space-between',
-    gap: theme.typography.pxToRem(16)
+    gap: theme.typography.pxToRem(16),
+    [theme.breakpoints.down(760)]: {
+      gap: 0
+    }
   },
 
   controls: {
@@ -31,6 +34,9 @@ export const appPlayerStyles = makeStyles()((theme) => ({
     gap: theme.typography.pxToRem(2),
     '&:last-child': {
       justifySelf: 'end'
+    },
+    [theme.breakpoints.down(760)]: {
+      justifyContent: 'end'
     }
   },
 
@@ -65,7 +71,7 @@ export const appPlayerStyles = makeStyles()((theme) => ({
   },
 
   trackInfo: {
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down(760)]: {
       display: 'none'
     }
   },
@@ -79,7 +85,7 @@ export const appPlayerStyles = makeStyles()((theme) => ({
   },
 
   volume: {
-    [theme.breakpoints.down('xs')]: {
+    [theme.breakpoints.down('md')]: {
       display: 'none'
     }
   },

--- a/components/CtaRegion/CtaRegion.styles.ts
+++ b/components/CtaRegion/CtaRegion.styles.ts
@@ -3,101 +3,86 @@
  * Styles for CtaRegion.
  */
 
-import { createTheme, Theme } from '@mui/material/styles';
-import { blue } from '@theme/colors';
+import { makeStyles } from 'tss-react/mui';
+import { blue, grey } from '@theme/colors';
 
-export const ctaRegionTheme = (theme: Theme) =>
-  createTheme(theme, {
-    typography: {},
-    components: {
-      MuiCard: {
-        styleOverrides: {
-          root: {
-            display: 'grid',
-            gridFlow: 'column',
-            gridGap: theme.spacing(2),
-            padding: theme.spacing(2),
-            background: 'transparent',
-            borderLeft: `4px solid ${theme.palette.primary.main}`,
-            color: 'inherit'
-          }
-        }
+export const useSidebarCtaStyles = makeStyles()((theme) => ({
+  root: {
+    '& :where(.MuiCard-root)': {
+      borderLeft: `4px solid var(--cta-accent-color, ${theme.palette.primary.main})`
+    },
+    '& :is(.MuiCard-root)': {
+      display: 'grid',
+      gridGap: theme.spacing(2),
+      padding: theme.spacing(2),
+      background: 'transparent',
+      color: 'inherit'
+    },
+    '& :is(.MuiCardHeader-root)': {
+      padding: 0,
+      color: blue[900]
+    },
+    '& :is(.MuiCardHeader-title)': {
+      fontSize: '1.1rem'
+    },
+    '& :is(.MuiCardContent-root)': {
+      padding: 0,
+      '& p': {
+        margin: 0
       },
-      MuiCardHeader: {
-        styleOverrides: {
-          root: {
-            padding: 0,
-            color: blue[900]
-          },
-          title: {
-            fontSize: '1.1rem'
-          }
-        }
+      '& p + p': {
+        marginTop: '1rem'
       },
-      MuiCardContent: {
-        styleOverrides: {
-          root: {
-            padding: 0,
-            '& p': {
-              margin: 0
-            },
-            '& p + p': {
-              marginTop: '1rem'
-            }
-          }
-        }
+      '& a:link, & a:visited': {
+        color: theme.palette.primary.main,
+        fontWeight: 'bold',
+        textDecoration: 'none'
       },
-      MuiCardActions: {
-        styleOverrides: {
-          root: {
-            padding: 0
-          }
-        }
+      '& ul': {
+        margin: '1em 0 0 16px',
+        padding: 0
       },
-      MuiCheckbox: {
-        styleOverrides: {
-          root: {
-            color: 'inherit'
-          }
-        }
+      '& li': {
+        padding: 0,
+        margin: 0,
+        color: grey[500]
       },
-      Mui: {
-        styleOverrides: {
-          root: {
-            paddingLeft: theme.spacing(2)
-          },
-          label: {
-            paddingTop: theme.spacing(2),
-            paddingBottom: theme.spacing(2),
-            textAlign: 'left',
-            color: theme.palette.grey[700]
-          }
-        }
+      '& li a:link, & li a:visited': {
+        padding: '3px 0',
+        width: '100%'
       },
-      MuiIconButton: {
-        styleOverrides: {
-          root: {
-            '&:hover': {
-              backgroundColor: theme.palette.action.focus
-            }
-          }
-        }
-      },
-      MuiPaper: {
-        styleOverrides: {
-          root: {}
-        }
-      },
-      MuiToolbar: {
-        styleOverrides: {
-          root: {
-            justifyContent: 'center',
-            marginTop: theme.spacing(3),
-            '& > * + *': {
-              marginLeft: theme.spacing(2)
-            }
-          }
-        }
+      '& li a:hover': {
+        color: theme.palette.primary.dark,
+        textDecoration: 'underline'
+      }
+    },
+    '& :where(.MuiCardActions-root)': {
+      padding: 0
+    },
+    '& :where(.MuiCheckbox-root)': {
+      color: 'inherit'
+    },
+    '& :where(.MuiFormControlLabel-root)': {
+      paddingLeft: theme.spacing(2),
+      color: theme.palette.grey[700]
+    },
+    '& :where(.MuiFormControlLabel-label)': {
+      paddingTop: theme.spacing(2),
+      paddingBottom: theme.spacing(2),
+      textAlign: 'left',
+      color: theme.palette.grey[700]
+    },
+    '& :where(.MuiIconButton-root)': {
+      '&:hover': {
+        backgroundColor: theme.palette.action.focus
+      }
+    },
+    '& :where(.MuiToolbar-root)': {
+      justifyContent: 'center',
+      marginTop: theme.spacing(3),
+      '& > * + *': {
+        marginLeft: theme.spacing(2)
       }
     }
-  });
+  }
+}));

--- a/components/CtaRegion/CtaRegion.tsx
+++ b/components/CtaRegion/CtaRegion.tsx
@@ -3,24 +3,24 @@
  * Component for sidebar elements.
  */
 
-import React from 'react';
-import { ThemeProvider } from '@mui/material';
-import { ICtaRegionProps } from '@interfaces/cta';
+import type { ICtaRegionProps } from '@interfaces/cta';
+import { Box } from '@mui/material';
 import { getShownMessage } from '@lib/cta';
-import { ctaRegionTheme } from './CtaRegion.styles';
+import { useSidebarCtaStyles } from './CtaRegion.styles';
 import { ctaTypeComponentMap } from './components';
 
 export const CtaRegion = ({ data }: ICtaRegionProps) => {
   const shownMessage = getShownMessage(data);
   const { type } = shownMessage || {};
   const CtaMessageComponent = ctaTypeComponentMap.get(type);
+  const { classes } = useSidebarCtaStyles();
 
   return (
     data &&
     CtaMessageComponent && (
-      <ThemeProvider theme={ctaRegionTheme}>
+      <Box className={classes.root}>
         <CtaMessageComponent data={{ ...shownMessage }} />
-      </ThemeProvider>
+      </Box>
     )
   );
 };

--- a/components/CtaRegion/components/CtaMessageInfo/CtaMessageInfo.tsx
+++ b/components/CtaRegion/components/CtaMessageInfo/CtaMessageInfo.tsx
@@ -31,7 +31,7 @@ export const CtaMessageInfo = ({ data }: ICtaMessageProps) => {
     <Card elevation={0}>
       {heading && <CardHeader title={heading} />}
       {message && (
-        <CardContent>
+        <CardContent sx={{ '&:last-child': { paddingBlockEnd: 0 } }}>
           <Typography component="div" variant="body1">
             <HtmlContent html={message} />
           </Typography>

--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -35,10 +35,11 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
   if (!html) return null;
 
   const cleanHtml = (dirtyHtml: string) =>
-    [(h: string) => h.replace(/<[^>/]+>(\s|&nbsp;)*<\/[^>]+>/g, '')].reduce(
-      (acc, func) => func(acc),
-      dirtyHtml
-    );
+    [
+      (h: string) =>
+        h.replace(/\r?\n|\r/g, '').replace(/<[^>/]+>(\s|&nbsp;)*<\/[^>]+>/g, '')
+    ].reduce((acc, func) => func(acc), dirtyHtml);
+
   const transform = (node: DomElement, index: number) =>
     [
       anchorToLink,

--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -5,6 +5,7 @@
 
 import { type ReactElement } from 'react';
 import { type DomElement } from 'htmlparser2';
+import type { Maybe } from '@interfaces';
 import ReactHtmlParser, { type Transform } from 'react-html-parser';
 import {
   anchorToLink,
@@ -19,7 +20,7 @@ import {
 } from './transforms';
 
 export interface IHtmlContentProps {
-  html: string;
+  html?: Maybe<string>;
   transforms?: ((
     // eslint-disable-next-line no-unused-vars
     N: DomElement,
@@ -56,10 +57,10 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
     );
 
   return (
-      <>
-        {ReactHtmlParser(cleanHtml(html), {
-          transform: transform as Transform
-        })}
-      </>
+    <>
+      {ReactHtmlParser(cleanHtml(html), {
+        transform: transform as Transform
+      })}
+    </>
   );
 };

--- a/components/LandingPageHeader/LandingPageHeader.tsx
+++ b/components/LandingPageHeader/LandingPageHeader.tsx
@@ -34,15 +34,13 @@ export const LandingPageHeader = ({
         })}
       >
         {image?.sourceUrl && (
-          <Box>
-            <Image
-              alt={image.altText || ''}
-              src={image.sourceUrl}
-              layout="fill"
-              objectFit="cover"
-              priority
-            />
-          </Box>
+          <Image
+            alt={image.altText || ''}
+            src={image.sourceUrl}
+            layout="fill"
+            objectFit="cover"
+            priority
+          />
         )}
         <Box className={classes.content}>
           <Container fixed className={classes.header}>

--- a/components/NewsletterForm/NewsletterForm.tsx
+++ b/components/NewsletterForm/NewsletterForm.tsx
@@ -3,7 +3,9 @@
  * Component for newsletter  elements.
  */
 
-import React, { ChangeEvent, FormEvent, useState, HTMLAttributes } from 'react';
+import type { Maybe } from '@interfaces';
+import type { ChangeEvent, FormEvent, HTMLAttributes } from 'react';
+import { useState } from 'react';
 import {
   Box,
   Button,
@@ -25,7 +27,7 @@ import {
 } from './NewsletterForm.styles';
 
 export interface INewsletterProps extends HTMLAttributes<{}> {
-  label?: string;
+  label?: Maybe<string>;
   options?: INewsletterOptions;
   onSubscribed?: Function;
   compact?: boolean;

--- a/components/NewsletterForm/NewsletterForm.tsx
+++ b/components/NewsletterForm/NewsletterForm.tsx
@@ -71,7 +71,7 @@ export const NewsletterForm = ({
     const resp = await postNewsletterSubscription(data, {
       ...options,
       ...(isAmp &&
-        options && { 'source-position': `${options['source-position']}-amp` })
+        options && { 'source-placement': `${options['source-placement']}-amp` })
     });
     const { error: err } = resp;
 

--- a/components/QuickLinks/QuickLinks.tsx
+++ b/components/QuickLinks/QuickLinks.tsx
@@ -3,9 +3,8 @@
  * Component for links to content page.
  */
 
-import type { IButton } from '@interfaces';
+import type { IButton, IButtonWithUrl } from '@interfaces';
 import React from 'react';
-import { parse } from 'url';
 import { Label } from '@mui/icons-material';
 import { Breadcrumbs, Container, Link } from '@mui/material';
 import { isLocalUrl } from '@lib/parse/url';
@@ -34,7 +33,11 @@ export const QuickLinks = ({ data }: QuickLinksProps) => {
             className={classes.label}
           />
           {data
-            .map(({ url, ...other }) => ({ ...other, url: parse(url) }))
+            .filter((v): v is IButtonWithUrl => !!v.url)
+            .map(({ url, ...other }) => ({
+              ...other,
+              url: new URL(url, 'https://theworld.org')
+            }))
             .map(({ name, url, key, attributes }) =>
               isLocalUrl(url.href) ? (
                 <Link

--- a/components/Sidebar/SidebarHeader/SidebarHeader.styles.ts
+++ b/components/Sidebar/SidebarHeader/SidebarHeader.styles.ts
@@ -5,21 +5,23 @@
 
 import { makeStyles } from 'tss-react/mui';
 
-export const sidebarHeaderStyles = makeStyles()((theme) => ({
-  root: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.typography.pxToRem(8),
-    padding: '1rem 1rem 0.5rem',
-    '& :is(h1, h2, h3, h4, h5, h6)': {
-      flexGrow: 1,
-      fontSize: theme.typography.pxToRem(15),
-      fontWeight: 400
-    },
-    '& > :is(.MuiSvgIcon-root)': {
-      marginRight: '0.25rem',
-      fill: theme.palette.secondary.main,
-      verticalAlign: 'text-bottom'
+export const sidebarHeaderStyles = makeStyles<{ disablePadding?: boolean }>()(
+  (theme, { disablePadding }) => ({
+    root: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.typography.pxToRem(8),
+      padding: `1rem ${disablePadding ? 0 : '1rem'} 0.5rem`,
+      '& :is(h1, h2, h3, h4, h5, h6)': {
+        flexGrow: 1,
+        fontSize: theme.typography.pxToRem(15),
+        fontWeight: 400
+      },
+      '& > :is(.MuiSvgIcon-root)': {
+        marginRight: '0.25rem',
+        fill: theme.palette.secondary.main,
+        verticalAlign: 'text-bottom'
+      }
     }
-  }
-}));
+  })
+);

--- a/components/Sidebar/SidebarHeader/SidebarHeader.styles.ts
+++ b/components/Sidebar/SidebarHeader/SidebarHeader.styles.ts
@@ -15,7 +15,8 @@ export const sidebarHeaderStyles = makeStyles<{ disablePadding?: boolean }>()(
       '& :is(h1, h2, h3, h4, h5, h6)': {
         flexGrow: 1,
         fontSize: theme.typography.pxToRem(15),
-        fontWeight: 400
+        fontWeight: 400,
+        textWrap: 'balance'
       },
       '& > :is(.MuiSvgIcon-root)': {
         marginRight: '0.25rem',

--- a/components/Sidebar/SidebarHeader/SidebarHeader.tsx
+++ b/components/Sidebar/SidebarHeader/SidebarHeader.tsx
@@ -7,14 +7,17 @@ import React from 'react';
 import { Box, BoxProps } from '@mui/material';
 import { sidebarHeaderStyles } from './SidebarHeader.styles';
 
-export interface ISidebarHeaderProps extends BoxProps {}
+export interface ISidebarHeaderProps extends BoxProps {
+  disablePadding?: boolean;
+}
 
 export const SidebarHeader = ({
+  disablePadding,
   children,
   className,
   ...other
 }: ISidebarHeaderProps) => {
-  const { classes, cx } = sidebarHeaderStyles();
+  const { classes, cx } = sidebarHeaderStyles({ disablePadding });
 
   return (
     <Box component="header" {...other} className={cx(classes.root, className)}>

--- a/components/Sidebar/SidebarLatestStories/SidebarLatestStories.tsx
+++ b/components/Sidebar/SidebarLatestStories/SidebarLatestStories.tsx
@@ -3,12 +3,12 @@
  * Component for sidebar latest story links list.
  */
 
-import type { PostStory } from '@interfaces';
-import { useContext } from 'react';
+import type { PostStory, RootState } from '@interfaces';
+import { useStore } from 'react-redux';
 import Link from 'next/link';
 import { Button, Typography } from '@mui/material';
 import { MenuBookRounded, NavigateNext } from '@mui/icons-material';
-import { AppContext } from '@contexts/AppContext';
+import { getAppDataLatestStories } from '@store/reducers';
 import { Sidebar } from '../Sidebar';
 import { SidebarHeader } from '../SidebarHeader';
 import { SidebarFooter } from '../SidebarFooter';
@@ -23,8 +23,9 @@ export const SidebarLatestStories = ({
   data,
   label
 }: SidebarLatestStoriesProps) => {
-  const { data: appData } = useContext(AppContext);
-  const { latestStories } = appData || {};
+  const store = useStore<RootState>();
+  const state = store.getState();
+  const latestStories = getAppDataLatestStories(state);
   const stories = data || latestStories;
   const listItems = stories?.map<SidebarListItem>((story) => ({
     data: story,

--- a/components/Sidebar/SidebarList/SidebarList.styles.ts
+++ b/components/Sidebar/SidebarList/SidebarList.styles.ts
@@ -52,7 +52,7 @@ export const sidebarListStyles = makeStyles()((theme) => ({
       listStyle: 'disc',
       marginTop: 0,
       marginBottom: 0,
-      marginLeft: theme.spacing(2),
+      marginLeft: theme.spacing(3),
       color: theme.palette.grey[500],
       '&.noBullet': {
         display: 'unset',

--- a/components/Sidebar/SidebarList/SidebarList.tsx
+++ b/components/Sidebar/SidebarList/SidebarList.tsx
@@ -76,9 +76,10 @@ export const SidebarList = ({
             (('title' in item.data && item.data?.title) ||
               ('name' in item.data && item.data?.name)));
 
-        return !!text
-          ?.toLocaleLowerCase()
-          .includes(searchText.toLocaleLowerCase());
+        return (
+          !!text &&
+          text.toLocaleLowerCase().includes(searchText.toLocaleLowerCase())
+        );
       });
   const [page, setPage] = useState(1);
   const { pageSize = 10 } = paginationProps || {};
@@ -97,7 +98,7 @@ export const SidebarList = ({
   };
 
   const handleSearchClear = () => {
-    setSearchText(null);
+    setSearchText(undefined);
   };
 
   const listProps = {
@@ -179,81 +180,80 @@ export const SidebarList = ({
     setPage(value);
   };
 
-  return (
-    hasData && (
-      <>
-        <List {...listProps}>
-          {pageItems.map((item) => {
-            const text =
-              item.title ||
-              (item.data &&
-                (('title' in item.data && item.data?.title) ||
-                  ('name' in item.data && item.data?.name)));
-            const url = item.url || item.data?.link;
-            const avatarSrc =
-              item.avatar?.sourceUrl || item.avatar?.mediaItemUrl;
+  if (!hasData) return null;
 
-            return item.data ? (
-              <ListItemButton
-                component={ContentLink}
-                url={url}
-                key={item.data.id}
-              >
-                {item.avatar && (
-                  <ListItemAvatar>
-                    {avatarSrc ? (
-                      <Avatar aria-hidden>
-                        <Image
-                          src={avatarSrc}
-                          alt={`Avatar of ${text}`}
-                          width={styleOptions.avatar.size}
-                          height={styleOptions.avatar.size}
-                          style={{ objectFit: 'cover' }}
-                        />
-                      </Avatar>
-                    ) : (
-                      <Avatar className={classes.noAvatarImage} aria-hidden>
-                        {text ? (
-                          [...text.matchAll(/\b[A-Z]/g)].join('')
-                        ) : (
-                          <Person />
-                        )}
-                      </Avatar>
-                    )}
-                  </ListItemAvatar>
-                )}
+  return (
+    <>
+      <List {...listProps}>
+        {pageItems.map((item) => {
+          const text =
+            item.title ||
+            (item.data &&
+              (('title' in item.data && item.data?.title) ||
+                ('name' in item.data && item.data?.name)));
+          const url = item.url || item.data?.link;
+          const avatarSrc = item.avatar?.sourceUrl || item.avatar?.mediaItemUrl;
+
+          return item.data ? (
+            <ListItemButton
+              component={ContentLink}
+              url={url}
+              key={item.data.id}
+            >
+              {item.avatar && (
+                <ListItemAvatar>
+                  {avatarSrc ? (
+                    <Avatar aria-hidden>
+                      <Image
+                        src={avatarSrc}
+                        alt={`Avatar of ${text}`}
+                        width={styleOptions.avatar.size}
+                        height={styleOptions.avatar.size}
+                        style={{ objectFit: 'cover' }}
+                      />
+                    </Avatar>
+                  ) : (
+                    <Avatar className={classes.noAvatarImage} aria-hidden>
+                      {text ? (
+                        [...text.matchAll(/\b[A-Z]/g)].join('')
+                      ) : (
+                        <Person />
+                      )}
+                    </Avatar>
+                  )}
+                </ListItemAvatar>
+              )}
+              <ListItemText {...listItemTextProps}>{text}</ListItemText>
+              {item.audio && (
+                <ListItemSecondaryAction>
+                  <AudioControls
+                    id={item.audio.id}
+                    fallbackProps={item.audioProps}
+                    variant="minimal"
+                  />
+                </ListItemSecondaryAction>
+              )}
+            </ListItemButton>
+          ) : (
+            (url && (
+              <ListItemButton component="a" href={url} key={url}>
                 <ListItemText {...listItemTextProps}>{text}</ListItemText>
-                {item.audio && (
-                  <ListItemSecondaryAction>
-                    <AudioControls
-                      id={item.audio.id}
-                      fallbackProps={item.audioProps}
-                      variant="minimal"
-                    />
-                  </ListItemSecondaryAction>
-                )}
               </ListItemButton>
-            ) : (
-              (url && (
-                <ListItemButton component="a" href={url} key={url}>
-                  <ListItemText {...listItemTextProps}>{text}</ListItemText>
-                </ListItemButton>
-              )) || <ListItemText {...listItemTextProps}>{text}</ListItemText>
-            );
-          })}
-        </List>
-        <SidebarFooter>
-          {showPagination && (
-            <Pagination
-              size="small"
-              count={pageCount}
-              page={page}
-              color="primary"
-              onChange={handleSegmentsPageChange}
-            />
-          )}
-        </SidebarFooter>
-      </>
-    )
+            )) || <ListItemText {...listItemTextProps}>{text}</ListItemText>
+          );
+        })}
+      </List>
+      <SidebarFooter>
+        {showPagination && (
+          <Pagination
+            size="small"
+            count={pageCount}
+            page={page}
+            color="primary"
+            onChange={handleSegmentsPageChange}
+          />
+        )}
+      </SidebarFooter>
+    </>
   );
 };

--- a/components/Sidebar/SidebarList/SidebarList.tsx
+++ b/components/Sidebar/SidebarList/SidebarList.tsx
@@ -3,6 +3,7 @@
  * Component for link lists in sidebar.
  */
 
+import type React from 'react';
 import type { IAudioData } from '@components/Player/types';
 import type {
   ContentNode,
@@ -12,6 +13,7 @@ import type {
   NodeWithTitle,
   TermNode
 } from '@interfaces';
+import { useState } from 'react';
 import Image from 'next/image';
 import {
   List,
@@ -22,12 +24,18 @@ import {
   ListSubheader,
   ListItemSecondaryAction,
   ListItemButton,
-  ListItemTextProps
+  ListItemTextProps,
+  PaginationProps,
+  Pagination,
+  TextField,
+  Alert,
+  IconButton
 } from '@mui/material';
-import { Person } from '@mui/icons-material';
+import { Close, Person, Search } from '@mui/icons-material';
 import { ContentLink } from '@components/ContentLink';
 import { AudioControls } from '@components/Player/components';
 import { sidebarListStyles, styleOptions } from './SidebarList.styles';
+import { SidebarFooter } from '../SidebarFooter';
 
 export type SidebarListItem = {
   title?: Maybe<string>;
@@ -45,98 +53,207 @@ export interface ISidebarListProps extends ListProps {
   data: SidebarListItem[];
   subheaderText?: string;
   bulleted?: boolean;
+  paginationProps?: Partial<PaginationProps & { pageSize?: number }>;
 }
 
 export const SidebarList = ({
   className,
   data,
+  subheader,
   subheaderText,
   bulleted = false,
+  paginationProps,
   ...other
 }: ISidebarListProps) => {
+  const hasData = !!data?.length;
+  const [searchText, setSearchText] = useState<string>();
+  const filteredItems = !searchText
+    ? data
+    : data.filter((item) => {
+        const text =
+          item.title ||
+          (item.data &&
+            (('title' in item.data && item.data?.title) ||
+              ('name' in item.data && item.data?.name)));
+
+        return !!text
+          ?.toLocaleLowerCase()
+          .includes(searchText.toLocaleLowerCase());
+      });
+  const [page, setPage] = useState(1);
+  const { pageSize = 10 } = paginationProps || {};
+  const itemCount = filteredItems?.length || 0;
+  const pageCount = Math.ceil(itemCount / pageSize);
+  const startIndex = (page - 1) * pageSize;
+  const endIndex = startIndex + pageSize;
+  const pageItems = filteredItems?.slice(startIndex, endIndex);
+  const showSearch = hasData && data.length > pageSize;
+  const showPagination = pageCount > 1;
   const { classes, cx } = sidebarListStyles();
   const listClasses = cx(classes.root, className);
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchText(event.target.value);
+  };
+
+  const handleSearchClear = () => {
+    setSearchText(null);
+  };
+
   const listProps = {
     component: 'nav',
     className: listClasses,
     ...other,
-    ...(subheaderText && {
-      subheader: (
-        <ListSubheader
-          classes={{ root: classes.MuiListSubheaderRoot }}
-          component="header"
-          disableSticky
-        >
-          {subheaderText}
-        </ListSubheader>
-      )
-    })
+    subheader: (
+      <ListSubheader
+        classes={{ root: classes.MuiListSubheaderRoot }}
+        component="header"
+        disableSticky
+      >
+        {subheader || subheaderText}
+
+        {showSearch && (
+          <TextField
+            aria-label="List Search"
+            value={searchText || ''}
+            placeholder="Search"
+            color="primary"
+            size="small"
+            variant="outlined"
+            fullWidth
+            sx={{
+              marginBlock: '0.5rem',
+              '--_border-color': '#eee',
+              '.MuiOutlinedInput-root': {
+                borderRadius: '2rem',
+                paddingRight: 0,
+                overflow: 'hidden',
+                '.MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'var(--_border-color)'
+                },
+                '&:hover': {
+                  '.MuiOutlinedInput-notchedOutline': {
+                    borderWidth: '3px',
+                    borderColor: 'var(--_border-color)'
+                  }
+                },
+                '&.Mui-focused': {
+                  '.MuiOutlinedInput-notchedOutline': {
+                    borderColor: 'var(--_border-color)'
+                  }
+                }
+              }
+            }}
+            InputProps={{
+              endAdornment: !searchText ? (
+                <IconButton disabled sx={{ paddingInlineEnd: '0.75rem' }}>
+                  <Search />
+                </IconButton>
+              ) : (
+                <IconButton
+                  onClick={handleSearchClear}
+                  sx={{ paddingInlineEnd: '0.75rem' }}
+                  disableRipple
+                >
+                  <Close />
+                </IconButton>
+              )
+            }}
+            onChange={handleSearchChange}
+          />
+        )}
+        {!filteredItems.length && (
+          <Alert severity="info">{`No results for "${searchText}".`}</Alert>
+        )}
+      </ListSubheader>
+    )
   } as ListProps;
   const listItemTextProps = {
     className: cx({ noBullet: !bulleted })
   } as ListItemTextProps;
 
-  return (
-    !!data && (
-      <List {...listProps}>
-        {data.map((item) => {
-          const text =
-            item.title ||
-            (item.data &&
-              (('title' in item.data && item.data?.title) ||
-                ('name' in item.data && item.data?.name)));
-          const url = item.url || item.data?.link;
-          const avatarSrc = item.avatar?.sourceUrl || item.avatar?.mediaItemUrl;
+  const handleSegmentsPageChange = async (
+    event: React.ChangeEvent<unknown>,
+    value: number
+  ) => {
+    setPage(value);
+  };
 
-          return item.data ? (
-            <ListItemButton
-              component={ContentLink}
-              url={url}
-              key={item.data.id}
-            >
-              {item.avatar && (
-                <ListItemAvatar>
-                  {avatarSrc ? (
-                    <Avatar aria-hidden>
-                      <Image
-                        src={avatarSrc}
-                        alt={`Avatar of ${text}`}
-                        width={styleOptions.avatar.size}
-                        height={styleOptions.avatar.size}
-                        style={{ objectFit: 'cover' }}
-                      />
-                    </Avatar>
-                  ) : (
-                    <Avatar className={classes.noAvatarImage} aria-hidden>
-                      {text ? (
-                        [...text.matchAll(/\b[A-Z]/g)].join('')
-                      ) : (
-                        <Person />
-                      )}
-                    </Avatar>
-                  )}
-                </ListItemAvatar>
-              )}
-              <ListItemText {...listItemTextProps}>{text}</ListItemText>
-              {item.audio && (
-                <ListItemSecondaryAction>
-                  <AudioControls
-                    id={item.audio.id}
-                    fallbackProps={item.audioProps}
-                    variant="minimal"
-                  />
-                </ListItemSecondaryAction>
-              )}
-            </ListItemButton>
-          ) : (
-            (url && (
-              <ListItemButton component="a" href={url} key={url}>
+  return (
+    hasData && (
+      <>
+        <List {...listProps}>
+          {pageItems.map((item) => {
+            const text =
+              item.title ||
+              (item.data &&
+                (('title' in item.data && item.data?.title) ||
+                  ('name' in item.data && item.data?.name)));
+            const url = item.url || item.data?.link;
+            const avatarSrc =
+              item.avatar?.sourceUrl || item.avatar?.mediaItemUrl;
+
+            return item.data ? (
+              <ListItemButton
+                component={ContentLink}
+                url={url}
+                key={item.data.id}
+              >
+                {item.avatar && (
+                  <ListItemAvatar>
+                    {avatarSrc ? (
+                      <Avatar aria-hidden>
+                        <Image
+                          src={avatarSrc}
+                          alt={`Avatar of ${text}`}
+                          width={styleOptions.avatar.size}
+                          height={styleOptions.avatar.size}
+                          style={{ objectFit: 'cover' }}
+                        />
+                      </Avatar>
+                    ) : (
+                      <Avatar className={classes.noAvatarImage} aria-hidden>
+                        {text ? (
+                          [...text.matchAll(/\b[A-Z]/g)].join('')
+                        ) : (
+                          <Person />
+                        )}
+                      </Avatar>
+                    )}
+                  </ListItemAvatar>
+                )}
                 <ListItemText {...listItemTextProps}>{text}</ListItemText>
+                {item.audio && (
+                  <ListItemSecondaryAction>
+                    <AudioControls
+                      id={item.audio.id}
+                      fallbackProps={item.audioProps}
+                      variant="minimal"
+                    />
+                  </ListItemSecondaryAction>
+                )}
               </ListItemButton>
-            )) || <ListItemText {...listItemTextProps}>{text}</ListItemText>
-          );
-        })}
-      </List>
+            ) : (
+              (url && (
+                <ListItemButton component="a" href={url} key={url}>
+                  <ListItemText {...listItemTextProps}>{text}</ListItemText>
+                </ListItemButton>
+              )) || <ListItemText {...listItemTextProps}>{text}</ListItemText>
+            );
+          })}
+        </List>
+        <SidebarFooter>
+          {showPagination && (
+            <Pagination
+              size="small"
+              count={pageCount}
+              page={page}
+              color="primary"
+              onChange={handleSegmentsPageChange}
+            />
+          )}
+        </SidebarFooter>
+      </>
     )
   );
 };

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -40,7 +40,6 @@ import {
   Typography
 } from '@mui/material';
 import { EqualizerRounded, PublicRounded } from '@mui/icons-material';
-import Pagination from '@mui/material/Pagination';
 import { LandingPage } from '@components/LandingPage';
 import { CtaRegion } from '@components/CtaRegion';
 import { HtmlContent } from '@components/HtmlContent';
@@ -51,7 +50,6 @@ import {
   SidebarHeader,
   SidebarLatestStories,
   SidebarList,
-  SidebarFooter,
   SidebarContent,
   SidebarCta
 } from '@components/Sidebar';
@@ -82,7 +80,6 @@ export const Bio = ({ data }: IContentComponentProps<Contributor>) => {
   const [oldScrollY, setOldScrollY] = useState(0);
   const [moreStoriesController, setMoreStoriesController] =
     useState<AbortController>();
-  const [segmentsPage, setSegmentsPage] = useState(1);
   const unsub = store.subscribe(() => {
     setState(store.getState());
   });
@@ -138,14 +135,8 @@ export const Bio = ({ data }: IContentComponentProps<Contributor>) => {
   );
 
   const segmentsState = getCollectionData<Segment>(state, type, id, 'segments');
-  const { items: allSegments, options: segmentsOptions } = segmentsState || {};
-  const segmentsPageSize = segmentsOptions?.pageSize || 10;
-  const segmentsCount = allSegments?.length || 0;
-  const segmentsPageCount = Math.ceil(segmentsCount / segmentsPageSize);
-  const segmentsStartIndex = (segmentsPage - 1) * segmentsPageSize;
-  const segmentsEndIndex = segmentsStartIndex + segmentsPageSize;
-  const segments = allSegments?.slice(segmentsStartIndex, segmentsEndIndex);
-  const hasSegments = !!allSegments?.length;
+  const { items: segments, options: segmentsOptions } = segmentsState || {};
+  const hasSegments = !!segments?.length;
 
   const { classes } = bioStyles();
 
@@ -208,13 +199,6 @@ export const Bio = ({ data }: IContentComponentProps<Contributor>) => {
     store.dispatch<any>(
       appendResourceCollection(moreStories, type, id, 'stories', options)
     );
-  };
-
-  const handleSegmentsPageChange = async (
-    event: React.ChangeEvent<unknown>,
-    value: number
-  ) => {
-    setSegmentsPage(value);
   };
 
   const mainElements = [
@@ -280,31 +264,23 @@ export const Bio = ({ data }: IContentComponentProps<Contributor>) => {
         <>
           {hasSegments && (
             <Sidebar item elevated>
-              <SidebarHeader>
-                <EqualizerRounded />
-                <Typography variant="h2">
-                  Latest segments from {name}
-                </Typography>
-              </SidebarHeader>
               <SidebarList
-                disablePadding
                 data={segments.map((segment) => ({
                   data: segment,
                   audio: segment.segmentContent?.audio
                 }))}
+                subheader={
+                  <SidebarHeader disablePadding>
+                    <EqualizerRounded />
+                    <Typography variant="h2">
+                      Latest segments from {name}
+                    </Typography>
+                  </SidebarHeader>
+                }
+                paginationProps={{
+                  pageSize: segmentsOptions?.pageSize
+                }}
               />
-              <SidebarFooter>
-                {segmentsPageCount > 1 && (
-                  <Pagination
-                    size="small"
-                    count={segmentsPageCount}
-                    page={segmentsPage}
-                    color="primary"
-                    size="small"
-                    onChange={handleSegmentsPageChange}
-                  />
-                )}
-              </SidebarFooter>
             </Sidebar>
           )}
           {!!followLinks?.length && (

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -102,6 +102,7 @@ export const Bio = ({ data }: IContentComponentProps<Contributor>) => {
         ([k, v]) =>
           v && (
             <IconButton
+              key={`${k}:${v}`}
               href={v}
               target="_blank"
               LinkComponent={Link}

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -244,6 +244,7 @@ export const Bio = () => {
                     count={segmentsPageCount}
                     page={segmentsPage}
                     color="primary"
+                    size="small"
                     onChange={handleSegmentsPageChange}
                   />
                 )}

--- a/components/pages/Bio/Bio.tsx
+++ b/components/pages/Bio/Bio.tsx
@@ -34,6 +34,7 @@ import {
   Box,
   Button,
   Divider,
+  Hidden,
   IconButton,
   SvgIcon,
   Typography
@@ -41,7 +42,7 @@ import {
 import { EqualizerRounded, PublicRounded } from '@mui/icons-material';
 import Pagination from '@mui/material/Pagination';
 import { LandingPage } from '@components/LandingPage';
-// import { CtaRegion } from '@components/CtaRegion';
+import { CtaRegion } from '@components/CtaRegion';
 import { HtmlContent } from '@components/HtmlContent';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
@@ -51,13 +52,13 @@ import {
   SidebarLatestStories,
   SidebarList,
   SidebarFooter,
-  SidebarContent
-  // SidebarCta,
+  SidebarContent,
+  SidebarCta
 } from '@components/Sidebar';
 import { StoryCard } from '@components/StoryCard';
 import { fetchApiContributorStories } from '@lib/fetch';
 import { StoryCardGrid } from '@components/StoryCardGrid';
-import { getCollectionData } from '@store/reducers';
+import { getCollectionData, getCtaRegionData } from '@store/reducers';
 import { appendResourceCollection } from '@store/actions/appendResourceCollection';
 import { BioHeader } from './components/BioHeader';
 import { bioStyles } from './Bio.styles';
@@ -148,19 +149,14 @@ export const Bio = ({ data }: IContentComponentProps<Contributor>) => {
 
   const { classes } = bioStyles();
 
-  // // CTA data.
-  // const ctaSidebarTop = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_landing_sidebar_01',
-  //   type,
-  //   id
-  // );
-  // const ctaSidebarBottom = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_landing_sidebar_02',
-  //   type,
-  //   id
-  // );
+  // CTA data.
+  const ctaSidebarTop = getCtaRegionData(state, 'landing-sidebar-1', type, id);
+  const ctaSidebarBottom = getCtaRegionData(
+    state,
+    'landing-sidebar-2',
+    type,
+    id
+  );
 
   // Plausible Events.
   const props = {
@@ -323,7 +319,7 @@ export const Bio = ({ data }: IContentComponentProps<Contributor>) => {
               </SidebarContent>
             </Sidebar>
           )}
-          {/* {ctaSidebarTop && (
+          {ctaSidebarTop && (
             <>
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarTop} />
@@ -332,7 +328,7 @@ export const Bio = ({ data }: IContentComponentProps<Contributor>) => {
                 <CtaRegion data={ctaSidebarTop} />
               </Hidden>
             </>
-          )} */}
+          )}
         </>
       )
     },
@@ -341,7 +337,7 @@ export const Bio = ({ data }: IContentComponentProps<Contributor>) => {
       children: (
         <>
           <SidebarLatestStories />
-          {/* {ctaSidebarBottom && (
+          {ctaSidebarBottom && (
             <>
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarBottom} />
@@ -350,7 +346,7 @@ export const Bio = ({ data }: IContentComponentProps<Contributor>) => {
                 <CtaRegion data={ctaSidebarBottom} />
               </Hidden>
             </>
-          )} */}
+          )}
         </>
       )
     }

--- a/components/pages/Category/Category.tsx
+++ b/components/pages/Category/Category.tsx
@@ -120,27 +120,17 @@ export const Category = ({ data }: IContentComponentProps<CategoryType>) => {
   const { classes } = categoryStyles();
 
   // CTA data.
-  const ctaInlineTop = getCtaRegionData(
-    state,
-    'tw_cta_region_landing_inline_01',
-    type,
-    id
-  );
+  const ctaInlineTop = getCtaRegionData(state, 'landing-inline-top', type, id);
   const ctaInlineBottom = getCtaRegionData(
     state,
-    'tw_cta_region_landing_inline_02',
+    'landing-inline-bottom',
     type,
     id
   );
-  const ctaSidebarTop = getCtaRegionData(
-    state,
-    'tw_cta_region_landing_sidebar_01',
-    type,
-    id
-  );
+  const ctaSidebarTop = getCtaRegionData(state, 'landing-sidebar-1', type, id);
   const ctaSidebarBottom = getCtaRegionData(
     state,
-    'tw_cta_region_landing_sidebar_02',
+    'landing-sidebar-2',
     type,
     id
   );

--- a/components/pages/Category/Category.tsx
+++ b/components/pages/Category/Category.tsx
@@ -382,24 +382,26 @@ export const Category = ({ data }: IContentComponentProps<CategoryType>) => {
                 bulleted
               />
             )}
-            {children && !!children.nodes.length && (
+          </Sidebar>
+          {children && !!children.edges.length && (
+            <Sidebar item elevated>
               <SidebarList
-                data={children.nodes.map(
-                  (child) =>
+                data={children.edges.map(
+                  ({ node }) =>
                     ({
-                      data: child
+                      data: node
                     } as SidebarListItem)
                 )}
                 subheader={
-                  <SidebarHeader>
+                  <SidebarHeader disablePadding>
                     <ListAltRounded />
                     <Typography variant="h2">Subcategories</Typography>
                   </SidebarHeader>
                 }
                 bulleted
               />
-            )}
-          </Sidebar>
+            </Sidebar>
+          )}
           {ctaSidebarTop && (
             <>
               <Hidden only="sm">

--- a/components/pages/Category/Category.tsx
+++ b/components/pages/Category/Category.tsx
@@ -252,7 +252,7 @@ export const Category = ({ data }: IContentComponentProps<CategoryType>) => {
           )}
           {ctaInlineTop && (
             <>
-              <Hidden xsDown>
+              <Hidden smDown>
                 <CtaRegion data={ctaInlineTop} />
               </Hidden>
               <Hidden smUp>
@@ -331,7 +331,7 @@ export const Category = ({ data }: IContentComponentProps<CategoryType>) => {
           )}
           {ctaInlineBottom && (
             <>
-              <Hidden xsDown>
+              <Hidden smDown>
                 <CtaRegion data={ctaInlineBottom} />
               </Hidden>
               <Hidden smUp>
@@ -407,7 +407,7 @@ export const Category = ({ data }: IContentComponentProps<CategoryType>) => {
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarTop} />
               </Hidden>
-              <Hidden xsDown mdUp>
+              <Hidden smDown mdUp>
                 <CtaRegion data={ctaSidebarTop} />
               </Hidden>
             </>
@@ -425,7 +425,7 @@ export const Category = ({ data }: IContentComponentProps<CategoryType>) => {
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarBottom} />
               </Hidden>
-              <Hidden xsDown mdUp>
+              <Hidden smDown mdUp>
                 <CtaRegion data={ctaSidebarBottom} />
               </Hidden>
             </>

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -12,12 +12,22 @@ import type {
   MediaItem,
   MediaItem_Audiofields as MediaItemAudioFields,
   Episode_Episodecontent as EpisodeEpisodeContent,
-  PostStory
+  PostStory,
+  RootState
 } from '@interfaces';
-import React, { useContext } from 'react';
-import { Box, Container, Divider, Grid, Typography } from '@mui/material';
+import { useContext } from 'react';
+import { useStore } from 'react-redux';
+import {
+  Box,
+  Container,
+  Divider,
+  Grid,
+  Hidden,
+  Typography
+} from '@mui/material';
 import { EqualizerRounded } from '@mui/icons-material';
 import { NoJsPlayer } from '@components/AudioPlayer/NoJsPlayer';
+import { CtaRegion } from '@components/CtaRegion';
 import { HtmlContent } from '@components/HtmlContent';
 import { MetaTags } from '@components/MetaTags';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
@@ -26,7 +36,8 @@ import {
   SidebarHeader,
   SidebarFooter,
   SidebarList,
-  SidebarLatestStories
+  SidebarLatestStories,
+  SidebarCta
 } from '@components/Sidebar';
 import { SpotifyPlayer } from '@components/SpotifyPlayer';
 import { StoryCard } from '@components/StoryCard';
@@ -34,11 +45,14 @@ import { StoryCard } from '@components/StoryCard';
 import { AppContext } from '@contexts/AppContext';
 // import { UiAction } from '@interfaces/state';
 import { parseDateParts } from '@lib/parse/date';
+import { getCtaRegionData } from '@store/reducers';
 import { episodeStyles } from './Episode.styles';
 import { EpisodeLede } from './components/EpisodeLede';
 import { EpisodeHeader } from './components/EpisodeHeader';
 
 export const Episode = ({ data }: IContentComponentProps<EpisodeType>) => {
+  const store = useStore<RootState>();
+  const state = store.getState();
   const {
     page: {
       resource: { type, id }
@@ -79,25 +93,25 @@ export const Episode = ({ data }: IContentComponentProps<EpisodeType>) => {
     (story): story is PostStory => !!story
   );
 
-  // // CTA data.
-  // const ctaInlineEnd = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_content_inline_end',
-  //   type,
-  //   id
-  // );
-  // const ctaSidebarTop = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_content_sidebar_01',
-  //   type,
-  //   id
-  // );
-  // const ctaSidebarBottom = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_content_sidebar_02',
-  //   type,
-  //   id
-  // );
+  // CTA data.
+  const ctaInlineEnd = getCtaRegionData(
+    state,
+    'tw_cta_region_content_inline_end',
+    type,
+    id
+  );
+  const ctaSidebarTop = getCtaRegionData(
+    state,
+    'tw_cta_region_content_sidebar_01',
+    type,
+    id
+  );
+  const ctaSidebarBottom = getCtaRegionData(
+    state,
+    'tw_cta_region_content_sidebar_02',
+    type,
+    id
+  );
 
   // Plausible Events.
   const props = {
@@ -245,7 +259,7 @@ export const Episode = ({ data }: IContentComponentProps<EpisodeType>) => {
                     ))}
                   </Box>
                 )}
-                {/* {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />} */}
+                {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />}
               </Box>
               <Sidebar container className={classes.sidebar}>
                 {segmentsList && (
@@ -310,21 +324,21 @@ export const Episode = ({ data }: IContentComponentProps<EpisodeType>) => {
                     />
                   </Sidebar>
                 )}
-                {/* {ctaSidebarTop && (
+                {ctaSidebarTop && (
                   <Hidden smDown>
                     <Sidebar item>
                       <SidebarCta data={ctaSidebarTop} />
                     </Sidebar>
                   </Hidden>
-                )} */}
+                )}
                 <SidebarLatestStories />
-                {/* {ctaSidebarBottom && (
+                {ctaSidebarBottom && (
                   <Hidden smDown>
                     <Sidebar item>
                       <SidebarCta data={ctaSidebarBottom} />
                     </Sidebar>
                   </Hidden>
-                )} */}
+                )}
               </Sidebar>
             </Box>
           </Grid>

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -94,21 +94,11 @@ export const Episode = ({ data }: IContentComponentProps<EpisodeType>) => {
   );
 
   // CTA data.
-  const ctaInlineEnd = getCtaRegionData(
-    state,
-    'tw_cta_region_content_inline_end',
-    type,
-    id
-  );
-  const ctaSidebarTop = getCtaRegionData(
-    state,
-    'tw_cta_region_content_sidebar_01',
-    type,
-    id
-  );
+  const ctaInlineEnd = getCtaRegionData(state, 'content-inline-end', type, id);
+  const ctaSidebarTop = getCtaRegionData(state, 'content-sidebar-1', type, id);
   const ctaSidebarBottom = getCtaRegionData(
     state,
-    'tw_cta_region_content_sidebar_02',
+    'content-sidebar-2',
     type,
     id
   );

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -3,6 +3,7 @@
  * Component for Homepage.
  */
 
+import type React from 'react';
 import type {
   Episode,
   Homepage as HomepageType,
@@ -10,9 +11,9 @@ import type {
   Post,
   RootState
 } from '@interfaces';
-// import type { ICtaRegionProps } from '@interfaces/cta';
+import type { ICtaRegionProps } from '@interfaces/cta';
 import { useContext, useEffect, useState } from 'react';
-// import dynamic from 'next/dynamic';
+import dynamic from 'next/dynamic';
 import { useStore } from 'react-redux';
 import { Box, Hidden, Typography } from '@mui/material';
 import StyleRounded from '@mui/icons-material/StyleRounded';
@@ -31,22 +32,23 @@ import { QuickLinks } from '@components/QuickLinks';
 import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
 import { SidebarEpisode } from '@components/Sidebar/SidebarEpisode';
-import {
-  getCollectionData
-  // getCtaRegionData
-} from '@store/reducers';
+import { getCollectionData, getCtaRegionData } from '@store/reducers';
 import { AppContext } from '@contexts/AppContext';
 
-// const CtaRegion = dynamic(
-//   () => import('@components/CtaRegion').then((mod) => mod.CtaRegion) as any
-// ) as React.FC<ICtaRegionProps>;
+const CtaRegion = dynamic(
+  () => import('@components/CtaRegion').then((mod) => mod.CtaRegion) as any
+) as React.FC<ICtaRegionProps>;
 
-// const SidebarCta = dynamic(
-//   () => import('@components/Sidebar').then((mod) => mod.SidebarCta) as any
-// ) as React.FC<ICtaRegionProps>;
+const SidebarCta = dynamic(
+  () => import('@components/Sidebar').then((mod) => mod.SidebarCta) as any
+) as React.FC<ICtaRegionProps>;
 
 export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
-  const { data: appData } = useContext(AppContext);
+  const {
+    data: appData,
+    page: { resource }
+  } = useContext(AppContext);
+  const { type, id } = resource || {};
   const { menus: appMenus } = appData || {};
   const { drawerMainNav } = appMenus || {};
   const store = useStore<RootState>();
@@ -96,31 +98,16 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
         } as SidebarListItem)
     );
 
-  // // CTA data.
-  // const inlineTop = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_landing_inline_01',
-  //   type,
-  //   id
-  // );
-  // const inlineBottom = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_landing_inline_02',
-  //   type,
-  //   id
-  // );
-  // const sidebarTop = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_landing_sidebar_01',
-  //   type,
-  //   id
-  // );
-  // const sidebarBottom = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_landing_sidebar_02',
-  //   type,
-  //   id
-  // );
+  // CTA data.
+  const inlineTop = getCtaRegionData(state, 'landing-inline-top', type, id);
+  const inlineBottom = getCtaRegionData(
+    state,
+    'landing-inline-bottom',
+    type,
+    id
+  );
+  const sidebarTop = getCtaRegionData(state, 'landing-sidebar-1', type, id);
+  const sidebarBottom = getCtaRegionData(state, 'landing-sidebar-2', type, id);
 
   const mainElements = [
     {
@@ -135,7 +122,7 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
               <StoryCardGrid data={featuredStories} gap={1} />
             )}
           </Box>
-          {/* {inlineTop && (
+          {inlineTop && (
             <>
               <Hidden xsDown>
                 <CtaRegion data={inlineTop} />
@@ -144,7 +131,7 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
                 <SidebarCta data={inlineTop} />
               </Hidden>
             </>
-          )} */}
+          )}
         </>
       )
     },
@@ -162,7 +149,7 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
               key={item.id}
             />
           ))}
-          {/* {inlineBottom && (
+          {inlineBottom && (
             <>
               <Hidden xsDown>
                 <CtaRegion data={inlineBottom} />
@@ -171,7 +158,7 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
                 <SidebarCta data={inlineBottom} />
               </Hidden>
             </>
-          )} */}
+          )}
         </>
       )
     }
@@ -186,14 +173,14 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
             <SidebarEpisode data={latestEpisode} label="Latest Episode" />
           )}
           <Hidden only="sm">
-            {/* {sidebarTop && <SidebarCta data={sidebarTop} />} */}
+            {sidebarTop && <SidebarCta data={sidebarTop} />}
             <SidebarLatestStories
               data={latestStories}
               label="Latest from our partners"
             />
           </Hidden>
           <Hidden xsDown mdUp>
-            {/* {sidebarTop && <CtaRegion data={sidebarTop} />} */}
+            {sidebarTop && <CtaRegion data={sidebarTop} />}
           </Hidden>
         </>
       )
@@ -211,7 +198,7 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
               <SidebarList data={categoriesMenu} />
             </Sidebar>
           )}
-          {/* {sidebarBottom && (
+          {sidebarBottom && (
             <>
               <Hidden only="sm">
                 <SidebarCta data={sidebarBottom} />
@@ -220,7 +207,7 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
                 <CtaRegion data={sidebarBottom} />
               </Hidden>
             </>
-          )} */}
+          )}
         </>
       )
     }

--- a/components/pages/Newsletter/Newsletter.tsx
+++ b/components/pages/Newsletter/Newsletter.tsx
@@ -1,42 +1,34 @@
 /**
- * @file Story.tsx
- * Component for Story.
+ * @file Newsletter.tsx
+ * Component for Newsletter.
  */
 
-import type { RootState } from '@interfaces';
-import React, { useContext, useState, useEffect } from 'react';
+import type {
+  IContentComponentProps,
+  Newsletter as NewsletterType
+} from '@interfaces';
+import React, { useState } from 'react';
 import Image from 'next/legacy/image';
-import { useStore } from 'react-redux';
 import { Box, Container, Grid, ThemeProvider, Typography } from '@mui/material';
 import { CheckCircleOutlineSharp } from '@mui/icons-material';
-import { AppContext } from '@contexts/AppContext';
 import { HtmlContent } from '@components/HtmlContent';
 import { MetaTags } from '@components/MetaTags';
 import { NewsletterForm } from '@components/NewsletterForm';
 import { Plausible, PlausibleEventArgs } from '@components/Plausible';
-import { IPriApiNewsletter } from '@interfaces/newsletter';
 import { parseNewsletterOptions } from '@lib/parse/cta';
-import { getDataByResource } from '@store/reducers';
 import { newsletterTheme, newsletterStyles } from './Newsletter.styles';
 
-export const Newsletter = () => {
-  const {
-    page: {
-      resource: { type, id }
-    }
-  } = useContext(AppContext);
-  const store = useStore<RootState>();
-  const [state, setState] = useState(store.getState());
-  const unsub = store.subscribe(() => {
-    setState(store.getState());
-  });
-  const data = getDataByResource<any>(state, type, id);
+export const Newsletter = ({
+  data
+}: IContentComponentProps<NewsletterType>) => {
   const [subscribed, setSubscribed] = useState(false);
-  const { metatags, title, body, buttonLabel, summary, image } = data;
-  const options = parseNewsletterOptions(
-    data as IPriApiNewsletter,
-    'newsletter-page'
-  );
+  const { id, seo, title, content, excerpt, featuredImage, newsletterOptions } =
+    data;
+  const image = featuredImage?.node;
+  const imageSrc = image?.sourceUrl || image?.mediaItemUrl;
+  const hasImage = !!imageSrc;
+  const { buttonLabel } = newsletterOptions || {};
+  const options = parseNewsletterOptions(data, 'newsletter-page');
   const { classes, cx } = newsletterStyles();
 
   const handleSubscribed = () => {
@@ -51,34 +43,30 @@ export const Newsletter = () => {
     ['Newsletter Sign Up', { props }]
   ];
 
-  useEffect(
-    () => () => {
-      unsub();
-    },
-    [unsub]
-  );
-
   return (
     <>
-      <MetaTags data={metatags} />
-      <Plausible events={plausibleEvents} subject={{ type, id }} />
+      <MetaTags data={{ ...seo }} />
+      <Plausible
+        events={plausibleEvents}
+        subject={{ type: 'post--newsletter', id }}
+      />
       <ThemeProvider theme={newsletterTheme}>
         <Container disableGutters={!!image} maxWidth={false}>
           <Grid container justifyContent="center">
             <Grid
               item
               xs={12}
-              sm={image ? 12 : 9}
+              sm={hasImage ? 12 : 9}
               className={cx(classes.header, {
-                [classes.withImage]: !!image
+                [classes.withImage]: hasImage
               })}
             >
-              {image && (
+              {hasImage && (
                 <Box className={classes.imageWrapper}>
                   <Image
-                    alt={image.alt}
+                    alt={image.altText || ''}
                     className={classes.image}
-                    src={image.url}
+                    src={imageSrc}
                     layout="fill"
                     objectFit="cover"
                     priority
@@ -87,7 +75,11 @@ export const Newsletter = () => {
               )}
               <div className={classes.content}>
                 <h1 className={classes.title}>{title}</h1>
-                <p className={classes.summary}>{summary}</p>
+                {excerpt && (
+                  <div className={classes.summary}>
+                    <HtmlContent html={excerpt} />
+                  </div>
+                )}
                 <Box className={classes.form}>
                   {!subscribed && (
                     <NewsletterForm
@@ -108,7 +100,7 @@ export const Newsletter = () => {
                         <Box
                           display="grid"
                           gridTemplateColumns="min-content 1fr"
-                          gap={16}
+                          gap={2}
                           justifyContent="center"
                           alignItems="center"
                         >
@@ -136,10 +128,10 @@ export const Newsletter = () => {
                 </Box>
               </div>
             </Grid>
-            {body && (
+            {content && (
               <Container fixed>
                 <Box className={classes.body} my={2}>
-                  <HtmlContent html={body} />
+                  <HtmlContent html={content} />
                 </Box>
               </Container>
             )}

--- a/components/pages/Program/Program.tsx
+++ b/components/pages/Program/Program.tsx
@@ -121,27 +121,17 @@ export const Program = ({ data }: IContentComponentProps<ProgramType>) => {
   const { classes } = programStyles();
 
   // CTA data.
-  const ctaInlineTop = getCtaRegionData(
-    state,
-    'tw_cta_region_landing_inline_01',
-    type,
-    id
-  );
+  const ctaInlineTop = getCtaRegionData(state, 'landing-inline-top', type, id);
   const ctaInlineBottom = getCtaRegionData(
     state,
-    'tw_cta_region_landing_inline_02',
+    'landing-inline-bottom',
     type,
     id
   );
-  const ctaSidebarTop = getCtaRegionData(
-    state,
-    'tw_cta_region_landing_sidebar_01',
-    type,
-    id
-  );
+  const ctaSidebarTop = getCtaRegionData(state, 'landing-sidebar-1', type, id);
   const ctaSidebarBottom = getCtaRegionData(
     state,
-    'tw_cta_region_landing_sidebar_02',
+    'landing-sidebar-2',
     type,
     id
   );
@@ -260,7 +250,7 @@ export const Program = ({ data }: IContentComponentProps<ProgramType>) => {
           )}
           {ctaInlineTop && (
             <>
-              <Hidden xsDown>
+              <Hidden smDown>
                 <CtaRegion data={ctaInlineTop} />
               </Hidden>
               <Hidden smUp>
@@ -339,7 +329,7 @@ export const Program = ({ data }: IContentComponentProps<ProgramType>) => {
           )}
           {ctaInlineBottom && (
             <>
-              <Hidden xsDown>
+              <Hidden smDown>
                 <CtaRegion data={ctaInlineBottom} />
               </Hidden>
               <Hidden smUp>
@@ -429,7 +419,7 @@ export const Program = ({ data }: IContentComponentProps<ProgramType>) => {
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarTop} />
               </Hidden>
-              <Hidden xsDown mdUp>
+              <Hidden smDown mdUp>
                 <CtaRegion data={ctaSidebarTop} />
               </Hidden>
             </>
@@ -447,7 +437,7 @@ export const Program = ({ data }: IContentComponentProps<ProgramType>) => {
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarBottom} />
               </Hidden>
-              <Hidden xsDown mdUp>
+              <Hidden smDown mdUp>
                 <CtaRegion data={ctaSidebarBottom} />
               </Hidden>
             </>

--- a/components/pages/Story/layouts/default/Story.default.tsx
+++ b/components/pages/Story/layouts/default/Story.default.tsx
@@ -7,32 +7,35 @@ import type React from 'react';
 import type { ITagsProps } from '@components/Tags';
 import type {
   IContentComponentProps,
+  ICtaRegionProps,
   Post_Additionalmedia as PostAdditionalMedia,
-  PostStory
+  PostStory,
+  RootState
 } from '@interfaces';
+import { useStore } from 'react-redux';
 import dynamic from 'next/dynamic';
 import { convertNodeToElement, Transform } from 'react-html-parser';
 import { DomElement } from 'htmlparser2';
 import { ThemeProvider } from '@mui/styles';
-import { Box, Container, Grid } from '@mui/material';
+import { Box, Container, Grid, Hidden } from '@mui/material';
 import { NoJsPlayer } from '@components/AudioPlayer/NoJsPlayer';
 import { Sidebar, SidebarLatestStories } from '@components/Sidebar';
 import { HtmlContent } from '@components/HtmlContent';
 import { enhanceImage } from '@components/HtmlContent/transforms';
-// import { ICtaRegionProps } from '@interfaces/cta';
+import { getCtaRegionData } from '@store/reducers';
 import { useStoryStyles, storyTheme } from './Story.default.styles';
 import { IStoryRelatedLinksProps, StoryHeader, StoryLede } from './components';
 
-// const CtaRegion = dynamic(
-//   () => import('@components/CtaRegion').then((mod) => mod.CtaRegion) as any
-// ) as React.FC<ICtaRegionProps>;
+const CtaRegion = dynamic(
+  () => import('@components/CtaRegion').then((mod) => mod.CtaRegion) as any
+) as React.FC<ICtaRegionProps>;
 
-// const SidebarCta = dynamic(
-//   () =>
-//     import('@components/Sidebar/SidebarCta').then(
-//       (mod) => mod.SidebarCta
-//     ) as any
-// ) as React.FC<ICtaRegionProps>;
+const SidebarCta = dynamic(
+  () =>
+    import('@components/Sidebar/SidebarCta').then(
+      (mod) => mod.SidebarCta
+    ) as any
+) as React.FC<ICtaRegionProps>;
 
 const StoryRelatedLinks = dynamic(
   () =>
@@ -50,7 +53,11 @@ export interface IStoryDefaultProps {
 }
 
 export const StoryDefault = ({ data }: IContentComponentProps<PostStory>) => {
+  const store = useStore<RootState>();
+  const state = store.getState();
+  const type = 'post--story';
   const {
+    id,
     additionalMedia,
     content,
     categories,
@@ -82,37 +89,37 @@ export const StoryDefault = ({ data }: IContentComponentProps<PostStory>) => {
   let ctaMobile01Position: number;
   let ctaMobile02Position: number;
 
-  // // CTA data.
-  // const ctaInlineMobile01 = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_content_inline_mobile_01',
-  //   type,
-  //   id as string
-  // );
-  // const ctaInlineMobile02 = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_content_inline_mobile_02',
-  //   type,
-  //   id as string
-  // );
-  // const ctaInlineEnd = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_content_inline_end',
-  //   type,
-  //   id as string
-  // );
-  // const ctaSidebarTop = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_content_sidebar_01',
-  //   type,
-  //   id as string
-  // );
-  // const ctaSidebarBottom = getCtaRegionData(
-  //   state,
-  //   'tw_cta_region_content_sidebar_02',
-  //   type,
-  //   id as string
-  // );
+  // CTA data.
+  const ctaInlineMobile01 = getCtaRegionData(
+    state,
+    'content-inline-1-mobile',
+    type,
+    id as string
+  );
+  const ctaInlineMobile02 = getCtaRegionData(
+    state,
+    'content-inline-2-mobile',
+    type,
+    id as string
+  );
+  const ctaInlineEnd = getCtaRegionData(
+    state,
+    'content-inline-end',
+    type,
+    id as string
+  );
+  const ctaSidebarTop = getCtaRegionData(
+    state,
+    'content-sidebar-1',
+    type,
+    id as string
+  );
+  const ctaSidebarBottom = getCtaRegionData(
+    state,
+    'content-sidebar-2',
+    type,
+    id as string
+  );
 
   const insertCtaMobile01 = (
     node: DomElement,
@@ -124,6 +131,7 @@ export const StoryDefault = ({ data }: IContentComponentProps<PostStory>) => {
       node.type === 'tag' &&
       node.name === 'p' &&
       node?.next?.name === 'p' &&
+      node?.next?.next?.next &&
       !ctaMobile01Position &&
       index >= 5
     ) {
@@ -131,11 +139,9 @@ export const StoryDefault = ({ data }: IContentComponentProps<PostStory>) => {
       return (
         <>
           {convertNodeToElement(node, index, transform)}
-          {/* {ctaInlineMobile01 && (
-            <Hidden mdUp>
-              <CtaRegion data={ctaInlineMobile01} />
-            </Hidden>
-          )} */}
+          <Hidden mdUp>
+            <CtaRegion data={ctaInlineMobile01} />
+          </Hidden>
         </>
       );
     }
@@ -161,11 +167,11 @@ export const StoryDefault = ({ data }: IContentComponentProps<PostStory>) => {
       return (
         <>
           {convertNodeToElement(node, index, transform)}
-          {/* {ctaInlineMobile02 && (
+          {ctaInlineMobile02 && (
             <Hidden mdUp>
               <CtaRegion data={ctaInlineMobile02} />
             </Hidden>
-          )} */}
+          )}
         </>
       );
     }
@@ -217,7 +223,24 @@ export const StoryDefault = ({ data }: IContentComponentProps<PostStory>) => {
                     />
                   )}
                 </Box>
-                {/* {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />} */}
+                {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />}
+              </Box>
+              <Sidebar container className={classes.sidebar}>
+                <SidebarLatestStories />
+                <Hidden mdDown>
+                  {ctaSidebarTop && (
+                    <Sidebar item stretch>
+                      <SidebarCta data={ctaSidebarTop} />
+                    </Sidebar>
+                  )}
+                  {ctaSidebarBottom && (
+                    <Sidebar item stretch>
+                      <SidebarCta data={ctaSidebarBottom} />
+                    </Sidebar>
+                  )}
+                </Hidden>
+              </Sidebar>
+              <Box component="aside" gridColumn="1 / -1">
                 {hasRelated && (
                   <aside>
                     <header>
@@ -231,21 +254,6 @@ export const StoryDefault = ({ data }: IContentComponentProps<PostStory>) => {
                 )}
                 {hasTags && <Tags data={allTags} label="Tags" />}
               </Box>
-              <Sidebar container className={classes.sidebar}>
-                <SidebarLatestStories />
-                {/* <Hidden smDown>
-                  {ctaSidebarTop && (
-                    <Sidebar item stretch>
-                      <SidebarCta data={ctaSidebarTop} />
-                    </Sidebar>
-                  )}
-                  {ctaSidebarBottom && (
-                    <Sidebar item stretch>
-                      <SidebarCta data={ctaSidebarBottom} />
-                    </Sidebar>
-                  )}
-                </Hidden> */}
-              </Sidebar>
             </Box>
           </Grid>
         </Grid>

--- a/components/pages/Story/layouts/default/Story.default.tsx
+++ b/components/pages/Story/layouts/default/Story.default.tsx
@@ -139,9 +139,11 @@ export const StoryDefault = ({ data }: IContentComponentProps<PostStory>) => {
       return (
         <>
           {convertNodeToElement(node, index, transform)}
-          <Hidden mdUp>
-            <CtaRegion data={ctaInlineMobile01} />
-          </Hidden>
+          {ctaInlineMobile01 && (
+            <Hidden mdUp>
+              <CtaRegion data={ctaInlineMobile01} />
+            </Hidden>
+          )}
         </>
       );
     }

--- a/components/pages/Story/layouts/feature/Story.feature.tsx
+++ b/components/pages/Story/layouts/feature/Story.feature.tsx
@@ -7,18 +7,25 @@ import type React from 'react';
 import type { ITagsProps } from '@components/Tags';
 import type {
   IContentComponentProps,
+  ICtaRegionProps,
   Post_Additionalmedia as PostAdditionalMedia,
-  PostStory
+  PostStory,
+  RootState
 } from '@interfaces';
+import { useStore } from 'react-redux';
 import dynamic from 'next/dynamic';
 import { ThemeProvider } from '@mui/styles';
 import { Box, Container } from '@mui/material';
 import { NoJsPlayer } from '@components/AudioPlayer/NoJsPlayer';
-// import { CtaRegion } from '@components/CtaRegion';
 import { HtmlContent } from '@components/HtmlContent';
 import { enhanceImage } from '@components/HtmlContent/transforms';
+import { getCtaRegionData } from '@store/reducers';
 import { storyStyles, storyTheme } from './Story.feature.styles';
 import { StoryHeader, IStoryRelatedLinksProps } from './components';
+
+const CtaRegion = dynamic(
+  () => import('@components/CtaRegion').then((mod) => mod.CtaRegion) as any
+) as React.FC<ICtaRegionProps>;
 
 const StoryRelatedLinks = dynamic(
   () =>
@@ -32,7 +39,11 @@ const Tags = dynamic(() =>
 ) as React.FC<ITagsProps>;
 
 export const StoryFeatured = ({ data }: IContentComponentProps<PostStory>) => {
+  const store = useStore<RootState>();
+  const state = store.getState();
+  const type = 'post--story';
   const {
+    id,
     additionalMedia,
     content,
     categories,
@@ -83,6 +94,13 @@ export const StoryFeatured = ({ data }: IContentComponentProps<PostStory>) => {
     }
   });
 
+  const ctaInlineEnd = getCtaRegionData(
+    state,
+    'content-inline-end',
+    type,
+    id as string
+  );
+
   return (
     <ThemeProvider theme={storyTheme}>
       <StoryHeader data={data} />
@@ -93,7 +111,7 @@ export const StoryFeatured = ({ data }: IContentComponentProps<PostStory>) => {
             <HtmlContent html={content} transforms={[enhanceImages]} />
           )}
         </Box>
-        {/* {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />} */}
+        {ctaInlineEnd && <CtaRegion data={ctaInlineEnd} />}
         {hasRelated && (
           <aside>
             <header>

--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -91,27 +91,17 @@ export const Term = ({ data }: TermProps) => {
   const latestEpisode = episodes?.shift();
 
   // CTA data.
-  const ctaInlineTop = getCtaRegionData(
-    state,
-    'tw_cta_region_landing_inline_01',
-    type,
-    id
-  );
+  const ctaInlineTop = getCtaRegionData(state, 'landing-inline-top', type, id);
   const ctaInlineBottom = getCtaRegionData(
     state,
-    'tw_cta_region_landing_inline_02',
+    'landing-inline-bottom',
     type,
     id
   );
-  const ctaSidebarTop = getCtaRegionData(
-    state,
-    'tw_cta_region_landing_sidebar_01',
-    type,
-    id
-  );
+  const ctaSidebarTop = getCtaRegionData(state, 'landing-sidebar-1', type, id);
   const ctaSidebarBottom = getCtaRegionData(
     state,
-    'tw_cta_region_landing_sidebar_02',
+    'landing-sidebar-2',
     type,
     id
   );
@@ -235,7 +225,7 @@ export const Term = ({ data }: TermProps) => {
           )}
           {ctaInlineTop && (
             <>
-              <Hidden xsDown>
+              <Hidden smDown>
                 <CtaRegion data={ctaInlineTop} />
               </Hidden>
               <Hidden smUp>
@@ -308,7 +298,7 @@ export const Term = ({ data }: TermProps) => {
           )}
           {ctaInlineBottom && (
             <>
-              <Hidden xsDown>
+              <Hidden smDown>
                 <CtaRegion data={ctaInlineBottom} />
               </Hidden>
               <Hidden smUp>
@@ -342,7 +332,7 @@ export const Term = ({ data }: TermProps) => {
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarTop} />
               </Hidden>
-              <Hidden xsDown mdUp>
+              <Hidden smDown mdUp>
                 <CtaRegion data={ctaSidebarTop} />
               </Hidden>
             </>
@@ -360,7 +350,7 @@ export const Term = ({ data }: TermProps) => {
               <Hidden only="sm">
                 <SidebarCta data={ctaSidebarBottom} />
               </Hidden>
-              <Hidden xsDown mdUp>
+              <Hidden smDown mdUp>
                 <CtaRegion data={ctaSidebarBottom} />
               </Hidden>
             </>

--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -34,7 +34,6 @@ import {
   getDataByResource
 } from '@store/reducers';
 import { generateLinkPropsForContent } from '@lib/routing';
-import { RootState } from '@interfaces/state';
 
 export const Term = () => {
   const {
@@ -44,7 +43,7 @@ export const Term = () => {
   } = useContext(AppContext);
   const router = useRouter();
   const { query } = router;
-  const store = useStore<RootState>();
+  const store = useStore();
   const [state, setState] = useState(store.getState());
   const unsub = store.subscribe(() => {
     setState(store.getState());

--- a/components/pages/Term/Term.tsx
+++ b/components/pages/Term/Term.tsx
@@ -34,6 +34,7 @@ import {
   getDataByResource
 } from '@store/reducers';
 import { generateLinkPropsForContent } from '@lib/routing';
+import { RootState } from '@interfaces/state';
 
 export const Term = () => {
   const {
@@ -43,7 +44,7 @@ export const Term = () => {
   } = useContext(AppContext);
   const router = useRouter();
   const { query } = router;
-  const store = useStore();
+  const store = useStore<RootState>();
   const [state, setState] = useState(store.getState());
   const unsub = store.subscribe(() => {
     setState(store.getState());

--- a/interfaces/api/generated.ts
+++ b/interfaces/api/generated.ts
@@ -70,6 +70,242 @@ export enum AvatarRatingEnum {
   X = 'X'
 }
 
+/** The callToAction type */
+export type CallToAction = ContentNode & DatabaseIdentifier & Node & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable & {
+  __typename?: 'CallToAction';
+  /**
+   * The id field matches the WP_Post-&gt;ID field.
+   * @deprecated Deprecated in favor of the databaseId field
+   */
+  callToActionId: Scalars['Int']['output'];
+  /** Connection between the ContentNode type and the ContentType type */
+  contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
+  /** The name of the Content Type the node belongs to */
+  contentTypeName: Scalars['String']['output'];
+  /** Fields to configure Call To Action prompts. | Added to the GraphQL Schema because the ACF Field Group &quot;CTA Options&quot; was set to Show in GraphQL. */
+  ctaOptions?: Maybe<CallToAction_Ctaoptions>;
+  /** Added to the GraphQL Schema because the ACF Field Group &quot;CTA Settings&quot; was set to Show in GraphQL. */
+  ctaSettings?: Maybe<CallToAction_Ctasettings>;
+  /** Fields for targeting CTA&#039;s to content, either directly or by taxonomy. | Added to the GraphQL Schema because the ACF Field Group &quot;CTA Targeting&quot; was set to Show in GraphQL. */
+  ctaTargeting?: Maybe<CallToAction_Ctatargeting>;
+  /** The unique identifier stored in the database */
+  databaseId: Scalars['Int']['output'];
+  /** Post publishing date. */
+  date?: Maybe<Scalars['String']['output']>;
+  /** The publishing date set in GMT. */
+  dateGmt?: Maybe<Scalars['String']['output']>;
+  /** The desired slug of the post */
+  desiredSlug?: Maybe<Scalars['String']['output']>;
+  /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
+  editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
+  /** The RSS enclosure for the object */
+  enclosure?: Maybe<Scalars['String']['output']>;
+  /** Connection between the ContentNode type and the EnqueuedScript type */
+  enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
+  /** Connection between the ContentNode type and the EnqueuedStylesheet type */
+  enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
+  /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
+  guid?: Maybe<Scalars['String']['output']>;
+  /** The globally unique identifier of the call_to_action object. */
+  id: Scalars['ID']['output'];
+  /** Whether the node is a Content Node */
+  isContentNode: Scalars['Boolean']['output'];
+  /** Whether the object is a node in the preview state */
+  isPreview?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether the object is restricted from the current viewer */
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether the node is a Term */
+  isTermNode: Scalars['Boolean']['output'];
+  /** The user that most recently edited the node */
+  lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
+  /** The permalink of the post */
+  link?: Maybe<Scalars['String']['output']>;
+  /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
+  modifiedGmt?: Maybe<Scalars['String']['output']>;
+  /** Connection between the CallToAction type and the callToAction type */
+  preview?: Maybe<CallToActionToPreviewConnectionEdge>;
+  /** The database id of the preview node */
+  previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
+  /** Whether the object is a node in the preview state */
+  previewRevisionId?: Maybe<Scalars['ID']['output']>;
+  /** The Yoast SEO data of the ContentNode */
+  seo?: Maybe<PostTypeSeo>;
+  /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
+  slug?: Maybe<Scalars['String']['output']>;
+  /** The current status of the object */
+  status?: Maybe<Scalars['String']['output']>;
+  /** The template assigned to the node */
+  template?: Maybe<ContentTemplate>;
+  /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
+  title?: Maybe<Scalars['String']['output']>;
+  /** The unique resource identifier path */
+  uri?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** The callToAction type */
+export type CallToActionEnqueuedScriptsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** The callToAction type */
+export type CallToActionEnqueuedStylesheetsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** The callToAction type */
+export type CallToActionTitleArgs = {
+  format?: InputMaybe<PostObjectFieldFormatEnum>;
+};
+
+/** Connection to callToAction Nodes */
+export type CallToActionConnection = {
+  /** A list of edges (relational context) between RootQuery and connected callToAction Nodes */
+  edges: Array<CallToActionConnectionEdge>;
+  /** A list of connected callToAction Nodes */
+  nodes: Array<CallToAction>;
+  /** Information about pagination in a connection. */
+  pageInfo: CallToActionConnectionPageInfo;
+};
+
+/** Edge between a Node and a connected callToAction */
+export type CallToActionConnectionEdge = {
+  /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The connected callToAction Node */
+  node: CallToAction;
+};
+
+/** Page Info on the connected CallToActionConnectionEdge */
+export type CallToActionConnectionPageInfo = {
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** The Type of Identifier used to fetch a single resource. Default is ID. */
+export enum CallToActionIdType {
+  /** Identify a resource by the Database ID. */
+  DatabaseId = 'DATABASE_ID',
+  /** Identify a resource by the (hashed) Global ID. */
+  Id = 'ID',
+  /** Identify a resource by the slug. Available to non-hierarchcial Types where the slug is a unique identifier. */
+  Slug = 'SLUG',
+  /** Identify a resource by the URI. */
+  Uri = 'URI'
+}
+
+/** Connection between the CallToAction type and the callToAction type */
+export type CallToActionToPreviewConnectionEdge = CallToActionConnectionEdge & Edge & OneToOneConnection & {
+  __typename?: 'CallToActionToPreviewConnectionEdge';
+  /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The node of the connection, without the edges */
+  node: CallToAction;
+};
+
+/** Field Group */
+export type CallToAction_Ctaoptions = AcfFieldGroup & {
+  __typename?: 'CallToAction_Ctaoptions';
+  actions?: Maybe<CallToAction_Ctaoptions_Actions>;
+  content?: Maybe<CallToAction_Ctaoptions_Content>;
+  /**
+   * &lt;p&gt;Select the type of call to action you wish to use.&lt;/p&gt;
+   * &lt;ul&gt;
+   * &lt;li&gt;Informational - General information.&lt;/li&gt;
+   * &lt;li&gt;Donation - Similar to Informational, but will be themed for donating. (Additional donation settings will come later for in app donation form configuration.)
+   * &lt;li&gt;Opt-In - Prompt to opt into something, such as privacy policy. Checkbox will be provided to enable action button when checked.&lt;/li&gt;
+   * &lt;li&gt;Newsletter - Show a newsletter subscription form. Mailing List can be customized from the default Top of The World newsletter list.&lt;/li&gt;
+   * &lt;/ul&gt;
+   */
+  ctaType?: Maybe<Scalars['String']['output']>;
+  /** The name of the ACF Field Group */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
+  newsletterSettings?: Maybe<CallToAction_Ctaoptions_NewsletterSettings>;
+  optInSettings?: Maybe<CallToAction_Ctaoptions_OptInSettings>;
+};
+
+/** Field Group */
+export type CallToAction_Ctaoptions_Actions = AcfFieldGroup & {
+  __typename?: 'CallToAction_Ctaoptions_Actions';
+  /** Label used in action button. Will override the default label, or create an action button for CTA types that usually do not have an default action. */
+  actionButtonLabel?: Maybe<Scalars['String']['output']>;
+  /** URL the action button should link to. Action button will act as a dismiss button in dismissible regions when no URL is provided. */
+  actionButtonUrl?: Maybe<Scalars['String']['output']>;
+  /** Customize the label of the dismiss button. Dismiss button will only be shown in dismissible regions. */
+  dismissButtonLabel?: Maybe<Scalars['String']['output']>;
+  /** The name of the ACF Field Group */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
+};
+
+/** Field Group */
+export type CallToAction_Ctaoptions_Content = AcfFieldGroup & {
+  __typename?: 'CallToAction_Ctaoptions_Content';
+  /** The name of the ACF Field Group */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
+  heading?: Maybe<Scalars['String']['output']>;
+  message?: Maybe<Scalars['String']['output']>;
+};
+
+/** Field Group */
+export type CallToAction_Ctaoptions_NewsletterSettings = AcfFieldGroup & {
+  __typename?: 'CallToAction_Ctaoptions_NewsletterSettings';
+  /** The name of the ACF Field Group */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
+  /** Select a Newsletter post to have sign up form settings pulled from. If a region wouldn&#039;t support a sign up form, a link to the newsletter page will be provided. */
+  newsletter?: Maybe<CallToAction_Ctaoptions_NewsletterSettings_Newsletter>;
+};
+
+export type CallToAction_Ctaoptions_NewsletterSettings_Newsletter = Newsletter;
+
+/** Field Group */
+export type CallToAction_Ctaoptions_OptInSettings = AcfFieldGroup & {
+  __typename?: 'CallToAction_Ctaoptions_OptInSettings';
+  /** The name of the ACF Field Group */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
+  optInText?: Maybe<Scalars['String']['output']>;
+};
+
+/** Field Group */
+export type CallToAction_Ctasettings = AcfFieldGroup & {
+  __typename?: 'CallToAction_Ctasettings';
+  /** Dissed messages use cookies to determine the next time it should be shown to a user. Set the number of minutes the cookie should expire. Default is &#039;0&#039; which expires when the user closes the browser window or tab. */
+  cookieLifespan?: Maybe<Scalars['Float']['output']>;
+  /** The name of the ACF Field Group */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
+};
+
+/** Field Group */
+export type CallToAction_Ctatargeting = AcfFieldGroup & {
+  __typename?: 'CallToAction_Ctatargeting';
+  /** The name of the ACF Field Group */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
+  /** Select which categories this CTA should appear on. CTA will be shown on the terms&#039; landing pages, and content tagged by these terms. */
+  targetCategories?: Maybe<Array<Maybe<Category>>>;
+  targetContent?: Maybe<Array<Maybe<CallToAction_Ctatargeting_TargetContent>>>;
+  /** Select which programs this CTA should appear on. CTA will be shown on the terms&#039; landing pages, and content tagged by these terms. */
+  targetPrograms?: Maybe<Array<Maybe<Program>>>;
+};
+
+export type CallToAction_Ctatargeting_TargetContent = Episode | Post;
+
 /** The category type */
 export type Category = DatabaseIdentifier & HierarchicalNode & HierarchicalTermNode & MenuItemLinkable & Node & TermNode & UniformResourceIdentifiable & {
   __typename?: 'Category';
@@ -2122,7 +2358,13 @@ export enum ContentTypeEnum {
   /** The Type of Content object */
   Attachment = 'ATTACHMENT',
   /** The Type of Content object */
+  CallToAction = 'CALL_TO_ACTION',
+  /** The Type of Content object */
+  CtaRegion = 'CTA_REGION',
+  /** The Type of Content object */
   Episode = 'EPISODE',
+  /** The Type of Content object */
+  Newsletter = 'NEWSLETTER',
   /** The Type of Content object */
   Page = 'PAGE',
   /** The Type of Content object */
@@ -2297,6 +2539,12 @@ export enum ContentTypesOfCountryEnum {
   Post = 'POST',
   /** The Type of Content object */
   Segment = 'SEGMENT'
+}
+
+/** Allowed Content Types of the CtaRegionType taxonomy. */
+export enum ContentTypesOfCtaRegionTypeEnum {
+  /** The Type of Content object */
+  CtaRegion = 'CTA_REGION'
 }
 
 /** Allowed Content Types of the License taxonomy. */
@@ -4060,6 +4308,33 @@ export type Country_Taxonomyimages = AcfFieldGroup & {
   logo?: Maybe<MediaItem>;
 };
 
+/** Input for the createCallToAction mutation. */
+export type CreateCallToActionInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
+  date?: InputMaybe<Scalars['String']['input']>;
+  /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** The password used to protect the content of the object */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** The slug of the object */
+  slug?: InputMaybe<Scalars['String']['input']>;
+  /** The status of the object */
+  status?: InputMaybe<PostStatusEnum>;
+  /** The title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The payload for the createCallToAction mutation. */
+export type CreateCallToActionPayload = {
+  __typename?: 'CreateCallToActionPayload';
+  /** The Post object mutation type. */
+  callToAction?: Maybe<CallToAction>;
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+};
+
 /** Input for the createCategory mutation. */
 export type CreateCategoryInput = {
   /** The slug that the category will be an alias of */
@@ -4214,6 +4489,60 @@ export type CreateCountryPayload = {
   country?: Maybe<Country>;
 };
 
+/** Input for the createCtaRegion mutation. */
+export type CreateCtaRegionInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** Set connections between the ctaRegion and ctaRegionTypes */
+  ctaRegionTypes?: InputMaybe<CtaRegionCtaRegionTypesInput>;
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
+  date?: InputMaybe<Scalars['String']['input']>;
+  /** The excerpt of the object */
+  excerpt?: InputMaybe<Scalars['String']['input']>;
+  /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** The password used to protect the content of the object */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** The slug of the object */
+  slug?: InputMaybe<Scalars['String']['input']>;
+  /** The status of the object */
+  status?: InputMaybe<PostStatusEnum>;
+  /** The title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The payload for the createCtaRegion mutation. */
+export type CreateCtaRegionPayload = {
+  __typename?: 'CreateCtaRegionPayload';
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  /** The Post object mutation type. */
+  ctaRegion?: Maybe<CtaRegion>;
+};
+
+/** Input for the createCtaRegionType mutation. */
+export type CreateCtaRegionTypeInput = {
+  /** The slug that the cta_region_type will be an alias of */
+  aliasOf?: InputMaybe<Scalars['String']['input']>;
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** The description of the cta_region_type object */
+  description?: InputMaybe<Scalars['String']['input']>;
+  /** The name of the cta_region_type object to mutate */
+  name: Scalars['String']['input'];
+  /** If this argument exists then the slug will be checked to see if it is not an existing valid term. If that check succeeds (it is not a valid term), then it is added and the term id is given. If it fails, then a check is made to whether the taxonomy is hierarchical and the parent argument is not empty. If the second check succeeds, the term will be inserted and the term id will be given. If the slug argument is empty, then it will be calculated from the term name. */
+  slug?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The payload for the createCtaRegionType mutation. */
+export type CreateCtaRegionTypePayload = {
+  __typename?: 'CreateCtaRegionTypePayload';
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  /** The created cta_region_type */
+  ctaRegionType?: Maybe<CtaRegionType>;
+};
+
 /** Input for the createEpisode mutation. */
 export type CreateEpisodeInput = {
   /** Set connections between the episode and categories */
@@ -4329,6 +4658,37 @@ export type CreateMediaItemPayload = {
   clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The MediaItem object mutation type. */
   mediaItem?: Maybe<MediaItem>;
+};
+
+/** Input for the createNewsletter mutation. */
+export type CreateNewsletterInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** The content of the object */
+  content?: InputMaybe<Scalars['String']['input']>;
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
+  date?: InputMaybe<Scalars['String']['input']>;
+  /** The excerpt of the object */
+  excerpt?: InputMaybe<Scalars['String']['input']>;
+  /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** The password used to protect the content of the object */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** The slug of the object */
+  slug?: InputMaybe<Scalars['String']['input']>;
+  /** The status of the object */
+  status?: InputMaybe<PostStatusEnum>;
+  /** The title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The payload for the createNewsletter mutation. */
+export type CreateNewsletterPayload = {
+  __typename?: 'CreateNewsletterPayload';
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  /** The Post object mutation type. */
+  newsletter?: Maybe<Newsletter>;
 };
 
 /** Input for the createPage mutation. */
@@ -4732,6 +5092,672 @@ export type CreateUserPayload = {
   user?: Maybe<User>;
 };
 
+/** The ctaRegion type */
+export type CtaRegion = ContentNode & DatabaseIdentifier & Node & NodeWithExcerpt & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable & {
+  __typename?: 'CtaRegion';
+  /** Connection between the ContentNode type and the ContentType type */
+  contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
+  /** The name of the Content Type the node belongs to */
+  contentTypeName: Scalars['String']['output'];
+  /** Fields to define CTA Region content. | Added to the GraphQL Schema because the ACF Field Group &quot;CTA Region Content&quot; was set to Show in GraphQL. */
+  ctaRegionContent?: Maybe<CtaRegion_Ctaregioncontent>;
+  /**
+   * The id field matches the WP_Post-&gt;ID field.
+   * @deprecated Deprecated in favor of the databaseId field
+   */
+  ctaRegionId: Scalars['Int']['output'];
+  /** Connection between the CtaRegion type and the ctaRegionType type */
+  ctaRegionTypes?: Maybe<CtaRegionToCtaRegionTypeConnection>;
+  /** The unique identifier stored in the database */
+  databaseId: Scalars['Int']['output'];
+  /** Post publishing date. */
+  date?: Maybe<Scalars['String']['output']>;
+  /** The publishing date set in GMT. */
+  dateGmt?: Maybe<Scalars['String']['output']>;
+  /** The desired slug of the post */
+  desiredSlug?: Maybe<Scalars['String']['output']>;
+  /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
+  editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
+  /** The RSS enclosure for the object */
+  enclosure?: Maybe<Scalars['String']['output']>;
+  /** Connection between the ContentNode type and the EnqueuedScript type */
+  enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
+  /** Connection between the ContentNode type and the EnqueuedStylesheet type */
+  enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
+  /** The excerpt of the post. */
+  excerpt?: Maybe<Scalars['String']['output']>;
+  /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
+  guid?: Maybe<Scalars['String']['output']>;
+  /** The globally unique identifier of the cta_region object. */
+  id: Scalars['ID']['output'];
+  /** Whether the node is a Content Node */
+  isContentNode: Scalars['Boolean']['output'];
+  /** Whether the object is a node in the preview state */
+  isPreview?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether the object is restricted from the current viewer */
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether the node is a Term */
+  isTermNode: Scalars['Boolean']['output'];
+  /** The user that most recently edited the node */
+  lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
+  /** The permalink of the post */
+  link?: Maybe<Scalars['String']['output']>;
+  /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
+  modifiedGmt?: Maybe<Scalars['String']['output']>;
+  /** Connection between the CtaRegion type and the ctaRegion type */
+  preview?: Maybe<CtaRegionToPreviewConnectionEdge>;
+  /** The database id of the preview node */
+  previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
+  /** Whether the object is a node in the preview state */
+  previewRevisionId?: Maybe<Scalars['ID']['output']>;
+  /** The Yoast SEO data of the ContentNode */
+  seo?: Maybe<PostTypeSeo>;
+  /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
+  slug?: Maybe<Scalars['String']['output']>;
+  /** The current status of the object */
+  status?: Maybe<Scalars['String']['output']>;
+  /** The template assigned to the node */
+  template?: Maybe<ContentTemplate>;
+  /** Connection between the CtaRegion type and the TermNode type */
+  terms?: Maybe<CtaRegionToTermNodeConnection>;
+  /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
+  title?: Maybe<Scalars['String']['output']>;
+  /** The unique resource identifier path */
+  uri?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** The ctaRegion type */
+export type CtaRegionCtaRegionTypesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<CtaRegionToCtaRegionTypeConnectionWhereArgs>;
+};
+
+
+/** The ctaRegion type */
+export type CtaRegionEnqueuedScriptsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** The ctaRegion type */
+export type CtaRegionEnqueuedStylesheetsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** The ctaRegion type */
+export type CtaRegionExcerptArgs = {
+  format?: InputMaybe<PostObjectFieldFormatEnum>;
+};
+
+
+/** The ctaRegion type */
+export type CtaRegionTermsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<CtaRegionToTermNodeConnectionWhereArgs>;
+};
+
+
+/** The ctaRegion type */
+export type CtaRegionTitleArgs = {
+  format?: InputMaybe<PostObjectFieldFormatEnum>;
+};
+
+/** Connection to ctaRegion Nodes */
+export type CtaRegionConnection = {
+  /** A list of edges (relational context) between RootQuery and connected ctaRegion Nodes */
+  edges: Array<CtaRegionConnectionEdge>;
+  /** A list of connected ctaRegion Nodes */
+  nodes: Array<CtaRegion>;
+  /** Information about pagination in a connection. */
+  pageInfo: CtaRegionConnectionPageInfo;
+};
+
+/** Edge between a Node and a connected ctaRegion */
+export type CtaRegionConnectionEdge = {
+  /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The connected ctaRegion Node */
+  node: CtaRegion;
+};
+
+/** Page Info on the connected CtaRegionConnectionEdge */
+export type CtaRegionConnectionPageInfo = {
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** Set relationships between the ctaRegion to ctaRegionTypes */
+export type CtaRegionCtaRegionTypesInput = {
+  /** If true, this will append the ctaRegionType to existing related ctaRegionTypes. If false, this will replace existing relationships. Default true. */
+  append?: InputMaybe<Scalars['Boolean']['input']>;
+  /** The input list of items to set. */
+  nodes?: InputMaybe<Array<InputMaybe<CtaRegionCtaRegionTypesNodeInput>>>;
+};
+
+/** List of ctaRegionTypes to connect the ctaRegion to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists. */
+export type CtaRegionCtaRegionTypesNodeInput = {
+  /** The description of the ctaRegionType. This field is used to set a description of the ctaRegionType if a new one is created during the mutation. */
+  description?: InputMaybe<Scalars['String']['input']>;
+  /** The ID of the ctaRegionType. If present, this will be used to connect to the ctaRegion. If no existing ctaRegionType exists with this ID, no connection will be made. */
+  id?: InputMaybe<Scalars['ID']['input']>;
+  /** The name of the ctaRegionType. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field. */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** The slug of the ctaRegionType. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation. */
+  slug?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The Type of Identifier used to fetch a single resource. Default is ID. */
+export enum CtaRegionIdType {
+  /** Identify a resource by the Database ID. */
+  DatabaseId = 'DATABASE_ID',
+  /** Identify a resource by the (hashed) Global ID. */
+  Id = 'ID',
+  /** Identify a resource by the slug. Available to non-hierarchcial Types where the slug is a unique identifier. */
+  Slug = 'SLUG',
+  /** Identify a resource by the URI. */
+  Uri = 'URI'
+}
+
+/** Connection between the CtaRegion type and the ctaRegionType type */
+export type CtaRegionToCtaRegionTypeConnection = Connection & CtaRegionTypeConnection & {
+  __typename?: 'CtaRegionToCtaRegionTypeConnection';
+  /** Edges for the CtaRegionToCtaRegionTypeConnection connection */
+  edges: Array<CtaRegionToCtaRegionTypeConnectionEdge>;
+  /** The nodes of the connection, without the edges */
+  nodes: Array<CtaRegionType>;
+  /** Information about pagination in a connection. */
+  pageInfo: CtaRegionToCtaRegionTypeConnectionPageInfo;
+};
+
+/** An edge in a connection */
+export type CtaRegionToCtaRegionTypeConnectionEdge = CtaRegionTypeConnectionEdge & Edge & {
+  __typename?: 'CtaRegionToCtaRegionTypeConnectionEdge';
+  /** A cursor for use in pagination */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The Yoast SEO Primary cta_region_type */
+  isPrimary?: Maybe<Scalars['Boolean']['output']>;
+  /** The item at the end of the edge */
+  node: CtaRegionType;
+};
+
+/** Page Info on the &quot;CtaRegionToCtaRegionTypeConnection&quot; */
+export type CtaRegionToCtaRegionTypeConnectionPageInfo = CtaRegionTypeConnectionPageInfo & PageInfo & WpPageInfo & {
+  __typename?: 'CtaRegionToCtaRegionTypeConnectionPageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** Arguments for filtering the CtaRegionToCtaRegionTypeConnection connection */
+export type CtaRegionToCtaRegionTypeConnectionWhereArgs = {
+  /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
+  /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
+  childOf?: InputMaybe<Scalars['Int']['input']>;
+  /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Retrieve terms where the description is LIKE the input value. Default empty. */
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
+  /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Array of term ids to include. Default empty array. */
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Array of names to return term(s) for. Default empty. */
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Retrieve terms where the name is LIKE the input value. Default empty. */
+  nameLike?: InputMaybe<Scalars['String']['input']>;
+  /** Array of object IDs. Results will be limited to terms associated with these objects. */
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Direction the connection should be ordered in */
+  order?: InputMaybe<OrderEnum>;
+  /** Field(s) to order terms by. Defaults to 'name'. */
+  orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
+  /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Parent term ID to retrieve direct-child terms of. Default empty. */
+  parent?: InputMaybe<Scalars['Int']['input']>;
+  /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
+  search?: InputMaybe<Scalars['String']['input']>;
+  /** Array of slugs to return term(s) for. Default empty. */
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Array of term taxonomy IDs, to match when querying terms. */
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Array of term taxonomy IDs, to match when querying terms. */
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Whether to prime meta caches for matched terms. Default true. */
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Connection between the CtaRegion type and the ctaRegion type */
+export type CtaRegionToPreviewConnectionEdge = CtaRegionConnectionEdge & Edge & OneToOneConnection & {
+  __typename?: 'CtaRegionToPreviewConnectionEdge';
+  /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The node of the connection, without the edges */
+  node: CtaRegion;
+};
+
+/** Connection between the CtaRegion type and the TermNode type */
+export type CtaRegionToTermNodeConnection = Connection & TermNodeConnection & {
+  __typename?: 'CtaRegionToTermNodeConnection';
+  /** Edges for the CtaRegionToTermNodeConnection connection */
+  edges: Array<CtaRegionToTermNodeConnectionEdge>;
+  /** The nodes of the connection, without the edges */
+  nodes: Array<TermNode>;
+  /** Information about pagination in a connection. */
+  pageInfo: CtaRegionToTermNodeConnectionPageInfo;
+};
+
+/** An edge in a connection */
+export type CtaRegionToTermNodeConnectionEdge = Edge & TermNodeConnectionEdge & {
+  __typename?: 'CtaRegionToTermNodeConnectionEdge';
+  /** A cursor for use in pagination */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The item at the end of the edge */
+  node: TermNode;
+};
+
+/** Page Info on the &quot;CtaRegionToTermNodeConnection&quot; */
+export type CtaRegionToTermNodeConnectionPageInfo = PageInfo & TermNodeConnectionPageInfo & WpPageInfo & {
+  __typename?: 'CtaRegionToTermNodeConnectionPageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** Arguments for filtering the CtaRegionToTermNodeConnection connection */
+export type CtaRegionToTermNodeConnectionWhereArgs = {
+  /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
+  /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
+  childOf?: InputMaybe<Scalars['Int']['input']>;
+  /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Retrieve terms where the description is LIKE the input value. Default empty. */
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
+  /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Array of term ids to include. Default empty array. */
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Array of names to return term(s) for. Default empty. */
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Retrieve terms where the name is LIKE the input value. Default empty. */
+  nameLike?: InputMaybe<Scalars['String']['input']>;
+  /** Array of object IDs. Results will be limited to terms associated with these objects. */
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Direction the connection should be ordered in */
+  order?: InputMaybe<OrderEnum>;
+  /** Field(s) to order terms by. Defaults to 'name'. */
+  orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
+  /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Parent term ID to retrieve direct-child terms of. Default empty. */
+  parent?: InputMaybe<Scalars['Int']['input']>;
+  /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
+  search?: InputMaybe<Scalars['String']['input']>;
+  /** Array of slugs to return term(s) for. Default empty. */
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** The Taxonomy to filter terms by */
+  taxonomies?: InputMaybe<Array<InputMaybe<TaxonomyEnum>>>;
+  /** Array of term taxonomy IDs, to match when querying terms. */
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Array of term taxonomy IDs, to match when querying terms. */
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Whether to prime meta caches for matched terms. Default true. */
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** The ctaRegionType type */
+export type CtaRegionType = DatabaseIdentifier & Node & TermNode & UniformResourceIdentifiable & {
+  __typename?: 'CtaRegionType';
+  /** Connection between the CtaRegionType type and the ContentNode type */
+  contentNodes?: Maybe<CtaRegionTypeToContentNodeConnection>;
+  /** The number of objects connected to the object */
+  count?: Maybe<Scalars['Int']['output']>;
+  /**
+   * The id field matches the WP_Post-&gt;ID field.
+   * @deprecated Deprecated in favor of databaseId
+   */
+  ctaRegionTypeId?: Maybe<Scalars['Int']['output']>;
+  /** Connection between the CtaRegionType type and the ctaRegion type */
+  ctaRegions?: Maybe<CtaRegionTypeToCtaRegionConnection>;
+  /** The unique identifier stored in the database */
+  databaseId: Scalars['Int']['output'];
+  /** The description of the object */
+  description?: Maybe<Scalars['String']['output']>;
+  /** Connection between the TermNode type and the EnqueuedScript type */
+  enqueuedScripts?: Maybe<TermNodeToEnqueuedScriptConnection>;
+  /** Connection between the TermNode type and the EnqueuedStylesheet type */
+  enqueuedStylesheets?: Maybe<TermNodeToEnqueuedStylesheetConnection>;
+  /** The unique resource identifier path */
+  id: Scalars['ID']['output'];
+  /** Whether the node is a Content Node */
+  isContentNode: Scalars['Boolean']['output'];
+  /** Whether the object is restricted from the current viewer */
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether the node is a Term */
+  isTermNode: Scalars['Boolean']['output'];
+  /** The link to the term */
+  link?: Maybe<Scalars['String']['output']>;
+  /** The human friendly name of the object. */
+  name?: Maybe<Scalars['String']['output']>;
+  /** The Yoast SEO data of the CTA Region Types taxonomy. */
+  seo?: Maybe<TaxonomySeo>;
+  /** An alphanumeric identifier for the object unique to its type. */
+  slug?: Maybe<Scalars['String']['output']>;
+  /** Connection between the CtaRegionType type and the Taxonomy type */
+  taxonomy?: Maybe<CtaRegionTypeToTaxonomyConnectionEdge>;
+  /** The name of the taxonomy that the object is associated with */
+  taxonomyName?: Maybe<Scalars['String']['output']>;
+  /** The ID of the term group that this term object belongs to */
+  termGroupId?: Maybe<Scalars['Int']['output']>;
+  /** The taxonomy ID that the object is associated with */
+  termTaxonomyId?: Maybe<Scalars['Int']['output']>;
+  /** The unique resource identifier path */
+  uri?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** The ctaRegionType type */
+export type CtaRegionTypeContentNodesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<CtaRegionTypeToContentNodeConnectionWhereArgs>;
+};
+
+
+/** The ctaRegionType type */
+export type CtaRegionTypeCtaRegionsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<CtaRegionTypeToCtaRegionConnectionWhereArgs>;
+};
+
+
+/** The ctaRegionType type */
+export type CtaRegionTypeEnqueuedScriptsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** The ctaRegionType type */
+export type CtaRegionTypeEnqueuedStylesheetsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** Connection to ctaRegionType Nodes */
+export type CtaRegionTypeConnection = {
+  /** A list of edges (relational context) between RootQuery and connected ctaRegionType Nodes */
+  edges: Array<CtaRegionTypeConnectionEdge>;
+  /** A list of connected ctaRegionType Nodes */
+  nodes: Array<CtaRegionType>;
+  /** Information about pagination in a connection. */
+  pageInfo: CtaRegionTypeConnectionPageInfo;
+};
+
+/** Edge between a Node and a connected ctaRegionType */
+export type CtaRegionTypeConnectionEdge = {
+  /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The connected ctaRegionType Node */
+  node: CtaRegionType;
+};
+
+/** Page Info on the connected CtaRegionTypeConnectionEdge */
+export type CtaRegionTypeConnectionPageInfo = {
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** The Type of Identifier used to fetch a single resource. Default is ID. */
+export enum CtaRegionTypeIdType {
+  /** The Database ID for the node */
+  DatabaseId = 'DATABASE_ID',
+  /** The hashed Global ID */
+  Id = 'ID',
+  /** The name of the node */
+  Name = 'NAME',
+  /** Url friendly name of the node */
+  Slug = 'SLUG',
+  /** The URI for the node */
+  Uri = 'URI'
+}
+
+/** Connection between the CtaRegionType type and the ContentNode type */
+export type CtaRegionTypeToContentNodeConnection = Connection & ContentNodeConnection & {
+  __typename?: 'CtaRegionTypeToContentNodeConnection';
+  /** Edges for the CtaRegionTypeToContentNodeConnection connection */
+  edges: Array<CtaRegionTypeToContentNodeConnectionEdge>;
+  /** The nodes of the connection, without the edges */
+  nodes: Array<ContentNode>;
+  /** Information about pagination in a connection. */
+  pageInfo: CtaRegionTypeToContentNodeConnectionPageInfo;
+};
+
+/** An edge in a connection */
+export type CtaRegionTypeToContentNodeConnectionEdge = ContentNodeConnectionEdge & Edge & {
+  __typename?: 'CtaRegionTypeToContentNodeConnectionEdge';
+  /** A cursor for use in pagination */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The item at the end of the edge */
+  node: ContentNode;
+};
+
+/** Page Info on the &quot;CtaRegionTypeToContentNodeConnection&quot; */
+export type CtaRegionTypeToContentNodeConnectionPageInfo = ContentNodeConnectionPageInfo & PageInfo & WpPageInfo & {
+  __typename?: 'CtaRegionTypeToContentNodeConnectionPageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** Arguments for filtering the CtaRegionTypeToContentNodeConnection connection */
+export type CtaRegionTypeToContentNodeConnectionWhereArgs = {
+  /** The Types of content to filter */
+  contentTypes?: InputMaybe<Array<InputMaybe<ContentTypesOfCtaRegionTypeEnum>>>;
+  /** Filter the connection based on dates */
+  dateQuery?: InputMaybe<DateQueryInput>;
+  /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Specific database ID of the object */
+  id?: InputMaybe<Scalars['Int']['input']>;
+  /** Array of IDs for the objects to retrieve */
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Get objects with a specific mimeType property */
+  mimeType?: InputMaybe<MimeTypeEnum>;
+  /** Slug / post_name of the object */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** Specify objects to retrieve. Use slugs */
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** What paramater to use to order the objects by. */
+  orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
+  /** Use ID to return only children. Use 0 to return only top-level items */
+  parent?: InputMaybe<Scalars['ID']['input']>;
+  /** Specify objects whose parent is in an array */
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Specify posts whose parent is not in an array */
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Show posts with a specific password. */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** Show Posts based on a keyword search */
+  search?: InputMaybe<Scalars['String']['input']>;
+  /** Retrieve posts where post status is in an array. */
+  stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
+  /** Show posts with a specific status. */
+  status?: InputMaybe<PostStatusEnum>;
+  /** Title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Connection between the CtaRegionType type and the ctaRegion type */
+export type CtaRegionTypeToCtaRegionConnection = Connection & CtaRegionConnection & {
+  __typename?: 'CtaRegionTypeToCtaRegionConnection';
+  /** Edges for the CtaRegionTypeToCtaRegionConnection connection */
+  edges: Array<CtaRegionTypeToCtaRegionConnectionEdge>;
+  /** The nodes of the connection, without the edges */
+  nodes: Array<CtaRegion>;
+  /** Information about pagination in a connection. */
+  pageInfo: CtaRegionTypeToCtaRegionConnectionPageInfo;
+};
+
+/** An edge in a connection */
+export type CtaRegionTypeToCtaRegionConnectionEdge = CtaRegionConnectionEdge & Edge & {
+  __typename?: 'CtaRegionTypeToCtaRegionConnectionEdge';
+  /** A cursor for use in pagination */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The item at the end of the edge */
+  node: CtaRegion;
+};
+
+/** Page Info on the &quot;CtaRegionTypeToCtaRegionConnection&quot; */
+export type CtaRegionTypeToCtaRegionConnectionPageInfo = CtaRegionConnectionPageInfo & PageInfo & WpPageInfo & {
+  __typename?: 'CtaRegionTypeToCtaRegionConnectionPageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** Arguments for filtering the CtaRegionTypeToCtaRegionConnection connection */
+export type CtaRegionTypeToCtaRegionConnectionWhereArgs = {
+  /** Filter the connection based on dates */
+  dateQuery?: InputMaybe<DateQueryInput>;
+  /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Specific database ID of the object */
+  id?: InputMaybe<Scalars['Int']['input']>;
+  /** Array of IDs for the objects to retrieve */
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Get objects with a specific mimeType property */
+  mimeType?: InputMaybe<MimeTypeEnum>;
+  /** Slug / post_name of the object */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** Specify objects to retrieve. Use slugs */
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** What paramater to use to order the objects by. */
+  orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
+  /** Use ID to return only children. Use 0 to return only top-level items */
+  parent?: InputMaybe<Scalars['ID']['input']>;
+  /** Specify objects whose parent is in an array */
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Specify posts whose parent is not in an array */
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Show posts with a specific password. */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** Show Posts based on a keyword search */
+  search?: InputMaybe<Scalars['String']['input']>;
+  /** Retrieve posts where post status is in an array. */
+  stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
+  /** Show posts with a specific status. */
+  status?: InputMaybe<PostStatusEnum>;
+  /** Title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Connection between the CtaRegionType type and the Taxonomy type */
+export type CtaRegionTypeToTaxonomyConnectionEdge = Edge & OneToOneConnection & TaxonomyConnectionEdge & {
+  __typename?: 'CtaRegionTypeToTaxonomyConnectionEdge';
+  /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The node of the connection, without the edges */
+  node: Taxonomy;
+};
+
+/** Field Group */
+export type CtaRegion_Ctaregioncontent = AcfFieldGroup & {
+  __typename?: 'CtaRegion_Ctaregioncontent';
+  callToActions?: Maybe<Array<Maybe<CtaRegion_Ctaregioncontent_CallToActions>>>;
+  /** The name of the ACF Field Group */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
+};
+
+export type CtaRegion_Ctaregioncontent_CallToActions = CallToAction;
+
 /** Object that can be identified with a Database ID */
 export type DatabaseIdentifier = {
   /** The unique identifier stored in the database */
@@ -4783,6 +5809,29 @@ export type DefaultTemplate = ContentTemplate & {
   __typename?: 'DefaultTemplate';
   /** The name of the template */
   templateName?: Maybe<Scalars['String']['output']>;
+};
+
+/** Input for the deleteCallToAction mutation. */
+export type DeleteCallToActionInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** Whether the object should be force deleted instead of being moved to the trash */
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
+  /** The ID of the callToAction to delete */
+  id: Scalars['ID']['input'];
+  /** Override the edit lock when another user is editing the post */
+  ignoreEditLock?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** The payload for the deleteCallToAction mutation. */
+export type DeleteCallToActionPayload = {
+  __typename?: 'DeleteCallToActionPayload';
+  /** The object before it was deleted */
+  callToAction?: Maybe<CallToAction>;
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  /** The ID of the deleted object */
+  deletedId?: Maybe<Scalars['ID']['output']>;
 };
 
 /** Input for the deleteCategory mutation. */
@@ -4901,6 +5950,48 @@ export type DeleteCountryPayload = {
   deletedId?: Maybe<Scalars['ID']['output']>;
 };
 
+/** Input for the deleteCtaRegion mutation. */
+export type DeleteCtaRegionInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** Whether the object should be force deleted instead of being moved to the trash */
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
+  /** The ID of the ctaRegion to delete */
+  id: Scalars['ID']['input'];
+  /** Override the edit lock when another user is editing the post */
+  ignoreEditLock?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** The payload for the deleteCtaRegion mutation. */
+export type DeleteCtaRegionPayload = {
+  __typename?: 'DeleteCtaRegionPayload';
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  /** The object before it was deleted */
+  ctaRegion?: Maybe<CtaRegion>;
+  /** The ID of the deleted object */
+  deletedId?: Maybe<Scalars['ID']['output']>;
+};
+
+/** Input for the deleteCtaRegionType mutation. */
+export type DeleteCtaRegionTypeInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** The ID of the ctaRegionType to delete */
+  id: Scalars['ID']['input'];
+};
+
+/** The payload for the deleteCtaRegionType mutation. */
+export type DeleteCtaRegionTypePayload = {
+  __typename?: 'DeleteCtaRegionTypePayload';
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  /** The deteted term object */
+  ctaRegionType?: Maybe<CtaRegionType>;
+  /** The ID of the deleted object */
+  deletedId?: Maybe<Scalars['ID']['output']>;
+};
+
 /** Input for the deleteEpisode mutation. */
 export type DeleteEpisodeInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
@@ -4962,6 +6053,29 @@ export type DeleteMediaItemPayload = {
   deletedId?: Maybe<Scalars['ID']['output']>;
   /** The mediaItem before it was deleted */
   mediaItem?: Maybe<MediaItem>;
+};
+
+/** Input for the deleteNewsletter mutation. */
+export type DeleteNewsletterInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** Whether the object should be force deleted instead of being moved to the trash */
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
+  /** The ID of the newsletter to delete */
+  id: Scalars['ID']['input'];
+  /** Override the edit lock when another user is editing the post */
+  ignoreEditLock?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** The payload for the deleteNewsletter mutation. */
+export type DeleteNewsletterPayload = {
+  __typename?: 'DeleteNewsletterPayload';
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  /** The ID of the deleted object */
+  deletedId?: Maybe<Scalars['ID']['output']>;
+  /** The object before it was deleted */
+  newsletter?: Maybe<Newsletter>;
 };
 
 /** Input for the deletePage mutation. */
@@ -7232,8 +8346,6 @@ export type License = DatabaseIdentifier & MenuItemLinkable & Node & TermNode & 
   isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the node is a Term */
   isTermNode: Scalars['Boolean']['output'];
-  /** Added to the GraphQL Schema because the ACF Field Group &quot;Landing Page&quot; was set to Show in GraphQL. */
-  landingPage?: Maybe<License_Landingpage>;
   /**
    * The id field matches the WP_Post-&gt;ID field.
    * @deprecated Deprecated in favor of databaseId
@@ -7251,8 +8363,6 @@ export type License = DatabaseIdentifier & MenuItemLinkable & Node & TermNode & 
   slug?: Maybe<Scalars['String']['output']>;
   /** Connection between the License type and the Taxonomy type */
   taxonomy?: Maybe<LicenseToTaxonomyConnectionEdge>;
-  /** Added to the GraphQL Schema because the ACF Field Group &quot;Taxonomy Images&quot; was set to Show in GraphQL. */
-  taxonomyImages?: Maybe<License_Taxonomyimages>;
   /** The name of the taxonomy that the object is associated with */
   taxonomyName?: Maybe<Scalars['String']['output']>;
   /** The ID of the term group that this term object belongs to */
@@ -7510,25 +8620,6 @@ export type LicenseToTaxonomyConnectionEdge = Edge & OneToOneConnection & Taxono
   cursor?: Maybe<Scalars['String']['output']>;
   /** The node of the connection, without the edges */
   node: Taxonomy;
-};
-
-/** Field Group */
-export type License_Landingpage = AcfFieldGroup & {
-  __typename?: 'License_Landingpage';
-  featuredPosts?: Maybe<Array<Maybe<License_Landingpage_FeaturedPosts>>>;
-  /** The name of the ACF Field Group */
-  fieldGroupName?: Maybe<Scalars['String']['output']>;
-};
-
-export type License_Landingpage_FeaturedPosts = Post;
-
-/** Field Group */
-export type License_Taxonomyimages = AcfFieldGroup & {
-  __typename?: 'License_Taxonomyimages';
-  /** The name of the ACF Field Group */
-  fieldGroupName?: Maybe<Scalars['String']['output']>;
-  imageBanner?: Maybe<MediaItem>;
-  logo?: Maybe<MediaItem>;
 };
 
 /** File details for a Media Item */
@@ -8355,7 +9446,7 @@ export enum MenuItemNodeIdTypeEnum {
 }
 
 /** Deprecated in favor of MenuItemLinkeable Interface */
-export type MenuItemObjectUnion = Category | Episode | License | Page | Post | Program | ResourceDevelopmentTag | Segment | StoryFormat | Tag;
+export type MenuItemObjectUnion = Category | Episode | License | Newsletter | Page | Post | Program | ResourceDevelopmentTag | Segment | StoryFormat | Tag;
 
 /** Connection between the MenuItem type and the Menu type */
 export type MenuItemToMenuConnectionEdge = Edge & MenuConnectionEdge & OneToOneConnection & {
@@ -8501,185 +9592,367 @@ export type MenuToMenuItemConnectionWhereArgs = {
 
 /** The MimeType of the object */
 export enum MimeTypeEnum {
-  /** MimeType application/java */
+  /** application/java mime type. */
   ApplicationJava = 'APPLICATION_JAVA',
-  /** MimeType application/msword */
+  /** application/msword mime type. */
   ApplicationMsword = 'APPLICATION_MSWORD',
-  /** MimeType application/octet-stream */
+  /** application/octet-stream mime type. */
   ApplicationOctetStream = 'APPLICATION_OCTET_STREAM',
-  /** MimeType application/onenote */
+  /** application/onenote mime type. */
   ApplicationOnenote = 'APPLICATION_ONENOTE',
-  /** MimeType application/oxps */
+  /** application/oxps mime type. */
   ApplicationOxps = 'APPLICATION_OXPS',
-  /** MimeType application/pdf */
+  /** application/pdf mime type. */
   ApplicationPdf = 'APPLICATION_PDF',
-  /** MimeType application/rar */
+  /** application/rar mime type. */
   ApplicationRar = 'APPLICATION_RAR',
-  /** MimeType application/rtf */
+  /** application/rtf mime type. */
   ApplicationRtf = 'APPLICATION_RTF',
-  /** MimeType application/ttaf+xml */
+  /** application/ttaf+xml mime type. */
   ApplicationTtafXml = 'APPLICATION_TTAF_XML',
-  /** MimeType application/vnd.apple.keynote */
+  /** application/vnd.apple.keynote mime type. */
   ApplicationVndAppleKeynote = 'APPLICATION_VND_APPLE_KEYNOTE',
-  /** MimeType application/vnd.apple.numbers */
+  /** application/vnd.apple.numbers mime type. */
   ApplicationVndAppleNumbers = 'APPLICATION_VND_APPLE_NUMBERS',
-  /** MimeType application/vnd.apple.pages */
+  /** application/vnd.apple.pages mime type. */
   ApplicationVndApplePages = 'APPLICATION_VND_APPLE_PAGES',
-  /** MimeType application/vnd.ms-access */
+  /** application/vnd.ms-access mime type. */
   ApplicationVndMsAccess = 'APPLICATION_VND_MS_ACCESS',
-  /** MimeType application/vnd.ms-excel */
+  /** application/vnd.ms-excel mime type. */
   ApplicationVndMsExcel = 'APPLICATION_VND_MS_EXCEL',
-  /** MimeType application/vnd.ms-excel.addin.macroEnabled.12 */
+  /** application/vnd.ms-excel.addin.macroEnabled.12 mime type. */
   ApplicationVndMsExcelAddinMacroenabled_12 = 'APPLICATION_VND_MS_EXCEL_ADDIN_MACROENABLED_12',
-  /** MimeType application/vnd.ms-excel.sheet.binary.macroEnabled.12 */
+  /** application/vnd.ms-excel.sheet.binary.macroEnabled.12 mime type. */
   ApplicationVndMsExcelSheetBinaryMacroenabled_12 = 'APPLICATION_VND_MS_EXCEL_SHEET_BINARY_MACROENABLED_12',
-  /** MimeType application/vnd.ms-excel.sheet.macroEnabled.12 */
+  /** application/vnd.ms-excel.sheet.macroEnabled.12 mime type. */
   ApplicationVndMsExcelSheetMacroenabled_12 = 'APPLICATION_VND_MS_EXCEL_SHEET_MACROENABLED_12',
-  /** MimeType application/vnd.ms-excel.template.macroEnabled.12 */
+  /** application/vnd.ms-excel.template.macroEnabled.12 mime type. */
   ApplicationVndMsExcelTemplateMacroenabled_12 = 'APPLICATION_VND_MS_EXCEL_TEMPLATE_MACROENABLED_12',
-  /** MimeType application/vnd.ms-powerpoint */
+  /** application/vnd.ms-powerpoint mime type. */
   ApplicationVndMsPowerpoint = 'APPLICATION_VND_MS_POWERPOINT',
-  /** MimeType application/vnd.ms-powerpoint.addin.macroEnabled.12 */
+  /** application/vnd.ms-powerpoint.addin.macroEnabled.12 mime type. */
   ApplicationVndMsPowerpointAddinMacroenabled_12 = 'APPLICATION_VND_MS_POWERPOINT_ADDIN_MACROENABLED_12',
-  /** MimeType application/vnd.ms-powerpoint.presentation.macroEnabled.12 */
+  /** application/vnd.ms-powerpoint.presentation.macroEnabled.12 mime type. */
   ApplicationVndMsPowerpointPresentationMacroenabled_12 = 'APPLICATION_VND_MS_POWERPOINT_PRESENTATION_MACROENABLED_12',
-  /** MimeType application/vnd.ms-powerpoint.slideshow.macroEnabled.12 */
+  /** application/vnd.ms-powerpoint.slideshow.macroEnabled.12 mime type. */
   ApplicationVndMsPowerpointSlideshowMacroenabled_12 = 'APPLICATION_VND_MS_POWERPOINT_SLIDESHOW_MACROENABLED_12',
-  /** MimeType application/vnd.ms-powerpoint.slide.macroEnabled.12 */
+  /** application/vnd.ms-powerpoint.slide.macroEnabled.12 mime type. */
   ApplicationVndMsPowerpointSlideMacroenabled_12 = 'APPLICATION_VND_MS_POWERPOINT_SLIDE_MACROENABLED_12',
-  /** MimeType application/vnd.ms-powerpoint.template.macroEnabled.12 */
+  /** application/vnd.ms-powerpoint.template.macroEnabled.12 mime type. */
   ApplicationVndMsPowerpointTemplateMacroenabled_12 = 'APPLICATION_VND_MS_POWERPOINT_TEMPLATE_MACROENABLED_12',
-  /** MimeType application/vnd.ms-project */
+  /** application/vnd.ms-project mime type. */
   ApplicationVndMsProject = 'APPLICATION_VND_MS_PROJECT',
-  /** MimeType application/vnd.ms-word.document.macroEnabled.12 */
+  /** application/vnd.ms-word.document.macroEnabled.12 mime type. */
   ApplicationVndMsWordDocumentMacroenabled_12 = 'APPLICATION_VND_MS_WORD_DOCUMENT_MACROENABLED_12',
-  /** MimeType application/vnd.ms-word.template.macroEnabled.12 */
+  /** application/vnd.ms-word.template.macroEnabled.12 mime type. */
   ApplicationVndMsWordTemplateMacroenabled_12 = 'APPLICATION_VND_MS_WORD_TEMPLATE_MACROENABLED_12',
-  /** MimeType application/vnd.ms-write */
+  /** application/vnd.ms-write mime type. */
   ApplicationVndMsWrite = 'APPLICATION_VND_MS_WRITE',
-  /** MimeType application/vnd.ms-xpsdocument */
+  /** application/vnd.ms-xpsdocument mime type. */
   ApplicationVndMsXpsdocument = 'APPLICATION_VND_MS_XPSDOCUMENT',
-  /** MimeType application/vnd.oasis.opendocument.chart */
+  /** application/vnd.oasis.opendocument.chart mime type. */
   ApplicationVndOasisOpendocumentChart = 'APPLICATION_VND_OASIS_OPENDOCUMENT_CHART',
-  /** MimeType application/vnd.oasis.opendocument.database */
+  /** application/vnd.oasis.opendocument.database mime type. */
   ApplicationVndOasisOpendocumentDatabase = 'APPLICATION_VND_OASIS_OPENDOCUMENT_DATABASE',
-  /** MimeType application/vnd.oasis.opendocument.formula */
+  /** application/vnd.oasis.opendocument.formula mime type. */
   ApplicationVndOasisOpendocumentFormula = 'APPLICATION_VND_OASIS_OPENDOCUMENT_FORMULA',
-  /** MimeType application/vnd.oasis.opendocument.graphics */
+  /** application/vnd.oasis.opendocument.graphics mime type. */
   ApplicationVndOasisOpendocumentGraphics = 'APPLICATION_VND_OASIS_OPENDOCUMENT_GRAPHICS',
-  /** MimeType application/vnd.oasis.opendocument.presentation */
+  /** application/vnd.oasis.opendocument.presentation mime type. */
   ApplicationVndOasisOpendocumentPresentation = 'APPLICATION_VND_OASIS_OPENDOCUMENT_PRESENTATION',
-  /** MimeType application/vnd.oasis.opendocument.spreadsheet */
+  /** application/vnd.oasis.opendocument.spreadsheet mime type. */
   ApplicationVndOasisOpendocumentSpreadsheet = 'APPLICATION_VND_OASIS_OPENDOCUMENT_SPREADSHEET',
-  /** MimeType application/vnd.oasis.opendocument.text */
+  /** application/vnd.oasis.opendocument.text mime type. */
   ApplicationVndOasisOpendocumentText = 'APPLICATION_VND_OASIS_OPENDOCUMENT_TEXT',
-  /** MimeType application/vnd.openxmlformats-officedocument.presentationml.presentation */
+  /** application/vnd.openxmlformats-officedocument.presentationml.presentation mime type. */
   ApplicationVndOpenxmlformatsOfficedocumentPresentationmlPresentation = 'APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_PRESENTATIONML_PRESENTATION',
-  /** MimeType application/vnd.openxmlformats-officedocument.presentationml.slide */
+  /** application/vnd.openxmlformats-officedocument.presentationml.slide mime type. */
   ApplicationVndOpenxmlformatsOfficedocumentPresentationmlSlide = 'APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_PRESENTATIONML_SLIDE',
-  /** MimeType application/vnd.openxmlformats-officedocument.presentationml.slideshow */
+  /** application/vnd.openxmlformats-officedocument.presentationml.slideshow mime type. */
   ApplicationVndOpenxmlformatsOfficedocumentPresentationmlSlideshow = 'APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_PRESENTATIONML_SLIDESHOW',
-  /** MimeType application/vnd.openxmlformats-officedocument.presentationml.template */
+  /** application/vnd.openxmlformats-officedocument.presentationml.template mime type. */
   ApplicationVndOpenxmlformatsOfficedocumentPresentationmlTemplate = 'APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_PRESENTATIONML_TEMPLATE',
-  /** MimeType application/vnd.openxmlformats-officedocument.spreadsheetml.sheet */
+  /** application/vnd.openxmlformats-officedocument.spreadsheetml.sheet mime type. */
   ApplicationVndOpenxmlformatsOfficedocumentSpreadsheetmlSheet = 'APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_SPREADSHEETML_SHEET',
-  /** MimeType application/vnd.openxmlformats-officedocument.spreadsheetml.template */
+  /** application/vnd.openxmlformats-officedocument.spreadsheetml.template mime type. */
   ApplicationVndOpenxmlformatsOfficedocumentSpreadsheetmlTemplate = 'APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_SPREADSHEETML_TEMPLATE',
-  /** MimeType application/vnd.openxmlformats-officedocument.wordprocessingml.document */
+  /** application/vnd.openxmlformats-officedocument.wordprocessingml.document mime type. */
   ApplicationVndOpenxmlformatsOfficedocumentWordprocessingmlDocument = 'APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_WORDPROCESSINGML_DOCUMENT',
-  /** MimeType application/vnd.openxmlformats-officedocument.wordprocessingml.template */
+  /** application/vnd.openxmlformats-officedocument.wordprocessingml.template mime type. */
   ApplicationVndOpenxmlformatsOfficedocumentWordprocessingmlTemplate = 'APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_WORDPROCESSINGML_TEMPLATE',
-  /** MimeType application/wordperfect */
+  /** application/wordperfect mime type. */
   ApplicationWordperfect = 'APPLICATION_WORDPERFECT',
-  /** MimeType application/x-7z-compressed */
+  /** application/x-7z-compressed mime type. */
   ApplicationX_7ZCompressed = 'APPLICATION_X_7Z_COMPRESSED',
-  /** MimeType application/x-gzip */
+  /** application/x-gzip mime type. */
   ApplicationXGzip = 'APPLICATION_X_GZIP',
-  /** MimeType application/x-tar */
+  /** application/x-tar mime type. */
   ApplicationXTar = 'APPLICATION_X_TAR',
-  /** MimeType application/zip */
+  /** application/zip mime type. */
   ApplicationZip = 'APPLICATION_ZIP',
-  /** MimeType audio/aac */
+  /** audio/aac mime type. */
   AudioAac = 'AUDIO_AAC',
-  /** MimeType audio/flac */
+  /** audio/flac mime type. */
   AudioFlac = 'AUDIO_FLAC',
-  /** MimeType audio/midi */
+  /** audio/midi mime type. */
   AudioMidi = 'AUDIO_MIDI',
-  /** MimeType audio/mpeg */
+  /** audio/mpeg mime type. */
   AudioMpeg = 'AUDIO_MPEG',
-  /** MimeType audio/ogg */
+  /** audio/ogg mime type. */
   AudioOgg = 'AUDIO_OGG',
-  /** MimeType audio/wav */
+  /** audio/wav mime type. */
   AudioWav = 'AUDIO_WAV',
-  /** MimeType audio/x-matroska */
+  /** audio/x-matroska mime type. */
   AudioXMatroska = 'AUDIO_X_MATROSKA',
-  /** MimeType audio/x-ms-wax */
+  /** audio/x-ms-wax mime type. */
   AudioXMsWax = 'AUDIO_X_MS_WAX',
-  /** MimeType audio/x-ms-wma */
+  /** audio/x-ms-wma mime type. */
   AudioXMsWma = 'AUDIO_X_MS_WMA',
-  /** MimeType audio/x-realaudio */
+  /** audio/x-realaudio mime type. */
   AudioXRealaudio = 'AUDIO_X_REALAUDIO',
-  /** MimeType image/bmp */
+  /** image/bmp mime type. */
   ImageBmp = 'IMAGE_BMP',
-  /** MimeType image/gif */
+  /** image/gif mime type. */
   ImageGif = 'IMAGE_GIF',
-  /** MimeType image/heic */
+  /** image/heic mime type. */
   ImageHeic = 'IMAGE_HEIC',
-  /** MimeType image/jpeg */
+  /** image/jpeg mime type. */
   ImageJpeg = 'IMAGE_JPEG',
-  /** MimeType image/png */
+  /** image/png mime type. */
   ImagePng = 'IMAGE_PNG',
-  /** MimeType image/tiff */
+  /** image/tiff mime type. */
   ImageTiff = 'IMAGE_TIFF',
-  /** MimeType image/webp */
+  /** image/webp mime type. */
   ImageWebp = 'IMAGE_WEBP',
-  /** MimeType image/x-icon */
+  /** image/x-icon mime type. */
   ImageXIcon = 'IMAGE_X_ICON',
-  /** MimeType text/calendar */
+  /** text/calendar mime type. */
   TextCalendar = 'TEXT_CALENDAR',
-  /** MimeType text/css */
+  /** text/css mime type. */
   TextCss = 'TEXT_CSS',
-  /** MimeType text/csv */
+  /** text/csv mime type. */
   TextCsv = 'TEXT_CSV',
-  /** MimeType text/plain */
+  /** text/plain mime type. */
   TextPlain = 'TEXT_PLAIN',
-  /** MimeType text/richtext */
+  /** text/richtext mime type. */
   TextRichtext = 'TEXT_RICHTEXT',
-  /** MimeType text/tab-separated-values */
+  /** text/tab-separated-values mime type. */
   TextTabSeparatedValues = 'TEXT_TAB_SEPARATED_VALUES',
-  /** MimeType text/vtt */
+  /** text/vtt mime type. */
   TextVtt = 'TEXT_VTT',
-  /** MimeType video/3gpp */
+  /** video/3gpp mime type. */
   Video_3Gpp = 'VIDEO_3GPP',
-  /** MimeType video/3gpp2 */
+  /** video/3gpp2 mime type. */
   Video_3Gpp2 = 'VIDEO_3GPP2',
-  /** MimeType video/avi */
+  /** video/avi mime type. */
   VideoAvi = 'VIDEO_AVI',
-  /** MimeType video/divx */
+  /** video/divx mime type. */
   VideoDivx = 'VIDEO_DIVX',
-  /** MimeType video/mp4 */
+  /** video/mp4 mime type. */
   VideoMp4 = 'VIDEO_MP4',
-  /** MimeType video/mpeg */
+  /** video/mpeg mime type. */
   VideoMpeg = 'VIDEO_MPEG',
-  /** MimeType video/ogg */
+  /** video/ogg mime type. */
   VideoOgg = 'VIDEO_OGG',
-  /** MimeType video/quicktime */
+  /** video/quicktime mime type. */
   VideoQuicktime = 'VIDEO_QUICKTIME',
-  /** MimeType video/webm */
+  /** video/webm mime type. */
   VideoWebm = 'VIDEO_WEBM',
-  /** MimeType video/x-flv */
+  /** video/x-flv mime type. */
   VideoXFlv = 'VIDEO_X_FLV',
-  /** MimeType video/x-matroska */
+  /** video/x-matroska mime type. */
   VideoXMatroska = 'VIDEO_X_MATROSKA',
-  /** MimeType video/x-ms-asf */
+  /** video/x-ms-asf mime type. */
   VideoXMsAsf = 'VIDEO_X_MS_ASF',
-  /** MimeType video/x-ms-wm */
+  /** video/x-ms-wm mime type. */
   VideoXMsWm = 'VIDEO_X_MS_WM',
-  /** MimeType video/x-ms-wmv */
+  /** video/x-ms-wmv mime type. */
   VideoXMsWmv = 'VIDEO_X_MS_WMV',
-  /** MimeType video/x-ms-wmx */
+  /** video/x-ms-wmx mime type. */
   VideoXMsWmx = 'VIDEO_X_MS_WMX'
 }
+
+/** The newsletter type */
+export type Newsletter = ContentNode & DatabaseIdentifier & MenuItemLinkable & Node & NodeWithContentEditor & NodeWithExcerpt & NodeWithFeaturedImage & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable & {
+  __typename?: 'Newsletter';
+  /** The content of the post. */
+  content?: Maybe<Scalars['String']['output']>;
+  /** Connection between the ContentNode type and the ContentType type */
+  contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
+  /** The name of the Content Type the node belongs to */
+  contentTypeName: Scalars['String']['output'];
+  /** The unique identifier stored in the database */
+  databaseId: Scalars['Int']['output'];
+  /** Post publishing date. */
+  date?: Maybe<Scalars['String']['output']>;
+  /** The publishing date set in GMT. */
+  dateGmt?: Maybe<Scalars['String']['output']>;
+  /** The desired slug of the post */
+  desiredSlug?: Maybe<Scalars['String']['output']>;
+  /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
+  editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
+  /** The RSS enclosure for the object */
+  enclosure?: Maybe<Scalars['String']['output']>;
+  /** Connection between the ContentNode type and the EnqueuedScript type */
+  enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
+  /** Connection between the ContentNode type and the EnqueuedStylesheet type */
+  enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
+  /** The excerpt of the post. */
+  excerpt?: Maybe<Scalars['String']['output']>;
+  /** Connection between the NodeWithFeaturedImage type and the MediaItem type */
+  featuredImage?: Maybe<NodeWithFeaturedImageToMediaItemConnectionEdge>;
+  /** The database identifier for the featured image node assigned to the content node */
+  featuredImageDatabaseId?: Maybe<Scalars['Int']['output']>;
+  /** Globally unique ID of the featured image assigned to the node */
+  featuredImageId?: Maybe<Scalars['ID']['output']>;
+  /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
+  guid?: Maybe<Scalars['String']['output']>;
+  /** The globally unique identifier of the newsletter object. */
+  id: Scalars['ID']['output'];
+  /** Whether the node is a Content Node */
+  isContentNode: Scalars['Boolean']['output'];
+  /** Whether the object is a node in the preview state */
+  isPreview?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether the object is restricted from the current viewer */
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether the node is a Term */
+  isTermNode: Scalars['Boolean']['output'];
+  /** The user that most recently edited the node */
+  lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
+  /** The permalink of the post */
+  link?: Maybe<Scalars['String']['output']>;
+  /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
+  modifiedGmt?: Maybe<Scalars['String']['output']>;
+  /**
+   * The id field matches the WP_Post-&gt;ID field.
+   * @deprecated Deprecated in favor of the databaseId field
+   */
+  newsletterId: Scalars['Int']['output'];
+  /** Added to the GraphQL Schema because the ACF Field Group &quot;Newsletter Options&quot; was set to Show in GraphQL. */
+  newsletterOptions?: Maybe<Newsletter_Newsletteroptions>;
+  /** Connection between the Newsletter type and the newsletter type */
+  preview?: Maybe<NewsletterToPreviewConnectionEdge>;
+  /** The database id of the preview node */
+  previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
+  /** Whether the object is a node in the preview state */
+  previewRevisionId?: Maybe<Scalars['ID']['output']>;
+  /** The Yoast SEO data of the ContentNode */
+  seo?: Maybe<PostTypeSeo>;
+  /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
+  slug?: Maybe<Scalars['String']['output']>;
+  /** The current status of the object */
+  status?: Maybe<Scalars['String']['output']>;
+  /** The template assigned to the node */
+  template?: Maybe<ContentTemplate>;
+  /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
+  title?: Maybe<Scalars['String']['output']>;
+  /** The unique resource identifier path */
+  uri?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** The newsletter type */
+export type NewsletterContentArgs = {
+  format?: InputMaybe<PostObjectFieldFormatEnum>;
+};
+
+
+/** The newsletter type */
+export type NewsletterEnqueuedScriptsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** The newsletter type */
+export type NewsletterEnqueuedStylesheetsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** The newsletter type */
+export type NewsletterExcerptArgs = {
+  format?: InputMaybe<PostObjectFieldFormatEnum>;
+};
+
+
+/** The newsletter type */
+export type NewsletterTitleArgs = {
+  format?: InputMaybe<PostObjectFieldFormatEnum>;
+};
+
+/** Connection to newsletter Nodes */
+export type NewsletterConnection = {
+  /** A list of edges (relational context) between RootQuery and connected newsletter Nodes */
+  edges: Array<NewsletterConnectionEdge>;
+  /** A list of connected newsletter Nodes */
+  nodes: Array<Newsletter>;
+  /** Information about pagination in a connection. */
+  pageInfo: NewsletterConnectionPageInfo;
+};
+
+/** Edge between a Node and a connected newsletter */
+export type NewsletterConnectionEdge = {
+  /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The connected newsletter Node */
+  node: Newsletter;
+};
+
+/** Page Info on the connected NewsletterConnectionEdge */
+export type NewsletterConnectionPageInfo = {
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** The Type of Identifier used to fetch a single resource. Default is ID. */
+export enum NewsletterIdType {
+  /** Identify a resource by the Database ID. */
+  DatabaseId = 'DATABASE_ID',
+  /** Identify a resource by the (hashed) Global ID. */
+  Id = 'ID',
+  /** Identify a resource by the slug. Available to non-hierarchcial Types where the slug is a unique identifier. */
+  Slug = 'SLUG',
+  /** Identify a resource by the URI. */
+  Uri = 'URI'
+}
+
+/** Connection between the Newsletter type and the newsletter type */
+export type NewsletterToPreviewConnectionEdge = Edge & NewsletterConnectionEdge & OneToOneConnection & {
+  __typename?: 'NewsletterToPreviewConnectionEdge';
+  /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The node of the connection, without the edges */
+  node: Newsletter;
+};
+
+/** Field Group */
+export type Newsletter_Newsletteroptions = AcfFieldGroup & {
+  __typename?: 'Newsletter_Newsletteroptions';
+  /** Text to use in sign up form&#039;s submit button. */
+  buttonLabel?: Maybe<Scalars['String']['output']>;
+  /** The name of the ACF Field Group */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
+  /** To get the ID of the list, in CM, go to &lt;b&gt;Lists &amp; Subscribers&lt;/b&gt;, choose the list you want and click on &lt;b&gt;change name/type&lt;/b&gt;. */
+  listId?: Maybe<Scalars['String']['output']>;
+  /** Text to use as the label next to opt-in checkbox. Should include conformation of accepting privacy terms and include a link to a privacy policy page. */
+  optInText?: Maybe<Scalars['String']['output']>;
+};
 
 /** An object with an ID */
 export type Node = {
@@ -10240,8 +11513,6 @@ export type PostFormat = DatabaseIdentifier & Node & TermNode & UniformResourceI
   isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the node is a Term */
   isTermNode: Scalars['Boolean']['output'];
-  /** Added to the GraphQL Schema because the ACF Field Group &quot;Landing Page&quot; was set to Show in GraphQL. */
-  landingPage?: Maybe<PostFormat_Landingpage>;
   /** The link to the term */
   link?: Maybe<Scalars['String']['output']>;
   /** The human friendly name of the object. */
@@ -10259,8 +11530,6 @@ export type PostFormat = DatabaseIdentifier & Node & TermNode & UniformResourceI
   slug?: Maybe<Scalars['String']['output']>;
   /** Connection between the PostFormat type and the Taxonomy type */
   taxonomy?: Maybe<PostFormatToTaxonomyConnectionEdge>;
-  /** Added to the GraphQL Schema because the ACF Field Group &quot;Taxonomy Images&quot; was set to Show in GraphQL. */
-  taxonomyImages?: Maybe<PostFormat_Taxonomyimages>;
   /** The name of the taxonomy that the object is associated with */
   taxonomyName?: Maybe<Scalars['String']['output']>;
   /** The ID of the term group that this term object belongs to */
@@ -10538,25 +11807,6 @@ export type PostFormatToTaxonomyConnectionEdge = Edge & OneToOneConnection & Tax
   cursor?: Maybe<Scalars['String']['output']>;
   /** The node of the connection, without the edges */
   node: Taxonomy;
-};
-
-/** Field Group */
-export type PostFormat_Landingpage = AcfFieldGroup & {
-  __typename?: 'PostFormat_Landingpage';
-  featuredPosts?: Maybe<Array<Maybe<PostFormat_Landingpage_FeaturedPosts>>>;
-  /** The name of the ACF Field Group */
-  fieldGroupName?: Maybe<Scalars['String']['output']>;
-};
-
-export type PostFormat_Landingpage_FeaturedPosts = Post;
-
-/** Field Group */
-export type PostFormat_Taxonomyimages = AcfFieldGroup & {
-  __typename?: 'PostFormat_Taxonomyimages';
-  /** The name of the ACF Field Group */
-  fieldGroupName?: Maybe<Scalars['String']['output']>;
-  imageBanner?: Maybe<MediaItem>;
-  logo?: Maybe<MediaItem>;
 };
 
 /** The Type of Identifier used to fetch a single resource. Default is ID. */
@@ -14129,8 +15379,6 @@ export type ResourceDevelopmentTag = DatabaseIdentifier & MenuItemLinkable & Nod
   isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the node is a Term */
   isTermNode: Scalars['Boolean']['output'];
-  /** Added to the GraphQL Schema because the ACF Field Group &quot;Landing Page&quot; was set to Show in GraphQL. */
-  landingPage?: Maybe<ResourceDevelopmentTag_Landingpage>;
   /** The link to the term */
   link?: Maybe<Scalars['String']['output']>;
   /** The human friendly name of the object. */
@@ -14148,8 +15396,6 @@ export type ResourceDevelopmentTag = DatabaseIdentifier & MenuItemLinkable & Nod
   slug?: Maybe<Scalars['String']['output']>;
   /** Connection between the ResourceDevelopmentTag type and the Taxonomy type */
   taxonomy?: Maybe<ResourceDevelopmentTagToTaxonomyConnectionEdge>;
-  /** Added to the GraphQL Schema because the ACF Field Group &quot;Taxonomy Images&quot; was set to Show in GraphQL. */
-  taxonomyImages?: Maybe<ResourceDevelopmentTag_Taxonomyimages>;
   /** The name of the taxonomy that the object is associated with */
   taxonomyName?: Maybe<Scalars['String']['output']>;
   /** The ID of the term group that this term object belongs to */
@@ -14429,25 +15675,6 @@ export type ResourceDevelopmentTagToTaxonomyConnectionEdge = Edge & OneToOneConn
   node: Taxonomy;
 };
 
-/** Field Group */
-export type ResourceDevelopmentTag_Landingpage = AcfFieldGroup & {
-  __typename?: 'ResourceDevelopmentTag_Landingpage';
-  featuredPosts?: Maybe<Array<Maybe<ResourceDevelopmentTag_Landingpage_FeaturedPosts>>>;
-  /** The name of the ACF Field Group */
-  fieldGroupName?: Maybe<Scalars['String']['output']>;
-};
-
-export type ResourceDevelopmentTag_Landingpage_FeaturedPosts = Post;
-
-/** Field Group */
-export type ResourceDevelopmentTag_Taxonomyimages = AcfFieldGroup & {
-  __typename?: 'ResourceDevelopmentTag_Taxonomyimages';
-  /** The name of the ACF Field Group */
-  fieldGroupName?: Maybe<Scalars['String']['output']>;
-  imageBanner?: Maybe<MediaItem>;
-  logo?: Maybe<MediaItem>;
-};
-
 /** Input for the restoreComment mutation. */
 export type RestoreCommentInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
@@ -14470,6 +15697,8 @@ export type RestoreCommentPayload = {
 /** The root mutation */
 export type RootMutation = {
   __typename?: 'RootMutation';
+  /** The createCallToAction mutation */
+  createCallToAction?: Maybe<CreateCallToActionPayload>;
   /** The createCategory mutation */
   createCategory?: Maybe<CreateCategoryPayload>;
   /** The createCity mutation */
@@ -14482,12 +15711,18 @@ export type RootMutation = {
   createContributor?: Maybe<CreateContributorPayload>;
   /** The createCountry mutation */
   createCountry?: Maybe<CreateCountryPayload>;
+  /** The createCtaRegion mutation */
+  createCtaRegion?: Maybe<CreateCtaRegionPayload>;
+  /** The createCtaRegionType mutation */
+  createCtaRegionType?: Maybe<CreateCtaRegionTypePayload>;
   /** The createEpisode mutation */
   createEpisode?: Maybe<CreateEpisodePayload>;
   /** The createLicense mutation */
   createLicense?: Maybe<CreateLicensePayload>;
   /** The createMediaItem mutation */
   createMediaItem?: Maybe<CreateMediaItemPayload>;
+  /** The createNewsletter mutation */
+  createNewsletter?: Maybe<CreateNewsletterPayload>;
   /** The createPage mutation */
   createPage?: Maybe<CreatePagePayload>;
   /** The createPerson mutation */
@@ -14514,6 +15749,8 @@ export type RootMutation = {
   createTag?: Maybe<CreateTagPayload>;
   /** The createUser mutation */
   createUser?: Maybe<CreateUserPayload>;
+  /** The deleteCallToAction mutation */
+  deleteCallToAction?: Maybe<DeleteCallToActionPayload>;
   /** The deleteCategory mutation */
   deleteCategory?: Maybe<DeleteCategoryPayload>;
   /** The deleteCity mutation */
@@ -14526,12 +15763,18 @@ export type RootMutation = {
   deleteContributor?: Maybe<DeleteContributorPayload>;
   /** The deleteCountry mutation */
   deleteCountry?: Maybe<DeleteCountryPayload>;
+  /** The deleteCtaRegion mutation */
+  deleteCtaRegion?: Maybe<DeleteCtaRegionPayload>;
+  /** The deleteCtaRegionType mutation */
+  deleteCtaRegionType?: Maybe<DeleteCtaRegionTypePayload>;
   /** The deleteEpisode mutation */
   deleteEpisode?: Maybe<DeleteEpisodePayload>;
   /** The deleteLicense mutation */
   deleteLicense?: Maybe<DeleteLicensePayload>;
   /** The deleteMediaItem mutation */
   deleteMediaItem?: Maybe<DeleteMediaItemPayload>;
+  /** The deleteNewsletter mutation */
+  deleteNewsletter?: Maybe<DeleteNewsletterPayload>;
   /** The deletePage mutation */
   deletePage?: Maybe<DeletePagePayload>;
   /** The deletePerson mutation */
@@ -14568,6 +15811,8 @@ export type RootMutation = {
   restoreComment?: Maybe<RestoreCommentPayload>;
   /** Send password reset email to user */
   sendPasswordResetEmail?: Maybe<SendPasswordResetEmailPayload>;
+  /** The updateCallToAction mutation */
+  updateCallToAction?: Maybe<UpdateCallToActionPayload>;
   /** The updateCategory mutation */
   updateCategory?: Maybe<UpdateCategoryPayload>;
   /** The updateCity mutation */
@@ -14580,12 +15825,18 @@ export type RootMutation = {
   updateContributor?: Maybe<UpdateContributorPayload>;
   /** The updateCountry mutation */
   updateCountry?: Maybe<UpdateCountryPayload>;
+  /** The updateCtaRegion mutation */
+  updateCtaRegion?: Maybe<UpdateCtaRegionPayload>;
+  /** The updateCtaRegionType mutation */
+  updateCtaRegionType?: Maybe<UpdateCtaRegionTypePayload>;
   /** The updateEpisode mutation */
   updateEpisode?: Maybe<UpdateEpisodePayload>;
   /** The updateLicense mutation */
   updateLicense?: Maybe<UpdateLicensePayload>;
   /** The updateMediaItem mutation */
   updateMediaItem?: Maybe<UpdateMediaItemPayload>;
+  /** The updateNewsletter mutation */
+  updateNewsletter?: Maybe<UpdateNewsletterPayload>;
   /** The updatePage mutation */
   updatePage?: Maybe<UpdatePagePayload>;
   /** The updatePerson mutation */
@@ -14614,6 +15865,12 @@ export type RootMutation = {
   updateTag?: Maybe<UpdateTagPayload>;
   /** The updateUser mutation */
   updateUser?: Maybe<UpdateUserPayload>;
+};
+
+
+/** The root mutation */
+export type RootMutationCreateCallToActionArgs = {
+  input: CreateCallToActionInput;
 };
 
 
@@ -14654,6 +15911,18 @@ export type RootMutationCreateCountryArgs = {
 
 
 /** The root mutation */
+export type RootMutationCreateCtaRegionArgs = {
+  input: CreateCtaRegionInput;
+};
+
+
+/** The root mutation */
+export type RootMutationCreateCtaRegionTypeArgs = {
+  input: CreateCtaRegionTypeInput;
+};
+
+
+/** The root mutation */
 export type RootMutationCreateEpisodeArgs = {
   input: CreateEpisodeInput;
 };
@@ -14668,6 +15937,12 @@ export type RootMutationCreateLicenseArgs = {
 /** The root mutation */
 export type RootMutationCreateMediaItemArgs = {
   input: CreateMediaItemInput;
+};
+
+
+/** The root mutation */
+export type RootMutationCreateNewsletterArgs = {
+  input: CreateNewsletterInput;
 };
 
 
@@ -14750,6 +16025,12 @@ export type RootMutationCreateUserArgs = {
 
 
 /** The root mutation */
+export type RootMutationDeleteCallToActionArgs = {
+  input: DeleteCallToActionInput;
+};
+
+
+/** The root mutation */
 export type RootMutationDeleteCategoryArgs = {
   input: DeleteCategoryInput;
 };
@@ -14786,6 +16067,18 @@ export type RootMutationDeleteCountryArgs = {
 
 
 /** The root mutation */
+export type RootMutationDeleteCtaRegionArgs = {
+  input: DeleteCtaRegionInput;
+};
+
+
+/** The root mutation */
+export type RootMutationDeleteCtaRegionTypeArgs = {
+  input: DeleteCtaRegionTypeInput;
+};
+
+
+/** The root mutation */
 export type RootMutationDeleteEpisodeArgs = {
   input: DeleteEpisodeInput;
 };
@@ -14800,6 +16093,12 @@ export type RootMutationDeleteLicenseArgs = {
 /** The root mutation */
 export type RootMutationDeleteMediaItemArgs = {
   input: DeleteMediaItemInput;
+};
+
+
+/** The root mutation */
+export type RootMutationDeleteNewsletterArgs = {
+  input: DeleteNewsletterInput;
 };
 
 
@@ -14912,6 +16211,12 @@ export type RootMutationSendPasswordResetEmailArgs = {
 
 
 /** The root mutation */
+export type RootMutationUpdateCallToActionArgs = {
+  input: UpdateCallToActionInput;
+};
+
+
+/** The root mutation */
 export type RootMutationUpdateCategoryArgs = {
   input: UpdateCategoryInput;
 };
@@ -14948,6 +16253,18 @@ export type RootMutationUpdateCountryArgs = {
 
 
 /** The root mutation */
+export type RootMutationUpdateCtaRegionArgs = {
+  input: UpdateCtaRegionInput;
+};
+
+
+/** The root mutation */
+export type RootMutationUpdateCtaRegionTypeArgs = {
+  input: UpdateCtaRegionTypeInput;
+};
+
+
+/** The root mutation */
 export type RootMutationUpdateEpisodeArgs = {
   input: UpdateEpisodeInput;
 };
@@ -14962,6 +16279,12 @@ export type RootMutationUpdateLicenseArgs = {
 /** The root mutation */
 export type RootMutationUpdateMediaItemArgs = {
   input: UpdateMediaItemInput;
+};
+
+
+/** The root mutation */
+export type RootMutationUpdateNewsletterArgs = {
+  input: UpdateNewsletterInput;
 };
 
 
@@ -15053,6 +16376,15 @@ export type RootQuery = {
   __typename?: 'RootQuery';
   /** Entry point to get all settings for the site */
   allSettings?: Maybe<Settings>;
+  /** An object of the callToAction Type. Manages the Call To Action custom post type */
+  callToAction?: Maybe<CallToAction>;
+  /**
+   * A callToAction object
+   * @deprecated Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)
+   */
+  callToActionBy?: Maybe<CallToAction>;
+  /** Connection between the RootQuery type and the callToAction type */
+  callToActions?: Maybe<RootQueryToCallToActionConnection>;
   /** Connection between the RootQuery type and the category type */
   categories?: Maybe<RootQueryToCategoryConnection>;
   /** A 0bject */
@@ -15085,6 +16417,19 @@ export type RootQuery = {
   countries?: Maybe<RootQueryToCountryConnection>;
   /** A 0bject */
   country?: Maybe<Country>;
+  /** An object of the ctaRegion Type. Manages the CTA Region custom post type */
+  ctaRegion?: Maybe<CtaRegion>;
+  /**
+   * A ctaRegion object
+   * @deprecated Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)
+   */
+  ctaRegionBy?: Maybe<CtaRegion>;
+  /** A 0bject */
+  ctaRegionType?: Maybe<CtaRegionType>;
+  /** Connection between the RootQuery type and the ctaRegionType type */
+  ctaRegionTypes?: Maybe<RootQueryToCtaRegionTypeConnection>;
+  /** Connection between the RootQuery type and the ctaRegion type */
+  ctaRegions?: Maybe<RootQueryToCtaRegionConnection>;
   /** Fields of the &#039;DiscussionSettings&#039; settings group */
   discussionSettings?: Maybe<DiscussionSettings>;
   /** An object of the episode Type. Manages the Episode custom post type */
@@ -15119,6 +16464,15 @@ export type RootQuery = {
   menuItems?: Maybe<RootQueryToMenuItemConnection>;
   /** Connection between the RootQuery type and the Menu type */
   menus?: Maybe<RootQueryToMenuConnection>;
+  /** An object of the newsletter Type. Manages the Newsletter custom post type */
+  newsletter?: Maybe<Newsletter>;
+  /**
+   * A newsletter object
+   * @deprecated Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)
+   */
+  newsletterBy?: Maybe<Newsletter>;
+  /** Connection between the RootQuery type and the newsletter type */
+  newsletters?: Maybe<RootQueryToNewsletterConnection>;
   /** Fetches an object given its ID */
   node?: Maybe<Node>;
   /** Fetches an object given its Unique Resource Identifier */
@@ -15224,6 +16578,33 @@ export type RootQuery = {
   viewer?: Maybe<User>;
   /** Fields of the &#039;WritingSettings&#039; settings group */
   writingSettings?: Maybe<WritingSettings>;
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryCallToActionArgs = {
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
+  idType?: InputMaybe<CallToActionIdType>;
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryCallToActionByArgs = {
+  callToActionId?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryCallToActionsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<RootQueryToCallToActionConnectionWhereArgs>;
 };
 
 
@@ -15365,6 +16746,50 @@ export type RootQueryCountryArgs = {
 
 
 /** The root entry point into the Graph */
+export type RootQueryCtaRegionArgs = {
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
+  idType?: InputMaybe<CtaRegionIdType>;
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryCtaRegionByArgs = {
+  ctaRegionId?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryCtaRegionTypeArgs = {
+  id: Scalars['ID']['input'];
+  idType?: InputMaybe<CtaRegionTypeIdType>;
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryCtaRegionTypesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<RootQueryToCtaRegionTypeConnectionWhereArgs>;
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryCtaRegionsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<RootQueryToCtaRegionConnectionWhereArgs>;
+};
+
+
+/** The root entry point into the Graph */
 export type RootQueryEpisodeArgs = {
   asPreview?: InputMaybe<Scalars['Boolean']['input']>;
   id: Scalars['ID']['input'];
@@ -15466,6 +16891,33 @@ export type RootQueryMenusArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToMenuConnectionWhereArgs>;
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryNewsletterArgs = {
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
+  idType?: InputMaybe<NewsletterIdType>;
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryNewsletterByArgs = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  newsletterId?: InputMaybe<Scalars['Int']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryNewslettersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<RootQueryToNewsletterConnectionWhereArgs>;
 };
 
 
@@ -15836,6 +17288,79 @@ export type RootQueryUsersArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToUserConnectionWhereArgs>;
+};
+
+/** Connection between the RootQuery type and the callToAction type */
+export type RootQueryToCallToActionConnection = CallToActionConnection & Connection & {
+  __typename?: 'RootQueryToCallToActionConnection';
+  /** Edges for the RootQueryToCallToActionConnection connection */
+  edges: Array<RootQueryToCallToActionConnectionEdge>;
+  /** The nodes of the connection, without the edges */
+  nodes: Array<CallToAction>;
+  /** Information about pagination in a connection. */
+  pageInfo: RootQueryToCallToActionConnectionPageInfo;
+};
+
+/** An edge in a connection */
+export type RootQueryToCallToActionConnectionEdge = CallToActionConnectionEdge & Edge & {
+  __typename?: 'RootQueryToCallToActionConnectionEdge';
+  /** A cursor for use in pagination */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The item at the end of the edge */
+  node: CallToAction;
+};
+
+/** Page Info on the &quot;RootQueryToCallToActionConnection&quot; */
+export type RootQueryToCallToActionConnectionPageInfo = CallToActionConnectionPageInfo & PageInfo & WpPageInfo & {
+  __typename?: 'RootQueryToCallToActionConnectionPageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** Arguments for filtering the RootQueryToCallToActionConnection connection */
+export type RootQueryToCallToActionConnectionWhereArgs = {
+  /** Filter the connection based on dates */
+  dateQuery?: InputMaybe<DateQueryInput>;
+  /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Specific database ID of the object */
+  id?: InputMaybe<Scalars['Int']['input']>;
+  /** Array of IDs for the objects to retrieve */
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Get objects with a specific mimeType property */
+  mimeType?: InputMaybe<MimeTypeEnum>;
+  /** Slug / post_name of the object */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** Specify objects to retrieve. Use slugs */
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** What paramater to use to order the objects by. */
+  orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
+  /** Use ID to return only children. Use 0 to return only top-level items */
+  parent?: InputMaybe<Scalars['ID']['input']>;
+  /** Specify objects whose parent is in an array */
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Specify posts whose parent is not in an array */
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Show posts with a specific password. */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** Show Posts based on a keyword search */
+  search?: InputMaybe<Scalars['String']['input']>;
+  /** Retrieve posts where post status is in an array. */
+  stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
+  /** Show posts with a specific status. */
+  status?: InputMaybe<PostStatusEnum>;
+  /** Title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the category type */
@@ -16450,6 +17975,160 @@ export type RootQueryToCountryConnectionWhereArgs = {
   updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+/** Connection between the RootQuery type and the ctaRegion type */
+export type RootQueryToCtaRegionConnection = Connection & CtaRegionConnection & {
+  __typename?: 'RootQueryToCtaRegionConnection';
+  /** Edges for the RootQueryToCtaRegionConnection connection */
+  edges: Array<RootQueryToCtaRegionConnectionEdge>;
+  /** The nodes of the connection, without the edges */
+  nodes: Array<CtaRegion>;
+  /** Information about pagination in a connection. */
+  pageInfo: RootQueryToCtaRegionConnectionPageInfo;
+};
+
+/** An edge in a connection */
+export type RootQueryToCtaRegionConnectionEdge = CtaRegionConnectionEdge & Edge & {
+  __typename?: 'RootQueryToCtaRegionConnectionEdge';
+  /** A cursor for use in pagination */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The item at the end of the edge */
+  node: CtaRegion;
+};
+
+/** Page Info on the &quot;RootQueryToCtaRegionConnection&quot; */
+export type RootQueryToCtaRegionConnectionPageInfo = CtaRegionConnectionPageInfo & PageInfo & WpPageInfo & {
+  __typename?: 'RootQueryToCtaRegionConnectionPageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** Arguments for filtering the RootQueryToCtaRegionConnection connection */
+export type RootQueryToCtaRegionConnectionWhereArgs = {
+  /** Filter the connection based on dates */
+  dateQuery?: InputMaybe<DateQueryInput>;
+  /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Specific database ID of the object */
+  id?: InputMaybe<Scalars['Int']['input']>;
+  /** Array of IDs for the objects to retrieve */
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Get objects with a specific mimeType property */
+  mimeType?: InputMaybe<MimeTypeEnum>;
+  /** Slug / post_name of the object */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** Specify objects to retrieve. Use slugs */
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** What paramater to use to order the objects by. */
+  orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
+  /** Use ID to return only children. Use 0 to return only top-level items */
+  parent?: InputMaybe<Scalars['ID']['input']>;
+  /** Specify objects whose parent is in an array */
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Specify posts whose parent is not in an array */
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Show posts with a specific password. */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** Show Posts based on a keyword search */
+  search?: InputMaybe<Scalars['String']['input']>;
+  /** Retrieve posts where post status is in an array. */
+  stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
+  /** Show posts with a specific status. */
+  status?: InputMaybe<PostStatusEnum>;
+  /** Title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Connection between the RootQuery type and the ctaRegionType type */
+export type RootQueryToCtaRegionTypeConnection = Connection & CtaRegionTypeConnection & {
+  __typename?: 'RootQueryToCtaRegionTypeConnection';
+  /** Edges for the RootQueryToCtaRegionTypeConnection connection */
+  edges: Array<RootQueryToCtaRegionTypeConnectionEdge>;
+  /** The nodes of the connection, without the edges */
+  nodes: Array<CtaRegionType>;
+  /** Information about pagination in a connection. */
+  pageInfo: RootQueryToCtaRegionTypeConnectionPageInfo;
+};
+
+/** An edge in a connection */
+export type RootQueryToCtaRegionTypeConnectionEdge = CtaRegionTypeConnectionEdge & Edge & {
+  __typename?: 'RootQueryToCtaRegionTypeConnectionEdge';
+  /** A cursor for use in pagination */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The item at the end of the edge */
+  node: CtaRegionType;
+};
+
+/** Page Info on the &quot;RootQueryToCtaRegionTypeConnection&quot; */
+export type RootQueryToCtaRegionTypeConnectionPageInfo = CtaRegionTypeConnectionPageInfo & PageInfo & WpPageInfo & {
+  __typename?: 'RootQueryToCtaRegionTypeConnectionPageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** Arguments for filtering the RootQueryToCtaRegionTypeConnection connection */
+export type RootQueryToCtaRegionTypeConnectionWhereArgs = {
+  /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
+  /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
+  childOf?: InputMaybe<Scalars['Int']['input']>;
+  /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Retrieve terms where the description is LIKE the input value. Default empty. */
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
+  /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Array of term ids to include. Default empty array. */
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Array of names to return term(s) for. Default empty. */
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Retrieve terms where the name is LIKE the input value. Default empty. */
+  nameLike?: InputMaybe<Scalars['String']['input']>;
+  /** Array of object IDs. Results will be limited to terms associated with these objects. */
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Direction the connection should be ordered in */
+  order?: InputMaybe<OrderEnum>;
+  /** Field(s) to order terms by. Defaults to 'name'. */
+  orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
+  /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Parent term ID to retrieve direct-child terms of. Default empty. */
+  parent?: InputMaybe<Scalars['Int']['input']>;
+  /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
+  search?: InputMaybe<Scalars['String']['input']>;
+  /** Array of slugs to return term(s) for. Default empty. */
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Array of term taxonomy IDs, to match when querying terms. */
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Array of term taxonomy IDs, to match when querying terms. */
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Whether to prime meta caches for matched terms. Default true. */
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
 /** Connection between the RootQuery type and the EnqueuedScript type */
 export type RootQueryToEnqueuedScriptConnection = Connection & EnqueuedScriptConnection & {
   __typename?: 'RootQueryToEnqueuedScriptConnection';
@@ -16865,6 +18544,79 @@ export type RootQueryToMenuItemConnectionWhereArgs = {
   parentDatabaseId?: InputMaybe<Scalars['Int']['input']>;
   /** The ID of the parent menu object */
   parentId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+/** Connection between the RootQuery type and the newsletter type */
+export type RootQueryToNewsletterConnection = Connection & NewsletterConnection & {
+  __typename?: 'RootQueryToNewsletterConnection';
+  /** Edges for the RootQueryToNewsletterConnection connection */
+  edges: Array<RootQueryToNewsletterConnectionEdge>;
+  /** The nodes of the connection, without the edges */
+  nodes: Array<Newsletter>;
+  /** Information about pagination in a connection. */
+  pageInfo: RootQueryToNewsletterConnectionPageInfo;
+};
+
+/** An edge in a connection */
+export type RootQueryToNewsletterConnectionEdge = Edge & NewsletterConnectionEdge & {
+  __typename?: 'RootQueryToNewsletterConnectionEdge';
+  /** A cursor for use in pagination */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** The item at the end of the edge */
+  node: Newsletter;
+};
+
+/** Page Info on the &quot;RootQueryToNewsletterConnection&quot; */
+export type RootQueryToNewsletterConnectionPageInfo = NewsletterConnectionPageInfo & PageInfo & WpPageInfo & {
+  __typename?: 'RootQueryToNewsletterConnectionPageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** Raw schema for page */
+  seo?: Maybe<SeoPostTypePageInfo>;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+/** Arguments for filtering the RootQueryToNewsletterConnection connection */
+export type RootQueryToNewsletterConnectionWhereArgs = {
+  /** Filter the connection based on dates */
+  dateQuery?: InputMaybe<DateQueryInput>;
+  /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Specific database ID of the object */
+  id?: InputMaybe<Scalars['Int']['input']>;
+  /** Array of IDs for the objects to retrieve */
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Get objects with a specific mimeType property */
+  mimeType?: InputMaybe<MimeTypeEnum>;
+  /** Slug / post_name of the object */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** Specify objects to retrieve. Use slugs */
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** What paramater to use to order the objects by. */
+  orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
+  /** Use ID to return only children. Use 0 to return only top-level items */
+  parent?: InputMaybe<Scalars['ID']['input']>;
+  /** Specify objects whose parent is in an array */
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Specify posts whose parent is not in an array */
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  /** Show posts with a specific password. */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** Show Posts based on a keyword search */
+  search?: InputMaybe<Scalars['String']['input']>;
+  /** Retrieve posts where post status is in an array. */
+  stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
+  /** Show posts with a specific status. */
+  status?: InputMaybe<PostStatusEnum>;
+  /** Title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the page type */
@@ -18312,8 +20064,11 @@ export type SeoContentTypeArchive = {
 /** The Yoast SEO search appearance content types */
 export type SeoContentTypes = {
   __typename?: 'SEOContentTypes';
+  callToAction?: Maybe<SeoContentType>;
+  ctaRegion?: Maybe<SeoContentType>;
   episode?: Maybe<SeoContentType>;
   mediaItem?: Maybe<SeoContentType>;
+  newsletter?: Maybe<SeoContentType>;
   page?: Maybe<SeoContentType>;
   post?: Maybe<SeoContentType>;
   segment?: Maybe<SeoContentType>;
@@ -20722,8 +22477,6 @@ export type StoryFormat = DatabaseIdentifier & MenuItemLinkable & Node & TermNod
   isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the node is a Term */
   isTermNode: Scalars['Boolean']['output'];
-  /** Added to the GraphQL Schema because the ACF Field Group &quot;Landing Page&quot; was set to Show in GraphQL. */
-  landingPage?: Maybe<StoryFormat_Landingpage>;
   /** The link to the term */
   link?: Maybe<Scalars['String']['output']>;
   /** The human friendly name of the object. */
@@ -20741,8 +22494,6 @@ export type StoryFormat = DatabaseIdentifier & MenuItemLinkable & Node & TermNod
   storyFormatId?: Maybe<Scalars['Int']['output']>;
   /** Connection between the StoryFormat type and the Taxonomy type */
   taxonomy?: Maybe<StoryFormatToTaxonomyConnectionEdge>;
-  /** Added to the GraphQL Schema because the ACF Field Group &quot;Taxonomy Images&quot; was set to Show in GraphQL. */
-  taxonomyImages?: Maybe<StoryFormat_Taxonomyimages>;
   /** The name of the taxonomy that the object is associated with */
   taxonomyName?: Maybe<Scalars['String']['output']>;
   /** The ID of the term group that this term object belongs to */
@@ -21020,25 +22771,6 @@ export type StoryFormatToTaxonomyConnectionEdge = Edge & OneToOneConnection & Ta
   cursor?: Maybe<Scalars['String']['output']>;
   /** The node of the connection, without the edges */
   node: Taxonomy;
-};
-
-/** Field Group */
-export type StoryFormat_Landingpage = AcfFieldGroup & {
-  __typename?: 'StoryFormat_Landingpage';
-  featuredPosts?: Maybe<Array<Maybe<StoryFormat_Landingpage_FeaturedPosts>>>;
-  /** The name of the ACF Field Group */
-  fieldGroupName?: Maybe<Scalars['String']['output']>;
-};
-
-export type StoryFormat_Landingpage_FeaturedPosts = Post;
-
-/** Field Group */
-export type StoryFormat_Taxonomyimages = AcfFieldGroup & {
-  __typename?: 'StoryFormat_Taxonomyimages';
-  /** The name of the ACF Field Group */
-  fieldGroupName?: Maybe<Scalars['String']['output']>;
-  imageBanner?: Maybe<MediaItem>;
-  logo?: Maybe<MediaItem>;
 };
 
 /** The tag type */
@@ -21691,6 +23423,8 @@ export enum TaxonomyEnum {
   Contributor = 'CONTRIBUTOR',
   /** Taxonomy enum country */
   Country = 'COUNTRY',
+  /** Taxonomy enum cta_region_type */
+  Ctaregiontype = 'CTAREGIONTYPE',
   /** Taxonomy enum license */
   License = 'LICENSE',
   /** Taxonomy enum person */
@@ -22043,6 +23777,37 @@ export type UniformResourceIdentifiable = {
   uri?: Maybe<Scalars['String']['output']>;
 };
 
+/** Input for the updateCallToAction mutation. */
+export type UpdateCallToActionInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
+  date?: InputMaybe<Scalars['String']['input']>;
+  /** The ID of the callToAction object */
+  id: Scalars['ID']['input'];
+  /** Override the edit lock when another user is editing the post */
+  ignoreEditLock?: InputMaybe<Scalars['Boolean']['input']>;
+  /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** The password used to protect the content of the object */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** The slug of the object */
+  slug?: InputMaybe<Scalars['String']['input']>;
+  /** The status of the object */
+  status?: InputMaybe<PostStatusEnum>;
+  /** The title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The payload for the updateCallToAction mutation. */
+export type UpdateCallToActionPayload = {
+  __typename?: 'UpdateCallToActionPayload';
+  /** The Post object mutation type. */
+  callToAction?: Maybe<CallToAction>;
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+};
+
 /** Input for the updateCategory mutation. */
 export type UpdateCategoryInput = {
   /** The slug that the category will be an alias of */
@@ -22209,6 +23974,66 @@ export type UpdateCountryPayload = {
   country?: Maybe<Country>;
 };
 
+/** Input for the updateCtaRegion mutation. */
+export type UpdateCtaRegionInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** Set connections between the ctaRegion and ctaRegionTypes */
+  ctaRegionTypes?: InputMaybe<CtaRegionCtaRegionTypesInput>;
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
+  date?: InputMaybe<Scalars['String']['input']>;
+  /** The excerpt of the object */
+  excerpt?: InputMaybe<Scalars['String']['input']>;
+  /** The ID of the ctaRegion object */
+  id: Scalars['ID']['input'];
+  /** Override the edit lock when another user is editing the post */
+  ignoreEditLock?: InputMaybe<Scalars['Boolean']['input']>;
+  /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** The password used to protect the content of the object */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** The slug of the object */
+  slug?: InputMaybe<Scalars['String']['input']>;
+  /** The status of the object */
+  status?: InputMaybe<PostStatusEnum>;
+  /** The title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The payload for the updateCtaRegion mutation. */
+export type UpdateCtaRegionPayload = {
+  __typename?: 'UpdateCtaRegionPayload';
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  /** The Post object mutation type. */
+  ctaRegion?: Maybe<CtaRegion>;
+};
+
+/** Input for the updateCtaRegionType mutation. */
+export type UpdateCtaRegionTypeInput = {
+  /** The slug that the cta_region_type will be an alias of */
+  aliasOf?: InputMaybe<Scalars['String']['input']>;
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** The description of the cta_region_type object */
+  description?: InputMaybe<Scalars['String']['input']>;
+  /** The ID of the ctaRegionType object to update */
+  id: Scalars['ID']['input'];
+  /** The name of the cta_region_type object to mutate */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** If this argument exists then the slug will be checked to see if it is not an existing valid term. If that check succeeds (it is not a valid term), then it is added and the term id is given. If it fails, then a check is made to whether the taxonomy is hierarchical and the parent argument is not empty. If the second check succeeds, the term will be inserted and the term id will be given. If the slug argument is empty, then it will be calculated from the term name. */
+  slug?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The payload for the updateCtaRegionType mutation. */
+export type UpdateCtaRegionTypePayload = {
+  __typename?: 'UpdateCtaRegionTypePayload';
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  /** The created cta_region_type */
+  ctaRegionType?: Maybe<CtaRegionType>;
+};
+
 /** Input for the updateEpisode mutation. */
 export type UpdateEpisodeInput = {
   /** Set connections between the episode and categories */
@@ -22332,6 +24157,41 @@ export type UpdateMediaItemPayload = {
   clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The MediaItem object mutation type. */
   mediaItem?: Maybe<MediaItem>;
+};
+
+/** Input for the updateNewsletter mutation. */
+export type UpdateNewsletterInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** The content of the object */
+  content?: InputMaybe<Scalars['String']['input']>;
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
+  date?: InputMaybe<Scalars['String']['input']>;
+  /** The excerpt of the object */
+  excerpt?: InputMaybe<Scalars['String']['input']>;
+  /** The ID of the newsletter object */
+  id: Scalars['ID']['input'];
+  /** Override the edit lock when another user is editing the post */
+  ignoreEditLock?: InputMaybe<Scalars['Boolean']['input']>;
+  /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** The password used to protect the content of the object */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** The slug of the object */
+  slug?: InputMaybe<Scalars['String']['input']>;
+  /** The status of the object */
+  status?: InputMaybe<PostStatusEnum>;
+  /** The title of the object */
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The payload for the updateNewsletter mutation. */
+export type UpdateNewsletterPayload = {
+  __typename?: 'UpdateNewsletterPayload';
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  /** The Post object mutation type. */
+  newsletter?: Maybe<Newsletter>;
 };
 
 /** Input for the updatePage mutation. */

--- a/interfaces/app/IApp.ts
+++ b/interfaces/app/IApp.ts
@@ -1,8 +1,11 @@
-import type { IButton, PostStory } from '@interfaces';
+import type { IButton, ICtaMessage, PostStory } from '@interfaces';
 
 export interface IApp {
   latestStories?: PostStory[];
-  menus: {
+  menus?: {
     [k: string]: IButton[];
+  };
+  ctaRegions?: {
+    [k: string]: ICtaMessage[];
   };
 }

--- a/interfaces/button/button.interface.ts
+++ b/interfaces/button/button.interface.ts
@@ -33,9 +33,9 @@ export type ButtonColors = OverridableStringUnion<
 >;
 
 export interface IButton {
-  key: string | number;
+  key?: string | number;
   name: string;
-  url: string;
+  url?: string;
   service?: string;
   itemLinkClass?: string;
   color?: IconButtonColors | ButtonColors;

--- a/interfaces/button/button.interface.ts
+++ b/interfaces/button/button.interface.ts
@@ -35,7 +35,7 @@ export type ButtonColors = OverridableStringUnion<
 export interface IButton {
   key?: string | number;
   name: string;
-  url?: string;
+  url?: string | URL;
   service?: string;
   itemLinkClass?: string;
   color?: IconButtonColors | ButtonColors;
@@ -43,4 +43,8 @@ export interface IButton {
   title?: string;
   children?: IButton[];
   attributes?: { [k: string]: string };
+}
+
+export interface IButtonWithUrl extends IButton {
+  url: string;
 }

--- a/interfaces/content/content.interface.ts
+++ b/interfaces/content/content.interface.ts
@@ -3,8 +3,6 @@
  * Interfaces for content.
  */
 
-import { IApp } from '@interfaces/app';
-
 export interface IContentComponentProps<D> {
   data: D;
 }
@@ -16,7 +14,6 @@ export interface IContentComponentProxyProps {
   redirect?: string;
   data?: any;
   cookies?: any;
-  appData?: IApp;
 }
 
 export interface IContentContext {

--- a/interfaces/cta/cta.interface.ts
+++ b/interfaces/cta/cta.interface.ts
@@ -3,8 +3,9 @@
  * Interfaces for content.
  */
 
+import { Category, ContentNode, Newsletter, Program } from '@interfaces/api';
 import { IButton } from '@interfaces/button';
-import { INewsletterOptions, IPriApiNewsletter } from '@interfaces/newsletter';
+import { INewsletterOptions } from '@interfaces/newsletter';
 
 export type CtaMessageType = 'info' | 'optin' | 'donation' | 'newsletter';
 
@@ -18,11 +19,11 @@ export interface ICtaMessage {
   cookieLifespan?: number;
   action?: IButton;
   dismiss?: IButton;
-  newsletter?: IPriApiNewsletter;
+  newsletter?: Newsletter;
   newsletterOptions?: INewsletterOptions;
-  targetContent?: string[];
-  targetCategories?: string[];
-  targetProgram?: string;
+  targetContent?: ContentNode[];
+  targetCategories?: Category[];
+  targetPrograms?: Program[];
   region?: string;
 }
 
@@ -45,5 +46,5 @@ export interface ICtaMessageComponentContext {
 export interface ICtaFilterProps {
   id?: string;
   categories?: string[];
-  program?: string;
+  programs?: string[];
 }

--- a/interfaces/newsletter/newsletter.interface.ts
+++ b/interfaces/newsletter/newsletter.interface.ts
@@ -3,7 +3,8 @@
  * Interfaces for link.
  */
 
-import { IPriApiResource } from 'pri-api-library/types';
+import type { Maybe } from '@interfaces/api';
+import type { IPriApiResource } from 'pri-api-library/types';
 
 export interface IPriApiNewsletter extends IPriApiResource {
   listId: string;
@@ -25,7 +26,7 @@ export interface INewsletterCustomFields {
 }
 
 export interface INewsletterOptions {
-  listId?: string;
+  listId?: Maybe<string>;
   customFields?: INewsletterCustomFields;
 }
 

--- a/interfaces/state/appData.interface.ts
+++ b/interfaces/state/appData.interface.ts
@@ -1,0 +1,14 @@
+/**
+ * @file appData.interface.ts
+ *
+ * Define interfaces for app data state.
+ */
+
+import { IApp } from '@interfaces/app';
+import { AnyAction } from 'redux';
+
+export interface AppDataState extends IApp {}
+
+export interface AppDataAction extends AnyAction {
+  payload?: AppDataState;
+}

--- a/interfaces/state/ctaRegionGroupData.interface.ts
+++ b/interfaces/state/ctaRegionGroupData.interface.ts
@@ -12,9 +12,9 @@ export interface CtaRegionGroupData {
   [k: string]: ICtaMessage[];
 }
 
-export interface Cookies {
+export type Cookies = Partial<{
   [k: string]: string;
-}
+}>;
 
 export interface CtaRegionGroupFilterProps {
   id: string;

--- a/interfaces/state/index.ts
+++ b/interfaces/state/index.ts
@@ -1,3 +1,4 @@
+export * from './appData.interface';
 export * from './collections.interface';
 export * from './contentData.interface';
 export * from './ctaData.interface';

--- a/interfaces/state/menusData.interface.ts
+++ b/interfaces/state/menusData.interface.ts
@@ -5,7 +5,12 @@
  */
 
 import { IButton } from '@interfaces/button';
+import { AnyAction } from 'redux';
 
 export interface MenusDataState {
   [k: string]: IButton[];
+}
+
+export interface MenuDataAction extends AnyAction {
+  payload?: MenusDataState;
 }

--- a/interfaces/state/rootState.interface.ts
+++ b/interfaces/state/rootState.interface.ts
@@ -4,6 +4,9 @@
  * Define interfaces for RootState.
  */
 
+import { AnyAction } from 'redux';
+import { Maybe } from '@interfaces/api';
+import { AppDataState } from './appData.interface';
 import { ContentDataState } from './contentData.interface';
 import { CollectionsState } from './collections.interface';
 import { CtaRegionGroupDataState } from './ctaRegionGroupData.interface';
@@ -12,6 +15,7 @@ import { SearchState } from './search.interface';
 import { UiState } from './ui.interface';
 
 export interface RootState {
+  appData: Maybe<AppDataState>;
   aliasData: ContentDataState;
   contentData: ContentDataState;
   collections: CollectionsState;
@@ -19,4 +23,8 @@ export interface RootState {
   menusData: MenusDataState;
   search: SearchState;
   ui: UiState;
+}
+
+export interface HydrateAction extends AnyAction {
+  payload?: RootState;
 }

--- a/lib/cta/filterCtaMessages.ts
+++ b/lib/cta/filterCtaMessages.ts
@@ -31,15 +31,16 @@ export const filterCtaMessages = (filterProps: ICtaFilterProps) => (
 
   // Check Category Targets.
   if (targetCategories?.length) {
-    const filterPropsCategories = filterProps?.categories || [];
+    const filterPropsCategories = [...(new Set([...(filterProps?.categories || [])]))];
+    const targetCategoriesUnique = [...(new Set([...targetCategories]))];
     const combinedCategories = new Set([
-      ...targetCategories,
+      ...targetCategoriesUnique,
       ...filterPropsCategories
     ]);
 
     categoriesMatched =
-      [...combinedCategories].length !==
-      targetCategories.length + filterPropsCategories.length;
+      [...combinedCategories].length ===
+      filterPropsCategories.length;
   }
 
   // Check Program Target.

--- a/lib/cta/filterCtaMessages.ts
+++ b/lib/cta/filterCtaMessages.ts
@@ -8,45 +8,49 @@ import { ICtaFilterProps, ICtaMessage } from '@interfaces/cta';
  * Determine if a message should be used based on filterProps.
  *
  * @param filterProps - Properties to compare to for filter targeting.
- *
- * @return {object|null} - Returns array filter callback to filter CTA message.
  */
-export const filterCtaMessages = (filterProps: ICtaFilterProps) => (
-  message: ICtaMessage
-) => {
-  const { targetContent, targetCategories, targetProgram } = message;
-  const isTargeted = targetContent || targetCategories || targetProgram;
-  let contentMatched = false;
-  let categoriesMatched = false;
-  let programMatched = false;
+export const filterCtaMessages =
+  (filterProps: ICtaFilterProps) => (message: ICtaMessage) => {
+    const { targetContent, targetCategories, targetPrograms } = message;
+    const isTargeted = targetContent || targetCategories || targetPrograms;
+    let contentMatched = false;
+    let categoriesMatched = false;
+    let programsMatched = false;
 
-  // Always use messages that are not target.
-  if (!isTargeted) return true;
+    // Always use messages that are not target.
+    if (!isTargeted) return true;
 
-  // Check Content Targets.
-  if (targetContent?.length) {
-    contentMatched =
-      !!filterProps?.id && targetContent.includes(filterProps.id);
-  }
+    // Check Content Targets.
+    if (targetContent?.length) {
+      contentMatched =
+        !!filterProps?.id &&
+        targetContent.map((item) => item.id).includes(filterProps.id);
+    }
 
-  // Check Category Targets.
-  if (targetCategories?.length) {
-    const filterPropsCategories = filterProps?.categories || [];
-    const combinedCategories = new Set([
-      ...targetCategories,
-      ...filterPropsCategories
-    ]);
+    // Check Category Targets.
+    if (targetCategories?.length) {
+      const filterPropsCategories = filterProps?.categories || [];
+      const combinedCategories = new Set([
+        ...targetCategories.map((item) => item.id),
+        ...filterPropsCategories
+      ]);
 
-    categoriesMatched =
-      [...combinedCategories].length !==
-      targetCategories.length + filterPropsCategories.length;
-  }
+      categoriesMatched =
+        [...combinedCategories].length === targetCategories.length;
+    }
 
-  // Check Program Target.
-  if (targetProgram) {
-    programMatched = targetProgram === filterProps?.program;
-  }
+    // Check Program Target.
+    if (targetPrograms) {
+      const filterPropsPrograms = filterProps?.programs || [];
+      const combinedCategories = new Set([
+        ...targetPrograms.map((item) => item.id),
+        ...filterPropsPrograms
+      ]);
 
-  // Use message if any of the targeting matched.
-  return contentMatched || categoriesMatched || programMatched;
-};
+      programsMatched =
+        [...combinedCategories].length === targetPrograms.length;
+    }
+
+    // Use message if any of the targeting matched.
+    return contentMatched || categoriesMatched || programsMatched;
+  };

--- a/lib/cta/getCookieKey.ts
+++ b/lib/cta/getCookieKey.ts
@@ -10,5 +10,5 @@ import { cookieKeyPrefix } from './ctaConfig';
  * @param id
  *    CTA message id.
  */
-export const getCookieKey = (id: string | number) =>
-  [cookieKeyPrefix, id].join('-');
+export const getCookieKey = (id: string) =>
+  [cookieKeyPrefix, id.replace(/[^\w]/g, '')].join('-');

--- a/lib/cta/getShownMessage.ts
+++ b/lib/cta/getShownMessage.ts
@@ -28,9 +28,11 @@ export const getShownMessage = (
           const { name, hash } = msg;
           const cookieName = getCookieKey(name);
           const hashOld = cookies[cookieName];
+
           if (!result && (!hashOld || hashOld !== hash)) {
             return msg;
           }
+
           return result;
         }, message);
   }

--- a/lib/cta/setCtaCookie.ts
+++ b/lib/cta/setCtaCookie.ts
@@ -17,11 +17,7 @@ import { getCookieKey } from './getCookieKey';
  * @param maxAgeDays
  *    Number of hours cookie should be expired for.
  */
-export const setCtaCookie = (
-  id: string | number,
-  hash: string,
-  maxAgeDays?: number
-) => {
+export const setCtaCookie = (id: string, hash: string, maxAgeDays?: number) => {
   const key = getCookieKey(id);
   const maxAge = (maxAgeDays || 0) * 24 * 60 * 60 * 1000;
   const expires = new Date(Date.now() + maxAge);

--- a/lib/fetch/api/gqlClient.ts
+++ b/lib/fetch/api/gqlClient.ts
@@ -65,7 +65,12 @@ export const gqlClient = new ApolloClient({
       }
     }
   }),
-  link: from([httpLink])
+  link: from([httpLink]),
+  defaultOptions: {
+    query: {
+      fetchPolicy: 'no-cache'
+    }
+  }
 });
 
 export default gqlClient;

--- a/lib/fetch/api/graphql/fragments/cta.fragment.ts
+++ b/lib/fetch/api/graphql/fragments/cta.fragment.ts
@@ -1,0 +1,70 @@
+import { gql } from '@apollo/client';
+
+export const CTA_REGION_PROPS = gql`
+  fragment CtaRegionProps on CtaRegion {
+    id
+    title
+    slug
+    ctaRegionContent {
+      callToActions {
+        ...CtaProps
+      }
+    }
+  }
+`;
+
+export const CTA_PROPS = gql`
+  fragment CtaProps on CallToAction {
+    id
+    modified
+    ctaOptions {
+      ctaType
+      content {
+        heading
+        message
+      }
+      actions {
+        actionButtonLabel
+        actionButtonUrl
+        dismissButtonLabel
+      }
+      optInSettings {
+        optInText
+      }
+      newsletterSettings {
+        newsletter {
+          ... on Newsletter {
+            id
+            title
+            link
+            newsletterOptions {
+              buttonLabel
+              listId
+              optInText
+            }
+          }
+        }
+      }
+    }
+    ctaSettings {
+      cookieLifespan
+    }
+    ctaTargeting {
+      targetCategories {
+        id
+      }
+      targetPrograms {
+        id
+      }
+      targetContent {
+        __typename
+        ... on Post {
+          id
+        }
+        ... on Episode {
+          id
+        }
+      }
+    }
+  }
+`;

--- a/lib/fetch/api/graphql/fragments/index.ts
+++ b/lib/fetch/api/graphql/fragments/index.ts
@@ -1,4 +1,5 @@
 export * from './audio.fragment';
+export * from './cta.fragment';
 export * from './episode.fragment';
 export * from './image.fragment';
 export * from './menu.fragment';

--- a/lib/fetch/api/graphql/fragments/menu.fragment.ts
+++ b/lib/fetch/api/graphql/fragments/menu.fragment.ts
@@ -11,7 +11,7 @@ export const MENU_ITEM_PROPS = gql`
 
 export const MENU_PROPS = gql`
   fragment MenuProps on Menu {
-    menuItems {
+    menuItems(first: 100) {
       nodes {
         ...MenuItemProps
       }

--- a/lib/fetch/category/fetchGqlCategory.ts
+++ b/lib/fetch/category/fetchGqlCategory.ts
@@ -129,7 +129,7 @@ export async function fetchGqlCategory(id: string, idType?: string) {
   });
   const category = response?.data?.category;
 
-  if (!category) return undefined;
+  if (!category?.children) return undefined;
 
   if (category.children.pageInfo) {
     let childrenEdges = [...category.children.edges];
@@ -147,16 +147,15 @@ export async function fetchGqlCategory(id: string, idType?: string) {
             cursor: endCursor
           }
         })
-        .then((res) => res.data.category.children);
+        .then((res) => res.data.category?.children);
 
       if (moreChildren) {
         childrenEdges = [...childrenEdges, ...moreChildren.edges];
+        category.children.pageInfo = { ...moreChildren.pageInfo };
       }
 
       hasNextPage = !!moreChildren?.pageInfo.hasNextPage;
       endCursor = moreChildren?.pageInfo.endCursor;
-
-      category.children.pageInfo = { ...moreChildren.pageInfo };
     }
 
     category.children.edges = childrenEdges;

--- a/lib/fetch/homepage/fetchGqlHomepage.ts
+++ b/lib/fetch/homepage/fetchGqlHomepage.ts
@@ -32,7 +32,7 @@ const GET_HOMEPAGE = gql`
         }
       }
     }
-    quickLinks: menu(id: "homepage-quick-links", idType: SLUG) {
+    quickLinks: menu(id: "homepage-quick-links-menu", idType: SLUG) {
       ...MenuProps
     }
   }
@@ -80,7 +80,6 @@ export async function fetchGqlHomepage() {
   // Get latest stories NOT from The World.
   const latestStoriesResponse = await gqlClient.query<{
     posts: Maybe<RootQueryToPostConnection>;
-    quickLinks: Maybe<Menu>;
   }>({
     query: GET_HOMEPAGE_LATEST_STORIES,
     variables: {

--- a/lib/fetch/newsletter/fetchGqlNewsletter.ts
+++ b/lib/fetch/newsletter/fetchGqlNewsletter.ts
@@ -1,0 +1,50 @@
+/**
+ * Fetch Newsletter data from WP GraphQL API.
+ */
+
+import type { Newsletter, Maybe } from '@interfaces';
+import { gql } from '@apollo/client';
+import { gqlClient } from '@lib/fetch/api';
+import { IMAGE_PROPS } from '@lib/fetch/api/graphql';
+
+const GET_NEWSLETTER = gql`
+  query getNewsletter($id: ID!, $idType: NewsletterIdType) {
+    newsletter(id: $id, idType: $idType) {
+      id
+      link
+      title
+      content
+      excerpt
+      featuredImage {
+        node {
+          ...ImageProps
+        }
+      }
+      newsletterOptions {
+        listId
+        buttonLabel
+        optInText
+      }
+    }
+  }
+  ${IMAGE_PROPS}
+`;
+
+export async function fetchGqlNewsletter(id: string, idType?: string) {
+  const response = await gqlClient.query<{
+    newsletter: Maybe<Newsletter>;
+  }>({
+    query: GET_NEWSLETTER,
+    variables: {
+      id,
+      idType
+    }
+  });
+  const newsletter = response?.data?.newsletter;
+
+  if (!newsletter) return undefined;
+
+  return newsletter;
+}
+
+export default fetchGqlNewsletter;

--- a/lib/fetch/newsletter/index.ts
+++ b/lib/fetch/newsletter/index.ts
@@ -1,1 +1,2 @@
+export * from './fetchGqlNewsletter';
 export * from './fetchNewsletter';

--- a/lib/fetch/story/fetchGqlStory.ts
+++ b/lib/fetch/story/fetchGqlStory.ts
@@ -2,7 +2,7 @@
  * Fetch Story data from WP GraphQL API.
  */
 
-import type { Maybe, Post, PostStory } from '@interfaces';
+import type { Maybe, PostStory } from '@interfaces';
 import { gql } from '@apollo/client';
 import { gqlClient } from '@lib/fetch/api';
 import { IMAGE_PROPS, POST_SEO_PROPS } from '@lib/fetch/api/graphql';
@@ -167,34 +167,13 @@ const GET_POST = gql`
 `;
 
 export const fetchGqlStory = async (id?: string, idType?: string) => {
-  let storyId = id;
-
-  if (idType) {
-    const response = await gqlClient.query<{ post: Maybe<Post> }>({
-      query: gql`
-        query getPost($id: ID!, $idType: PostIdType) {
-          post(id: $id, idType: $idType) {
-            id
-          }
-        }
-      `,
-      variables: {
-        id,
-        idType
-      }
-    });
-
-    storyId = response.data.post?.id;
-  }
-
-  if (!storyId) return undefined;
-
   const response = await gqlClient.query<{
     post: Maybe<PostStory>;
   }>({
     query: GET_POST,
     variables: {
-      id: storyId
+      id,
+      idType
     }
   });
   const post = response?.data?.post;

--- a/lib/parse/cta/parseCtaMessage.ts
+++ b/lib/parse/cta/parseCtaMessage.ts
@@ -4,14 +4,13 @@
  */
 
 import { IPriApiResource } from 'pri-api-library/types';
-import { ICtaMessage } from '@interfaces/cta';
-import { IPriApiNewsletter, INewsletterOptions } from '@interfaces/newsletter';
+import type { Newsletter, INewsletterOptions, ICtaMessage } from '@interfaces';
 
 export const parseNewsletterOptions = (
-  { listId }: IPriApiNewsletter,
+  data: Newsletter,
   region: string
 ): INewsletterOptions => ({
-  listId,
+  listId: data.newsletterOptions?.listId,
   customFields: {
     source: 'website',
     ...(region && { 'source-placement': region })
@@ -24,7 +23,7 @@ export const parseCtaMessage = (
 ): ICtaMessage => ({
   name: message.id as string,
   type: message.ctaType,
-  hash: message.contentHash,
+  hash: message.contentHash, // TODO: create this hash during parse.
   ...(message.heading && { heading: message.heading }),
   ...(message.message && { message: message.message }),
   ...(message.cookieLifespan && {

--- a/lib/routing/handleButtonClick.ts
+++ b/lib/routing/handleButtonClick.ts
@@ -5,7 +5,6 @@
 
 import { MouseEvent } from 'react';
 import Router from 'next/router';
-import { parse, Url } from 'url';
 import { isLocalUrl } from '../parse/url';
 
 /**
@@ -18,7 +17,7 @@ import { isLocalUrl } from '../parse/url';
  * @returns
  *    Url object with alias query relative to app.
  */
-export const generateLinkHrefFromUrl = (url: Url) => {
+export const generateLinkHrefFromUrl = (url: URL) => {
   const pathname = url.pathname !== '/' ? '/[...alias]' : '/';
   const query =
     pathname !== '/' && url.pathname
@@ -42,11 +41,14 @@ export const generateLinkHrefFromUrl = (url: Url) => {
  */
 /* istanbul ignore next */
 export const handleButtonClick =
-  (url?: Url | string, callback?: Function) => (event: MouseEvent) => {
+  (url?: URL | string, callback?: Function) => (event: MouseEvent) => {
     event.preventDefault();
 
     if (url) {
-      const parsedUrl = typeof url === 'string' ? parse(url as string) : url;
+      const parsedUrl =
+        typeof url === 'string'
+          ? new URL(url as string, 'https://theworld.org')
+          : url;
 
       Router.push(
         isLocalUrl(parsedUrl.href)

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -80,10 +80,10 @@ const ContentProxy = ({ type }: Props) => {
 export const getServerSideProps = wrapper.getServerSideProps(
   (store) =>
     async ({ res, req, params }): Promise<GetServerSidePropsResult<any>> => {
-      let resourceId: string;
-      let resourceType: string = 'homepage';
-      let redirect: string;
-      const { alias } = params;
+      let resourceId: string | undefined;
+      let resourceType: string | null = 'homepage';
+      let redirect: string | undefined;
+      const { alias } = params || {};
       const aliasPath = (alias as string[]).join('/');
       const rgxFileExt = /\.\w+$/;
 

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -45,6 +45,7 @@ const ContentProxy = ({ type, data }: Props) => {
     case 'node--episodes':
       return <DynamicEpisode data={data} />;
 
+    case 'post--newsletter':
     case 'node--newsletter_sign_ups':
       return <DynamicNewsletter />;
 

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -47,7 +47,7 @@ const ContentProxy = ({ type, data }: Props) => {
 
     case 'post--newsletter':
     case 'node--newsletter_sign_ups':
-      return <DynamicNewsletter />;
+      return <DynamicNewsletter data={data} />;
 
     case 'post--page':
     case 'node--pages':

--- a/pages/[...alias].tsx
+++ b/pages/[...alias].tsx
@@ -10,8 +10,6 @@ import { getResourceFetchData } from '@lib/import/fetchData';
 import { fetchTwApiQueryAlias } from '@lib/fetch';
 import { wrapper } from '@store';
 import { fetchAppData } from '@store/actions/fetchAppData';
-// import { fetchCtaRegionGroupData } from '@store/actions/fetchCtaRegionGroupData';
-// import { fetchAppData } from '@store/actions/fetchAppData';
 
 // Define dynamic component imports.
 const DynamicAudio = dynamic(() => import('@components/pages/Audio'));
@@ -128,29 +126,25 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
 
         if (fetchData) {
           const fetchDataResp = fetchData(resourceId);
-          const [data, appData] = await Promise.all([
+          const [data] = await Promise.all([
             typeof fetchDataResp !== 'function'
               ? fetchDataResp
               : store.dispatch(fetchDataResp),
-            fetchAppData()
+            store.dispatch<any>(fetchAppData(req.cookies))
           ]);
-
-          // await store.dispatch<any>(
-          //   fetchCtaRegionGroupData('tw_cta_regions_site')
-          // );
 
           return {
             props: {
               type: resourceType,
               id: data.id,
-              cookies: req.cookies,
-              data,
-              appData
+              data
             }
           };
         }
       }
     }
+
+    await store.dispatch<any>(fetchAppData(req.cookies));
 
     return { notFound: true };
   });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -119,12 +119,10 @@ const TwApp = ({
   const { store, props } = wrapper.useWrappedStore(rest);
   const { pageProps } = props as AppProps<AppPageProps>;
   const [plausibleDomain, setPlausibleDomain] = useState('');
-  const { cookies, appData, contentOnly, ...componentProps } = pageProps;
+  const { cookies, contentOnly, ...componentProps } = pageProps;
   const { type, id } = componentProps;
   const contextValue = useMemo(
     () => ({
-      ...(appData && { data: appData }),
-      ...(cookies && { cookies }),
       page: {
         resource: {
           type,
@@ -136,6 +134,7 @@ const TwApp = ({
   );
 
   useEffect(() => {
+    // Configure Plausible provider.
     setPlausibleDomain((window as any)?.location.hostname || analytics.domain);
 
     // Remove the server-side injected CSS.

--- a/pages/api/contributor/[id]/index.ts
+++ b/pages/api/contributor/[id]/index.ts
@@ -1,20 +1,20 @@
 /**
- * @file program/[id]/index.ts
- * Gather program data from CMS API.
+ * @file contributor/[id]/index.ts
+ * Gather contributor data from CMS API.
  */
 
 import { NextApiRequest, NextApiResponse } from 'next';
-import { fetchGqlProgram } from '@lib/fetch';
+import { fetchGqlContributor } from '@lib/fetch';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
-  const programId = !!id && (typeof id === 'string' ? id : id[0]);
+  const contributorId = !!id && (typeof id === 'string' ? id : id[0]);
 
-  if (programId) {
-    const program = await fetchGqlProgram(programId);
+  if (contributorId) {
+    const contributor = await fetchGqlContributor(contributorId);
 
-    if (program) {
-      return res.status(200).json(program);
+    if (contributor) {
+      return res.status(200).json(contributor);
     }
 
     return res.status(404).end();

--- a/pages/api/episode/[id].ts
+++ b/pages/api/episode/[id].ts
@@ -10,10 +10,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
 
   if (id) {
-    const story = await fetchGqlEpisode(id as string);
+    const data = await fetchGqlEpisode(id as string);
 
-    if (story) {
-      return res.status(200).json(story);
+    if (data) {
+      return res.status(200).json(data);
     }
 
     return res.status(404).end();

--- a/pages/api/newsletter/[id].ts
+++ b/pages/api/newsletter/[id].ts
@@ -1,35 +1,23 @@
 /**
- * @file [id].ts
+ * @file newsletter/[id].ts
  * Gather newsletter data from CMS API.
  */
+
 import { NextApiRequest, NextApiResponse } from 'next';
-import { fetchPriApiItem } from '@lib/fetch/api';
-import { IPriApiResourceResponse } from 'pri-api-library/types';
+import { fetchGqlNewsletter } from '@lib/fetch';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
 
   if (id) {
-    const newsletter = (await fetchPriApiItem(
-      'node--newsletter_sign_ups',
-      id as string,
-      {
-        include: ['image']
-      }
-    )) as IPriApiResourceResponse;
+    const data = await fetchGqlNewsletter(id as string);
 
-    if (newsletter) {
-      res.setHeader(
-        'Cache-Control',
-        process.env.TW_API_RESOURCE_CACHE_CONTROL ||
-          'public, s-maxage=600, stale-while-revalidate'
-      );
-
-      return res.status(200).json(newsletter.data);
+    if (data) {
+      return res.status(200).json(data);
     }
 
-    return res.status(404);
+    return res.status(404).end();
   }
 
-  return res.status(400);
+  return res.status(400).end();
 };

--- a/pages/api/page/[id].ts
+++ b/pages/api/page/[id].ts
@@ -1,29 +1,19 @@
 /**
- * @file episode/[id].ts
- * Gather episode data from CMS API.
+ * @file page/[id].ts
+ * Gather page data from CMS API.
  */
+
 import { NextApiRequest, NextApiResponse } from 'next';
-import { IPriApiResourceResponse } from 'pri-api-library/types';
-import { fetchPriApiItem } from '@lib/fetch/api';
+import { fetchGqlPage } from '@lib/fetch';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
 
   if (id) {
-    const page = (await fetchPriApiItem(
-      'node--pages',
-      id as string,
-      {}
-    )) as IPriApiResourceResponse;
+    const data = await fetchGqlPage(id as string);
 
-    if (page) {
-      res.setHeader(
-        'Cache-Control',
-        process.env.TW_API_RESOURCE_CACHE_CONTROL ||
-          'public, s-maxage=600, stale-while-revalidate'
-      );
-
-      return res.status(200).json(page.data);
+    if (data) {
+      return res.status(200).json(data);
     }
 
     return res.status(404).end();

--- a/pages/categories/[...slugs].tsx
+++ b/pages/categories/[...slugs].tsx
@@ -23,9 +23,9 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
 
     if (slug) {
       const dataResponse = fetchCategoryData(slug, 'SLUG');
-      const [data, appData] = await Promise.all([
+      const [data] = await Promise.all([
         store.dispatch<any>(dataResponse),
-        fetchAppData()
+        store.dispatch<any>(fetchAppData(req.cookies))
       ]);
 
       if (data) {
@@ -33,9 +33,7 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
           props: {
             type: 'term--category',
             id: data.id,
-            cookies: req.cookies,
-            data,
-            appData
+            data
           }
         };
       }

--- a/pages/contributors/[slug].tsx
+++ b/pages/contributors/[slug].tsx
@@ -23,9 +23,9 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
 
     if (slug) {
       const dataResponse = fetchContributorData(slug, 'SLUG');
-      const [data, appData] = await Promise.all([
+      const [data] = await Promise.all([
         store.dispatch<any>(dataResponse),
-        fetchAppData()
+        store.dispatch<any>(fetchAppData(req.cookies))
       ]);
 
       if (data) {
@@ -33,9 +33,7 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
           props: {
             type: 'term--contributor',
             id: data.id,
-            cookies: req.cookies,
-            data,
-            appData
+            data
           }
         };
       }

--- a/pages/episodes/[year]/[month]/[day]/[slug].tsx
+++ b/pages/episodes/[year]/[month]/[day]/[slug].tsx
@@ -6,41 +6,41 @@
 
 import { Episode } from '@components/pages/Episode';
 import { IContentComponentProxyProps } from '@interfaces';
+import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
 import { fetchEpisodeData } from '@store/actions/fetchEpisodeData';
-import { GetServerSideProps } from 'next';
 
 const EpisodePage = ({ data }: IContentComponentProxyProps) => (
   <Episode data={data} />
 );
 
-export const getServerSideProps: GetServerSideProps<
-  IContentComponentProxyProps
-> = async ({ req, params }) => {
-  const slug =
-    params?.slug &&
-    (typeof params.slug === 'string' ? params.slug : params.slug[0]);
+export const getServerSideProps =
+  wrapper.getServerSideProps<IContentComponentProxyProps>(
+    (store) =>
+      async ({ req, params }) => {
+        const slug =
+          params?.slug &&
+          (typeof params.slug === 'string' ? params.slug : params.slug[0]);
 
-  if (slug) {
-    const [data, appData] = await Promise.all([
-      fetchEpisodeData(slug, 'SLUG'),
-      fetchAppData()
-    ]);
+        if (slug) {
+          const [data] = await Promise.all([
+            fetchEpisodeData(slug, 'SLUG'),
+            store.dispatch<any>(fetchAppData(req.cookies))
+          ]);
 
-    if (data) {
-      return {
-        props: {
-          type: 'post--episode',
-          id: data.id,
-          cookies: req.cookies,
-          data,
-          appData
+          if (data) {
+            return {
+              props: {
+                type: 'post--episode',
+                id: data.id,
+                data
+              }
+            };
+          }
         }
-      };
-    }
-  }
 
-  return { notFound: true };
-};
+        return { notFound: true };
+      }
+  );
 
 export default EpisodePage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,17 +19,15 @@ const IndexPage = ({ data }: IContentComponentProps<HomepageType>) => (
 export const getServerSideProps = wrapper.getServerSideProps(
   (store) =>
     async ({ req }) => {
-      const [data, appData] = await Promise.all([
+      const [data] = await Promise.all([
         store.dispatch<any>(fetchHomepageData()),
-        fetchAppData()
+        store.dispatch<any>(fetchAppData(req.cookies))
       ]);
 
       return {
         props: {
           type: 'homepage',
-          cookies: req.cookies,
-          data,
-          appData
+          data
         }
       };
     }

--- a/pages/media/[...slug].tsx
+++ b/pages/media/[...slug].tsx
@@ -6,14 +6,12 @@
 import React from 'react';
 import { GetServerSidePropsResult } from 'next';
 import dynamic from 'next/dynamic';
-import crypto from 'crypto';
 import { IPriApiResource } from 'pri-api-library/types';
 import { IContentComponentProxyProps } from '@interfaces/content';
 import { RootState } from '@interfaces/state';
 import { fetchAliasData } from '@store/actions/fetchAliasData';
 import { wrapper } from '@store';
 import { getResourceFetchData } from '@lib/import/fetchData';
-import { fetchCtaRegionGroupData } from '@store/actions/fetchCtaRegionGroupData';
 import { fetchAppData } from '@store/actions/fetchAppData';
 
 // Define dynamic component imports.
@@ -95,34 +93,16 @@ export const getServerSideProps = wrapper.getServerSideProps(
         const fetchData = getResourceFetchData(resourceType);
 
         if (fetchData) {
-          store.dispatch<any>({
-            type: 'SET_COOKIES',
-            payload: {
-              cookies: req.cookies
-            }
-          });
-
-          const data = await store.dispatch(fetchData(resourceId, res));
-
-          await store.dispatch<any>(fetchAppData());
-
-          await store.dispatch<any>(
-            fetchCtaRegionGroupData('tw_cta_regions_site')
-          );
-
-          res.setHeader(
-            'Cache-Control',
-            `public, s-maxage=${60 * 60 * 24}, stale-while-revalidate=${60 * 5}`
-          );
+          const [data] = await Promise.all([
+            store.dispatch(fetchData(resourceId, res)),
+            store.dispatch<any>(fetchAppData(req.cookies))
+          ]);
 
           return {
             props: {
               type: resourceType,
               id: resourceId,
-              dataHash: crypto
-                .createHash('sha256')
-                .update(JSON.stringify(data))
-                .digest('hex')
+              data
             }
           };
         }

--- a/pages/newsletters/[slug].tsx
+++ b/pages/newsletters/[slug].tsx
@@ -6,41 +6,41 @@
 
 import { Newsletter } from '@components/pages/Newsletter';
 import { IContentComponentProxyProps } from '@interfaces';
+import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
 import { fetchNewsletterData } from '@store/actions/fetchNewsletterData';
-import { GetServerSideProps } from 'next';
 
 const NewsletterPage = ({ data }: IContentComponentProxyProps) => (
   <Newsletter data={data} />
 );
 
-export const getServerSideProps: GetServerSideProps<
-  IContentComponentProxyProps
-> = async ({ req, params }) => {
-  const slug =
-    params?.slug &&
-    (typeof params.slug === 'string' ? params.slug : params.slug[0]);
+export const getServerSideProps =
+  wrapper.getServerSideProps<IContentComponentProxyProps>(
+    (store) =>
+      async ({ req, params }) => {
+        const slug =
+          params?.slug &&
+          (typeof params.slug === 'string' ? params.slug : params.slug[0]);
 
-  if (slug) {
-    const [data, appData] = await Promise.all([
-      fetchNewsletterData(slug, 'SLUG'),
-      fetchAppData()
-    ]);
+        if (slug) {
+          const [data] = await Promise.all([
+            fetchNewsletterData(slug, 'SLUG'),
+            store.dispatch<any>(fetchAppData(req.cookies))
+          ]);
 
-    if (data) {
-      return {
-        props: {
-          type: 'post--newsletter',
-          id: data.id,
-          cookies: req.cookies,
-          data,
-          appData
+          if (data) {
+            return {
+              props: {
+                type: 'post--newsletter',
+                id: data.id,
+                data
+              }
+            };
+          }
         }
-      };
-    }
-  }
 
-  return { notFound: true };
-};
+        return { notFound: true };
+      }
+  );
 
 export default NewsletterPage;

--- a/pages/newsletters/[slug].tsx
+++ b/pages/newsletters/[slug].tsx
@@ -1,17 +1,17 @@
 /**
- * @file pages/episodes/[year]/[month]/[day]/[slug].tsx
+ * @file pages/newsletters/[slug].tsx
  *
- * Episode page.
+ * Newsletter page.
  */
 
-import { Episode } from '@components/pages/Episode';
+import { Newsletter } from '@components/pages/Newsletter';
 import { IContentComponentProxyProps } from '@interfaces';
 import { fetchAppData } from '@store/actions/fetchAppData';
-import { fetchEpisodeData } from '@store/actions/fetchEpisodeData';
+import { fetchNewsletterData } from '@store/actions/fetchNewsletterData';
 import { GetServerSideProps } from 'next';
 
-const EpisodePage = ({ data }: IContentComponentProxyProps) => (
-  <Episode data={data} />
+const NewsletterPage = ({ data }: IContentComponentProxyProps) => (
+  <Newsletter data={data} />
 );
 
 export const getServerSideProps: GetServerSideProps<
@@ -23,14 +23,14 @@ export const getServerSideProps: GetServerSideProps<
 
   if (slug) {
     const [data, appData] = await Promise.all([
-      fetchEpisodeData(slug, 'SLUG'),
+      fetchNewsletterData(slug, 'SLUG'),
       fetchAppData()
     ]);
 
     if (data) {
       return {
         props: {
-          type: 'post--episode',
+          type: 'post--newsletter',
           id: data.id,
           cookies: req.cookies,
           data,
@@ -43,4 +43,4 @@ export const getServerSideProps: GetServerSideProps<
   return { notFound: true };
 };
 
-export default EpisodePage;
+export default NewsletterPage;

--- a/pages/programs/[slug]/index.tsx
+++ b/pages/programs/[slug]/index.tsx
@@ -23,9 +23,9 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
 
     if (slug) {
       const dataResponse = fetchProgramData(slug, 'SLUG');
-      const [data, appData] = await Promise.all([
+      const [data] = await Promise.all([
         store.dispatch<any>(dataResponse),
-        fetchAppData()
+        store.dispatch<any>(fetchAppData(req.cookies))
       ]);
 
       if (data) {
@@ -33,9 +33,7 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
           props: {
             type: 'term--program',
             id: data.id,
-            cookies: req.cookies,
-            data,
-            appData
+            data
           }
         };
       }

--- a/pages/programs/[slug]/team.tsx
+++ b/pages/programs/[slug]/team.tsx
@@ -6,41 +6,41 @@
 
 import { Team } from '@components/pages/Team';
 import { IContentComponentProxyProps } from '@interfaces';
+import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
 import { fetchProgramTeamData } from '@store/actions/fetchProgramTeamData';
-import { GetServerSideProps } from 'next';
 
 const ProgramTeamPage = ({ data }: IContentComponentProxyProps) => (
   <Team data={data} />
 );
 
-export const getServerSideProps: GetServerSideProps<
-  IContentComponentProxyProps
-> = async ({ req, params }) => {
-  const slug =
-    params?.slug &&
-    (typeof params.slug === 'string' ? params.slug : params.slug[0]);
+export const getServerSideProps =
+  wrapper.getServerSideProps<IContentComponentProxyProps>(
+    (store) =>
+      async ({ req, params }) => {
+        const slug =
+          params?.slug &&
+          (typeof params.slug === 'string' ? params.slug : params.slug[0]);
 
-  if (slug) {
-    const [data, appData] = await Promise.all([
-      fetchProgramTeamData(slug, 'SLUG'),
-      fetchAppData()
-    ]);
+        if (slug) {
+          const [data] = await Promise.all([
+            fetchProgramTeamData(slug, 'SLUG'),
+            store.dispatch<any>(fetchAppData(req.cookies))
+          ]);
 
-    if (data?.programContributors?.team?.length) {
-      return {
-        props: {
-          type: 'term--program-team',
-          id: data.id,
-          cookies: req.cookies,
-          data,
-          appData
+          if (data?.programContributors?.team?.length) {
+            return {
+              props: {
+                type: 'term--program-team',
+                id: data.id,
+                data
+              }
+            };
+          }
         }
-      };
-    }
-  }
 
-  return { notFound: true };
-};
+        return { notFound: true };
+      }
+  );
 
 export default ProgramTeamPage;

--- a/pages/segments/[year]/[month]/[day]/[slug].tsx
+++ b/pages/segments/[year]/[month]/[day]/[slug].tsx
@@ -6,41 +6,41 @@
 
 import { Segment } from '@components/pages/Segment';
 import { IContentComponentProxyProps } from '@interfaces';
+import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
 import { fetchSegmentData } from '@store/actions/fetchSegmentData';
-import { GetServerSideProps } from 'next';
 
 const SegmentPage = ({ data }: IContentComponentProxyProps) => (
   <Segment data={data} />
 );
 
-export const getServerSideProps: GetServerSideProps<
-  IContentComponentProxyProps
-> = async ({ req, params }) => {
-  const slug =
-    params?.slug &&
-    (typeof params.slug === 'string' ? params.slug : params.slug[0]);
+export const getServerSideProps =
+  wrapper.getServerSideProps<IContentComponentProxyProps>(
+    (store) =>
+      async ({ req, params }) => {
+        const slug =
+          params?.slug &&
+          (typeof params.slug === 'string' ? params.slug : params.slug[0]);
 
-  if (slug) {
-    const [data, appData] = await Promise.all([
-      fetchSegmentData(slug, 'SLUG'),
-      fetchAppData()
-    ]);
+        if (slug) {
+          const [data] = await Promise.all([
+            fetchSegmentData(slug, 'SLUG'),
+            store.dispatch<any>(fetchAppData(req.cookies))
+          ]);
 
-    if (data) {
-      return {
-        props: {
-          type: 'post--segment',
-          id: data.id,
-          cookies: req.cookies,
-          data,
-          appData
+          if (data) {
+            return {
+              props: {
+                type: 'post--segment',
+                id: data.id,
+                data
+              }
+            };
+          }
         }
-      };
-    }
-  }
 
-  return { notFound: true };
-};
+        return { notFound: true };
+      }
+  );
 
 export default SegmentPage;

--- a/pages/stories/[year]/[month]/[day]/[slug].tsx
+++ b/pages/stories/[year]/[month]/[day]/[slug].tsx
@@ -4,43 +4,43 @@
  * Story page.
  */
 
+import type { IContentComponentProxyProps } from '@interfaces';
 import { Story } from '@components/pages/Story';
-import { IContentComponentProxyProps } from '@interfaces';
 import { fetchAppData } from '@store/actions/fetchAppData';
+import { wrapper } from '@store/configureStore';
 import { fetchStoryData } from '@store/actions/fetchStoryData';
-import { GetServerSideProps } from 'next';
 
 const StoryPage = ({ data }: IContentComponentProxyProps) => (
   <Story data={data} />
 );
 
-export const getServerSideProps: GetServerSideProps<
-  IContentComponentProxyProps
-> = async ({ req, params }) => {
-  const slug =
-    params?.slug &&
-    (typeof params.slug === 'string' ? params.slug : params.slug[0]);
+export const getServerSideProps =
+  wrapper.getServerSideProps<IContentComponentProxyProps>(
+    (store) =>
+      async ({ req, params }) => {
+        const slug =
+          params?.slug &&
+          (typeof params.slug === 'string' ? params.slug : params.slug[0]);
 
-  if (slug) {
-    const [data, appData] = await Promise.all([
-      fetchStoryData(slug, 'SLUG'),
-      fetchAppData()
-    ]);
+        if (slug) {
+          const [data] = await Promise.all([
+            fetchStoryData(slug, 'SLUG'),
+            store.dispatch<any>(fetchAppData(req.cookies))
+          ]);
 
-    if (data) {
-      return {
-        props: {
-          type: 'post--story',
-          id: data.id,
-          cookies: req.cookies,
-          data,
-          appData
+          if (data) {
+            return {
+              props: {
+                type: 'post--story',
+                id: data.id,
+                data
+              }
+            };
+          }
         }
-      };
-    }
-  }
 
-  return { notFound: true };
-};
+        return { notFound: true };
+      }
+  );
 
 export default StoryPage;

--- a/pages/tags/[...slug].tsx
+++ b/pages/tags/[...slug].tsx
@@ -26,9 +26,9 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
 
     if (slug) {
       const dataResponse = fetchTagData(slug, 'SLUG', taxonomySingleName);
-      const [data, appData] = await Promise.all([
+      const [data] = await Promise.all([
         store.dispatch<any>(dataResponse),
-        fetchAppData()
+        store.dispatch<any>(fetchAppData(req.cookies))
       ]);
 
       if (data) {
@@ -36,9 +36,7 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
           props: {
             type: 'term--tag',
             id: data.id,
-            cookies: req.cookies,
-            data,
-            appData
+            data
           }
         };
       }

--- a/pages/tags/[slug].tsx
+++ b/pages/tags/[slug].tsx
@@ -21,9 +21,9 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
 
     if (slug) {
       const dataResponse = fetchTagData(slug, 'SLUG');
-      const [data, appData] = await Promise.all([
+      const [data] = await Promise.all([
         store.dispatch<any>(dataResponse),
-        fetchAppData()
+        store.dispatch<any>(fetchAppData(req.cookies))
       ]);
 
       if (data) {
@@ -31,9 +31,7 @@ export const getServerSideProps: GetServerSideProps<IContentComponentProxyProps>
           props: {
             type: 'term--tag',
             id: data.id,
-            cookies: req.cookies,
-            data,
-            appData
+            data
           }
         };
       }

--- a/store/actions/fetchCategoryData.ts
+++ b/store/actions/fetchCategoryData.ts
@@ -5,7 +5,7 @@
  */
 import type { AnyAction } from 'redux';
 import type { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import type { Category, RootState } from '@interfaces';
+import type { Category, ICtaFilterProps, RootState } from '@interfaces';
 import { fetchGqlCategory, fetchGqlCategoryPosts } from '@lib/fetch';
 import { getCollectionData } from '@store/reducers';
 import { appendResourceCollection } from './appendResourceCollection';
@@ -26,23 +26,19 @@ export const fetchCategoryData =
       const { episodes, ...categoryData } = category;
       const state = getState();
 
-      // const ctaDataPromise = dispatch<any>(
-      //   fetchCtaRegionGroupData('tw_cta_regions_landing')
-      // );
-
-      // // Set CTA filter props.
-      // dispatch({
-      //   type: 'SET_RESOURCE_CTA_FILTER_PROPS',
-      //   payload: {
-      //     filterProps: {
-      //       type,
-      //       id,
-      //       props: {
-      //         category: id
-      //       }
-      //     }
-      //   } as ICtaFilterProps
-      // });
+      // Set CTA filter props.
+      dispatch({
+        type: 'SET_RESOURCE_CTA_FILTER_PROPS',
+        payload: {
+          filterProps: {
+            type,
+            id: category.id,
+            props: {
+              categories: [category.id]
+            } as ICtaFilterProps
+          }
+        }
+      });
 
       // Get first page of stories.
       const storiesCollection = getCollectionData(

--- a/store/actions/fetchEpisodeData.ts
+++ b/store/actions/fetchEpisodeData.ts
@@ -1,7 +1,7 @@
 /**
- * @file fetchAudioData.ts
+ * @file fetchEpisodeData.ts
  *
- * Actions to fetch data for a audio resource.
+ * Actions to fetch data for a episode resource.
  */
 
 import { fetchGqlEpisode } from '@lib/fetch';

--- a/store/actions/fetchNewsletterData.ts
+++ b/store/actions/fetchNewsletterData.ts
@@ -1,50 +1,13 @@
 /**
- * @file fetchStoryData.ts
+ * @file fetchNewsletterData.ts
  *
- * Actions to fetch data for a story resource.
+ * Actions to fetch data for a newsletter resource.
  */
-import { AnyAction } from 'redux';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import {
-  IPriApiResource,
-  IPriApiResourceResponse
-} from 'pri-api-library/types';
-import { RootState } from '@interfaces/state';
-import { getDataByResource } from '@store/reducers';
-import { fetchApiNewsletter, fetchNewsletter } from '@lib/fetch';
 
-export const fetchNewsletterData =
-  (id: string): ThunkAction<void, {}, {}, AnyAction> =>
-  async (
-    dispatch: ThunkDispatch<{}, {}, AnyAction>,
-    getState: () => RootState
-  ): Promise<IPriApiResource> => {
-    const state = getState();
-    const type = 'node--newsletter_sign_ups';
-    const isOnServer = typeof window === 'undefined';
-    let data = getDataByResource<any>(state, type, id);
+import { fetchGqlNewsletter } from '@lib/fetch';
 
-    if (!data || !data.complete || isOnServer) {
-      dispatch({
-        type: 'FETCH_CONTENT_DATA_REQUEST',
-        payload: {
-          type,
-          id
-        }
-      });
+export const fetchNewsletterData = async (id: string, idType?: string) => {
+  const newsletter = await fetchGqlNewsletter(id, idType);
 
-      data = await (isOnServer ? fetchNewsletter : fetchApiNewsletter)(id).then(
-        (resp: IPriApiResourceResponse) => resp && resp.data
-      );
-
-      dispatch({
-        type: 'FETCH_CONTENT_DATA_SUCCESS',
-        payload: {
-          ...data,
-          complete: true
-        }
-      });
-    }
-
-    return data;
-  };
+  return newsletter;
+};

--- a/store/reducers/appData.ts
+++ b/store/reducers/appData.ts
@@ -1,0 +1,29 @@
+/**
+ * @file appData.ts
+ *
+ * Reducers for handling app data.
+ */
+
+import { HYDRATE } from 'next-redux-wrapper';
+import type { AppDataAction, HydrateAction, Maybe } from '@interfaces';
+import { AppDataState } from '@interfaces/state';
+
+export const appData = (state: AppDataState, action: AppDataAction) => {
+  switch (action?.type) {
+    case HYDRATE:
+      return { ...state, ...(action as HydrateAction).payload?.appData };
+    case 'FETCH_APP_DATA_SUCCESS':
+      return {
+        ...state,
+        ...action.payload
+      };
+
+    default:
+      return state || null;
+  }
+};
+
+export const getAppDataMenu = (state: Maybe<AppDataState>, menu: string) =>
+  state?.menus?.[menu];
+export const getAppDataLatestStories = (state: Maybe<AppDataState>) =>
+  state?.latestStories;

--- a/store/reducers/ctaRegionGroupData.ts
+++ b/store/reducers/ctaRegionGroupData.ts
@@ -61,11 +61,21 @@ export const getCtaRegionData = (
   id?: string | number
 ) => {
   const messages = type
-    ? state?.data?.[region]?.filter(
-        filterCtaMessages(
-          state.filterProps?.[makeResourceSignature({ type, id })]
+    ? state?.data?.[region]
+        ?.map((cta) => ({
+          priority:
+            (cta.targetContent && 2) ||
+            ((cta.targetCategories || cta.targetPrograms) && 1) ||
+            0,
+          cta
+        }))
+        .sort((a, b) => b.priority - a.priority)
+        .map((item) => item.cta)
+        .filter(
+          filterCtaMessages(
+            state.filterProps?.[makeResourceSignature({ type, id })]
+          )
         )
-      )
     : state?.data?.[region];
 
   return messages?.length ? messages : undefined;

--- a/store/reducers/index.ts
+++ b/store/reducers/index.ts
@@ -1,6 +1,7 @@
 import type { ContentNode } from '@interfaces';
 import { combineReducers } from 'redux';
 import { RootState } from '@interfaces/state';
+import * as fromAppData from './appData';
 import * as fromAliasData from './aliasData';
 import * as fromCollections from './collections';
 import * as fromContentData from './contentData';
@@ -10,6 +11,7 @@ import * as fromSearch from './search';
 import * as fromUi from './ui';
 
 export const initialState: RootState = {
+  appData: null,
   aliasData: {},
   contentData: {},
   collections: {},
@@ -31,6 +33,7 @@ export const initialState: RootState = {
 };
 
 export const reducers = combineReducers({
+  appData: fromAppData.appData,
   aliasData: fromAliasData.aliasData,
   contentData: fromContentData.contentData,
   collections: fromCollections.collections,
@@ -39,6 +42,12 @@ export const reducers = combineReducers({
   search: fromSearch.search,
   ui: fromUi.ui
 });
+
+export const getAppData = (state: RootState) => state?.appData;
+export const getAppDataMenu = (state: RootState, menu: string) =>
+  fromAppData.getAppDataMenu(getAppData(state), menu);
+export const getAppDataLatestStories = (state: RootState) =>
+  fromAppData.getAppDataLatestStories(getAppData(state));
 
 export const getDataByAlias = (state: RootState, alias: string) =>
   fromAliasData.getAliasData(state.aliasData, alias);


### PR DESCRIPTION
Closes #419 

- fetch CTA data with WP GraphQL API
- fix styling of banner and load-under CTA messages
- move bio segments list pagination into sidebar list component for performance and reusability
- update categories subcategory list to use paginated sidebar list
- add search to sidebar list component

## To Review

- [x] Checkout and update lando `main` branch.
- [x] Import latest backup of live WP env into lando.
- [x] Add one of each type of Call To Action to Site CTA Regions. Include the Planet Hip Hop playlist CTA.
- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Ensure all CTA Regions show the expected Call To Action.
- [ ] Dismiss the banner CTA.
- [x] Go to http://localhost:3000/categories/arts-culture-media/music/planet-hip-hop
- [x] Ensure Banner and Load-under regions update to the targeted CTA.
- [x] Ensure playlist CTA is shown in the expected inline region.
- [x] Dismiss banner CTA and refresh page.
- [x] Ensure next expected CTA is shown. If the banner and load-under were the same CTA, the load under CTA should have changes as well.
- [x] Repeat dismiss and refresh steps, and ensure each type of CTA's styles look good.
- [ ] Browse around stories, episodes, programs, etc. Ensure CTA are shown as expected.
- [x] Go to http://localhost:3000/categories/conflict-justice
- [x] Test pagination and search of the Subcategories sidebar list.
- [x] Go to http://localhost:3000/contributors/daniel-ofman
- [x] Test pagination and search of the segments sidebar list.
