### PR TITLE
423: Add support for Datawrapper chart embeds to HtmlContent component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
     "cflds",
     "clsx",
     "customsearch",
+    "Datawrapper",
     "denormalize",
     "Denormalized",
     "flipboard",

--- a/components/DatawrapperEmbed/DatawrapperEmbed.tsx
+++ b/components/DatawrapperEmbed/DatawrapperEmbed.tsx
@@ -1,0 +1,50 @@
+/**
+ * @file DatawrapperEmbed.tsx
+ * Component for datawrapperEmbed elements.
+ */
+
+import { Box } from '@mui/material';
+import type { DetailedHTMLProps, IframeHTMLAttributes } from 'react';
+import { useEffect, useState } from 'react';
+
+export interface IDatawrapperEmbedProps extends DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> {
+  frameborder?: string;
+}
+
+export const DatawrapperEmbed = ({
+  title,
+  height,
+  frameborder,
+  style,
+  ...iframeAttribs
+}: IDatawrapperEmbedProps) => {
+  const chartId = iframeAttribs.id?.split('-').pop();
+  const [iframeHeight, setIframeHeight] = useState(height);
+
+  function handleMessage(a: MessageEvent) {
+    const newHeight = chartId && a.data['datawrapper-height']?.[chartId]
+    if (newHeight && newHeight !== height) {
+      setIframeHeight(newHeight)
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    }
+  }, []);
+
+  if(!chartId) return null;
+
+  return (
+    <Box sx={{ my: 6 }}>
+      <iframe
+        title={title}
+        style={{ height: `${iframeHeight}px`, width: 0, minWidth: '100%', border: 'none'}}
+        {...iframeAttribs}
+      />
+    </Box>
+  );
+};

--- a/components/DatawrapperEmbed/index.ts
+++ b/components/DatawrapperEmbed/index.ts
@@ -1,0 +1,1 @@
+export * from './DatawrapperEmbed';

--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -9,6 +9,7 @@ import ReactHtmlParser, { type Transform } from 'react-html-parser';
 import {
   anchorToLink,
   audioDescendant,
+  datawrapperEmbed,
   facebookPost,
   facebookVideo,
   fbRootRemove,
@@ -40,6 +41,7 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
     [
       anchorToLink,
       audioDescendant,
+      datawrapperEmbed,
       facebookPost,
       facebookVideo,
       fbRootRemove,

--- a/components/HtmlContent/transforms/audioDescendant.tsx
+++ b/components/HtmlContent/transforms/audioDescendant.tsx
@@ -31,18 +31,6 @@ export const audioDescendant = (node: DomElement) => {
         data={{
           id: '',
           type: '',
-          self: '',
-          metatags: null,
-          title: '',
-          audioTitle: '',
-          description: '',
-          date: null,
-          broadcastDate: null,
-          metadata: null,
-          audioAuthor: null,
-          program: null,
-          segments: null,
-          usage: null,
           url: src
         }}
       />

--- a/components/HtmlContent/transforms/datawrapperEmbed.tsx
+++ b/components/HtmlContent/transforms/datawrapperEmbed.tsx
@@ -1,0 +1,36 @@
+/**
+ * @file datawrapperEmbed.tsx
+ *
+ * Converts a Datawrapper iframe embed to a DatawrapperEmbed component.
+ */
+
+import type { DomElement } from 'htmlparser2';
+import { findDescendant } from '@lib/parse/html';
+import { DatawrapperEmbed } from '@components/DatawrapperEmbed';
+
+export const datawrapperEmbed = (
+  node: DomElement
+) => {
+  const dwEmbedIframe = findDescendant(node, (n: DomElement) => {
+    if (n.type === 'tag' && n.name === 'iframe' && n.attribs.id?.includes('datawrapper')) {
+
+      return n;
+    }
+    return false;
+  });
+
+  if (
+    dwEmbedIframe
+  ) {
+    // Return DatawrapperEmbed.
+    const {
+      attribs
+    } = dwEmbedIframe;
+
+    return (
+      <DatawrapperEmbed {...attribs} />
+    );
+  }
+
+  return undefined;
+};

--- a/components/HtmlContent/transforms/index.ts
+++ b/components/HtmlContent/transforms/index.ts
@@ -1,5 +1,6 @@
 export * from './anchorToLink';
 export * from './audioDescendant';
+export * from './datawrapperEmbed';
 export * from './enhanceImage';
 export * from './facebookPost';
 export * from './facebookVideo';

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -23,7 +23,7 @@ export const Sidebar = ({
   elevated
 }: ISidebarProps) => {
   const { classes, cx } = sidebarStyles();
-  const component = item ? 'aside' : null;
+  const component = item ? 'aside' : undefined;
 
   return (
     <Box

--- a/interfaces/content/audio.interface.ts
+++ b/interfaces/content/audio.interface.ts
@@ -17,35 +17,34 @@ export interface IAudioResource extends IPriApiResource {
   /**
    * Meta tags for resource page.
    */
-  metatags: {
-    canonical: string;
-    [k: string]: string;
+  metatags?: {
+    [k: string]: string | null;
   };
 
   /**
    * System title of resource.
    */
-  title: string;
+  title?: string;
 
   /**
    * Display title.
    */
-  audioTitle: string;
+  audioTitle?: string;
 
   /**
    * Description of audio content.
    */
-  description: string;
+  description?: string;
 
   /**
    * System created date for resource.
    */
-  date: string;
+  date?: string;
 
   /**
    * Broadcast data of audio content.
    */
-  broadcastDate: string;
+  broadcastDate?: string;
 
   /**
    * Audio file URL.
@@ -55,7 +54,7 @@ export interface IAudioResource extends IPriApiResource {
   /**
    * File metadata.
    */
-  metadata: {
+  metadata?: {
     duration: string;
     size: string;
     mime: string;
@@ -64,22 +63,22 @@ export interface IAudioResource extends IPriApiResource {
   /**
    * Array authors of the audio content.
    */
-  audioAuthor: IPriApiResource[];
+  audioAuthor?: IPriApiResource[];
 
   /**
    * Program owning audio content.
    */
-  program: IPriApiResource;
+  program?: IPriApiResource;
 
   /**
    * Segment audio resources.
    */
-  segments: IAudioResource[];
+  segments?: IAudioResource[];
 
   /**
    * Resource the audio is associated with.
    */
-  usage:
+  usage?:
     | []
     | {
         episode?: IAudioUsage[];


### PR DESCRIPTION
Closes #423 

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to http://localhost:3000/stories/2023-09-05/student-loans-can-be-simple-and-automatic-other-countries-offer-lessons-us

> ...then...

- [x] Ensure chart iframes are rendered in the content.
- [x] Resize window and ensure charts resize responsively.
