### PR TITLE
421: Social Share Links

### DIFF
--- a/components/AppHeader/DrawerSocialNav/DrawerSocialNav.tsx
+++ b/components/AppHeader/DrawerSocialNav/DrawerSocialNav.tsx
@@ -5,29 +5,36 @@
 
 import type { IButtonWithUrl, RootState } from '@interfaces';
 import { useStore } from 'react-redux';
-import { IconButton, Toolbar } from '@mui/material';
+import { IconButton, SvgIcon, Toolbar } from '@mui/material';
 import { isLocalUrl } from '@lib/parse/url';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  Facebook,
-  Twitter,
-  RssFeed,
-  Instagram,
-  WhatsApp
-} from '@mui/icons-material';
+  faFacebook,
+  faInstagram,
+  faXTwitter,
+  faLinkedin,
+  faFlipboard,
+  faWhatsapp
+} from '@fortawesome/free-brands-svg-icons';
 import { getAppDataMenu } from '@store/reducers';
 import { drawerTopNavStyles } from './DrawerSocialNav.styles';
 
 const iconComponentMap = new Map();
-iconComponentMap.set('facebook', Facebook);
-iconComponentMap.set('twitter', Twitter);
-iconComponentMap.set('rss', RssFeed);
-iconComponentMap.set('instagram', Instagram);
-iconComponentMap.set('whatsapp', WhatsApp);
+[
+  ['facebook', <FontAwesomeIcon icon={faFacebook} aria-label="Facebook" />],
+  ['instagram', <FontAwesomeIcon icon={faInstagram} aria-label="Instagram" />],
+  ['twitter', <FontAwesomeIcon icon={faXTwitter} aria-label="Twitter" />],
+  ['linkedin', <FontAwesomeIcon icon={faLinkedin} aria-label="LinkedIn" />],
+  ['flipboard', <FontAwesomeIcon icon={faFlipboard} aria-label="Flipboard" />],
+  ['whatsapp', <FontAwesomeIcon icon={faWhatsapp} aria-label="WhatsApp" />]
+].forEach(([key, icon]) => {
+  iconComponentMap.set(key, icon);
+});
 
 const renderIcon = (icon: string, label: string) => {
   const IconComponent = iconComponentMap.get(icon);
 
-  return (IconComponent && <IconComponent aria-label={label} />) || label;
+  return (IconComponent && <SvgIcon>{IconComponent}</SvgIcon>) || label;
 };
 
 export const DrawerSocialNav = () => {

--- a/components/SocialShareMenu/SocialShareMenu.tsx
+++ b/components/SocialShareMenu/SocialShareMenu.tsx
@@ -11,7 +11,7 @@ import { useStore } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faFacebook,
-  faTwitter,
+  faXTwitter,
   faLinkedin,
   faFlipboard,
   faWhatsapp
@@ -30,7 +30,7 @@ import { useSocialShareMenuStyles } from './SocialShareMenu.styles';
 const defaultIconsMap = new Map();
 [
   ['facebook', <FontAwesomeIcon size="sm" icon={faFacebook} />],
-  ['twitter', <FontAwesomeIcon size="sm" icon={faTwitter} />],
+  ['twitter', <FontAwesomeIcon size="sm" icon={faXTwitter} />],
   ['linkedin', <FontAwesomeIcon size="sm" icon={faLinkedin} />],
   ['flipboard', <FontAwesomeIcon size="sm" icon={faFlipboard} />],
   ['whatsapp', <FontAwesomeIcon size="sm" icon={faWhatsapp} />],

--- a/interfaces/content/content.interface.ts
+++ b/interfaces/content/content.interface.ts
@@ -3,6 +3,8 @@
  * Interfaces for content.
  */
 
+import { ISocialLink } from '@interfaces/social';
+
 export interface IContentComponentProps<D> {
   data: D;
 }
@@ -14,6 +16,7 @@ export interface IContentComponentProxyProps {
   redirect?: string;
   data?: any;
   cookies?: any;
+  shareLinks?: ISocialLink[];
 }
 
 export interface IContentContext {

--- a/interfaces/social/social.interface.ts
+++ b/interfaces/social/social.interface.ts
@@ -3,10 +3,37 @@
  * Interfaces for icons.
  */
 
+export const socialShareKeys = [
+  'twitter',
+  'facebook',
+  'linkedin',
+  'flipboard',
+  'whatsapp',
+  'email'
+] as const;
+export type SocialShareKey = (typeof socialShareKeys)[number];
+
+const socialShareTitles = [
+  'Twitter',
+  'Facebook',
+  'LinkedIn',
+  'Flipboard',
+  'WhatsApp',
+  'Email'
+] as const;
+export type SocialShareTitle = (typeof socialShareTitles)[number];
+export const socialShareTitlesMap = new Map<SocialShareKey, SocialShareTitle>();
+socialShareTitlesMap.set('twitter', 'Twitter');
+socialShareTitlesMap.set('facebook', 'Facebook');
+socialShareTitlesMap.set('linkedin', 'LinkedIn');
+socialShareTitlesMap.set('flipboard', 'Flipboard');
+socialShareTitlesMap.set('whatsapp', 'WhatsApp');
+socialShareTitlesMap.set('email', 'Email');
+
 export interface ISocialLink {
-  key: string;
+  key: SocialShareKey;
   link: {
-    title: string;
+    title: SocialShareTitle;
     url: string;
   };
 }

--- a/lib/fetch/episode/fetchGqlEpisode.ts
+++ b/lib/fetch/episode/fetchGqlEpisode.ts
@@ -2,7 +2,7 @@
  * Fetch Episode data from WP GraphQL API.
  */
 
-import type { Episode, Maybe } from '@interfaces';
+import type { Episode, EpisodeIdType, Maybe } from '@interfaces';
 import { gql } from '@apollo/client';
 import { gqlClient } from '@lib/fetch/api';
 import {
@@ -99,7 +99,7 @@ const GET_EPISODE = gql`
   ${AUDIO_PARENT_PROPS}
 `;
 
-export async function fetchGqlEpisode(id: string, idType?: string) {
+export async function fetchGqlEpisode(id: string, idType?: EpisodeIdType) {
   const response = await gqlClient.query<{
     episode: Maybe<Episode>;
   }>({

--- a/lib/fetch/segment/fetchGqlSegment.ts
+++ b/lib/fetch/segment/fetchGqlSegment.ts
@@ -4,7 +4,7 @@
  * @param id Segment identifier.
  */
 
-import type { Maybe, Segment } from '@interfaces';
+import type { Maybe, Segment, SegmentIdType } from '@interfaces';
 import { gql } from '@apollo/client';
 import { gqlClient } from '@lib/fetch/api';
 import { IMAGE_PROPS, POST_SEO_PROPS } from '@lib/fetch/api/graphql';
@@ -13,6 +13,7 @@ const GET_SEGMENT = gql`
   query getSegment($id: ID!, $idType: SegmentIdType) {
     segment(id: $id, idType: $idType) {
       id
+      link
       title
       content
       contributors {
@@ -49,7 +50,7 @@ const GET_SEGMENT = gql`
   ${IMAGE_PROPS}
 `;
 
-export async function fetchGqlSegment(id: string, idType?: string) {
+export async function fetchGqlSegment(id: string, idType?: SegmentIdType) {
   const response = await gqlClient.query<{
     segment: Maybe<Segment>;
   }>({

--- a/lib/generate/social/generateShareLinks.ts
+++ b/lib/generate/social/generateShareLinks.ts
@@ -1,0 +1,112 @@
+import {
+  ISocialLink,
+  Maybe,
+  SocialShareKey,
+  socialShareKeys,
+  socialShareTitlesMap
+} from '@interfaces';
+
+export function generateShareLink(key: SocialShareKey, url: string) {
+  const title = socialShareTitlesMap.get(key);
+  return {
+    key,
+    link: {
+      url,
+      title
+    }
+  } as ISocialLink;
+}
+
+const socialShareTransformers = new Map<
+  SocialShareKey,
+  // eslint-disable-next-line no-unused-vars
+  (url: string, text?: Maybe<string>) => ISocialLink
+>();
+
+socialShareTransformers.set('twitter', (url, text) => {
+  const shareLinkUrl = new URL('http://twitter.com/share');
+
+  shareLinkUrl.searchParams.set('url', url);
+
+  if (text) shareLinkUrl.searchParams.set('text', text);
+
+  return generateShareLink('twitter', shareLinkUrl.toString());
+});
+
+socialShareTransformers.set('facebook', (url) => {
+  const shareLinkUrl = new URL('http://www.facebook.com/sharer.php');
+
+  shareLinkUrl.searchParams.set('u', url);
+
+  return generateShareLink('facebook', shareLinkUrl.toString());
+});
+
+socialShareTransformers.set('linkedin', (url, text) => {
+  const shareLinkUrl = new URL('https://www.linkedin.com/shareArticle');
+
+  shareLinkUrl.searchParams.set('mini', '1');
+  shareLinkUrl.searchParams.set('url', url);
+
+  if (text) shareLinkUrl.searchParams.set('title', text);
+
+  return generateShareLink('linkedin', shareLinkUrl.toString());
+});
+
+socialShareTransformers.set('flipboard', (url, text) => {
+  const shareLinkUrl = new URL(
+    'https://share.flipboard.com/bookmarklet/popout'
+  );
+
+  shareLinkUrl.searchParams.set('v', '2');
+  shareLinkUrl.searchParams.set('url', url);
+  shareLinkUrl.searchParams.set('utm_campaign', 'tools');
+  shareLinkUrl.searchParams.set('utm_medium', 'article-share');
+  shareLinkUrl.searchParams.set('utm_source', 'theworld.org');
+
+  if (text) shareLinkUrl.searchParams.set('title', text);
+
+  return generateShareLink('flipboard', shareLinkUrl.toString());
+});
+
+socialShareTransformers.set('whatsapp', (url) => {
+  const shareLinkUrl = new URL('https://api.whatsapp.com/send');
+
+  shareLinkUrl.searchParams.set(
+    'text',
+    `Check out what's on TheWorld.org: ${url}`
+  );
+
+  return generateShareLink('whatsapp', shareLinkUrl.toString());
+});
+
+socialShareTransformers.set('email', (url, text) => {
+  const shareLinkUrl = new URL('mailto:');
+
+  shareLinkUrl.searchParams.set(
+    'body',
+    `Check out what's on TheWorld.org: ${url}`
+  );
+
+  if (text) shareLinkUrl.searchParams.set('subject', text);
+
+  return generateShareLink('email', shareLinkUrl.toString());
+});
+
+export function generateShareLinks(url: string, text?: Maybe<string>) {
+  const linkProtocol = 'https';
+  const linkHostname = 'theworld.org';
+  const linkUrl = new URL(url, `${linkProtocol}://${linkHostname}`);
+
+  linkUrl.protocol = linkProtocol;
+  linkUrl.hostname = linkHostname;
+
+  const shareLinks = socialShareKeys
+    .map((key) => {
+      const func = socialShareTransformers.get(key);
+
+      return func && func(linkUrl.toString(), text);
+    })
+    .filter((v): v is ISocialLink => !!v);
+
+  return shareLinks;
+}

--- a/lib/generate/social/index.ts
+++ b/lib/generate/social/index.ts
@@ -1,0 +1,1 @@
+export * from './generateShareLinks';

--- a/pages/episodes/[year]/[month]/[day]/[slug].tsx
+++ b/pages/episodes/[year]/[month]/[day]/[slug].tsx
@@ -5,10 +5,11 @@
  */
 
 import { Episode } from '@components/pages/Episode';
-import { IContentComponentProxyProps } from '@interfaces';
+import { EpisodeIdType, IContentComponentProxyProps } from '@interfaces';
 import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
 import { fetchEpisodeData } from '@store/actions/fetchEpisodeData';
+import { generateShareLinks } from '@lib/generate/social';
 
 const EpisodePage = ({ data }: IContentComponentProxyProps) => (
   <Episode data={data} />
@@ -24,15 +25,20 @@ export const getServerSideProps =
 
         if (slug) {
           const [data] = await Promise.all([
-            fetchEpisodeData(slug, 'SLUG'),
+            fetchEpisodeData(slug, EpisodeIdType.Slug),
             store.dispatch<any>(fetchAppData(req.cookies))
           ]);
 
           if (data) {
+            const { link, title } = data;
+            const shareLinks =
+              link != null ? generateShareLinks(link, title) : undefined;
+
             return {
               props: {
                 type: 'post--episode',
                 id: data.id,
+                ...(shareLinks && { shareLinks }),
                 data
               }
             };

--- a/pages/segments/[year]/[month]/[day]/[slug].tsx
+++ b/pages/segments/[year]/[month]/[day]/[slug].tsx
@@ -5,10 +5,11 @@
  */
 
 import { Segment } from '@components/pages/Segment';
-import { IContentComponentProxyProps } from '@interfaces';
+import { IContentComponentProxyProps, SegmentIdType } from '@interfaces';
 import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
 import { fetchSegmentData } from '@store/actions/fetchSegmentData';
+import { generateShareLinks } from '@lib/generate/social';
 
 const SegmentPage = ({ data }: IContentComponentProxyProps) => (
   <Segment data={data} />
@@ -24,15 +25,20 @@ export const getServerSideProps =
 
         if (slug) {
           const [data] = await Promise.all([
-            fetchSegmentData(slug, 'SLUG'),
+            fetchSegmentData(slug, SegmentIdType.Slug),
             store.dispatch<any>(fetchAppData(req.cookies))
           ]);
 
           if (data) {
+            const { link, title } = data;
+            const shareLinks =
+              link != null ? generateShareLinks(link, title) : undefined;
+
             return {
               props: {
                 type: 'post--segment',
                 id: data.id,
+                ...(shareLinks && { shareLinks }),
                 data
               }
             };

--- a/pages/stories/[year]/[month]/[day]/[slug].tsx
+++ b/pages/stories/[year]/[month]/[day]/[slug].tsx
@@ -4,11 +4,12 @@
  * Story page.
  */
 
-import type { IContentComponentProxyProps } from '@interfaces';
+import { PostIdType, type IContentComponentProxyProps } from '@interfaces';
 import { Story } from '@components/pages/Story';
 import { fetchAppData } from '@store/actions/fetchAppData';
 import { wrapper } from '@store/configureStore';
 import { fetchStoryData } from '@store/actions/fetchStoryData';
+import { generateShareLinks } from '@lib/generate/social';
 
 const StoryPage = ({ data }: IContentComponentProxyProps) => (
   <Story data={data} />
@@ -24,15 +25,20 @@ export const getServerSideProps =
 
         if (slug) {
           const [data] = await Promise.all([
-            fetchStoryData(slug, 'SLUG'),
+            fetchStoryData(slug, PostIdType.Slug),
             store.dispatch<any>(fetchAppData(req.cookies))
           ]);
 
           if (data) {
+            const { link, title } = data;
+            const shareLinks =
+              link != null ? generateShareLinks(link, title) : undefined;
+
             return {
               props: {
                 type: 'post--story',
                 id: data.id,
+                ...(shareLinks && { shareLinks }),
                 data
               }
             };

--- a/store/actions/fetchEpisodeData.ts
+++ b/store/actions/fetchEpisodeData.ts
@@ -4,37 +4,11 @@
  * Actions to fetch data for a episode resource.
  */
 
+import { EpisodeIdType } from '@interfaces';
 import { fetchGqlEpisode } from '@lib/fetch';
 
-export const fetchEpisodeData = async (id: string, idType?: string) => {
-  const dataPromise = fetchGqlEpisode(id, idType);
-
-  // const ctaDataPromise = dispatch<any>(
-  //   fetchCtaRegionGroupData('tw_cta_regions_content')
-  // );
-
-  const episode = await dataPromise;
-  // await ctaDataPromise;
-
-  if (episode) {
-    // Set CTA filter props.
-    // dispatch({
-    //   type: 'SET_RESOURCE_CTA_FILTER_PROPS',
-    //   payload: {
-    //     filterProps: {
-    //       type,
-    //       id,
-    //       props: {
-    //         id,
-    //         categories: [
-    //           ...(story.categories?.nodes || []).map(({ id: tid }) => tid)
-    //         ].filter((v: any) => !!v),
-    //         program: story.programs?.nodes[0].id || null
-    //       }
-    //     }
-    //   } as ICtaFilterProps
-    // });
-  }
+export const fetchEpisodeData = async (id: string, idType?: EpisodeIdType) => {
+  const episode = await fetchGqlEpisode(id, idType);
 
   return episode;
 };

--- a/store/actions/fetchSegmentData.ts
+++ b/store/actions/fetchSegmentData.ts
@@ -4,37 +4,11 @@
  * Actions to fetch data for a audio resource.
  */
 
+import { SegmentIdType } from '@interfaces';
 import { fetchGqlSegment } from '@lib/fetch';
 
-export const fetchSegmentData = async (id: string, idType?: string) => {
-  const dataPromise = await fetchGqlSegment(id, idType);
-
-  // const ctaDataPromise = dispatch<any>(
-  //   fetchCtaRegionGroupData('tw_cta_regions_content')
-  // );
-
-  const segment = await dataPromise;
-  // await ctaDataPromise;
-
-  if (segment) {
-    // Set CTA filter props.
-    // dispatch({
-    //   type: 'SET_RESOURCE_CTA_FILTER_PROPS',
-    //   payload: {
-    //     filterProps: {
-    //       type,
-    //       id,
-    //       props: {
-    //         id,
-    //         categories: [
-    //           ...(story.categories?.nodes || []).map(({ id: tid }) => tid)
-    //         ].filter((v: any) => !!v),
-    //         program: story.programs?.nodes[0].id || null
-    //       }
-    //     }
-    //   } as ICtaFilterProps
-    // });
-  }
+export const fetchSegmentData = async (id: string, idType?: SegmentIdType) => {
+  const segment = await fetchGqlSegment(id, idType);
 
   return segment;
 };

--- a/store/actions/fetchStoryData.ts
+++ b/store/actions/fetchStoryData.ts
@@ -7,7 +7,7 @@
 import { fetchGqlStory } from '@lib/fetch';
 import { IPriApiResource } from 'pri-api-library/types';
 import _uniqBy from 'lodash/uniqBy';
-// import { fetchCtaRegionGroupData } from './fetchCtaRegionGroupData';
+import { PostIdType } from '@interfaces';
 
 export const decorateWithBylines = (story: IPriApiResource) => {
   const { byline: b, bylines: bs, ...other } = story;
@@ -40,35 +40,8 @@ export const decorateWithBylines = (story: IPriApiResource) => {
   };
 };
 
-export const fetchStoryData = async (id: string, idType?: string) => {
-  const dataPromise = fetchGqlStory(id, idType);
-
-  // const ctaDataPromise = dispatch<any>(
-  //   fetchCtaRegionGroupData('tw_cta_regions_content')
-  // );
-
-  const story = await dataPromise;
-  // await ctaDataPromise;
-
-  if (story) {
-    // Set CTA filter props.
-    // dispatch({
-    //   type: 'SET_RESOURCE_CTA_FILTER_PROPS',
-    //   payload: {
-    //     filterProps: {
-    //       type,
-    //       id,
-    //       props: {
-    //         id,
-    //         categories: [
-    //           ...(story.categories?.nodes || []).map(({ id: tid }) => tid)
-    //         ].filter((v: any) => !!v),
-    //         program: story.programs?.nodes[0].id || null
-    //       }
-    //     }
-    //   } as ICtaFilterProps
-    // });
-  }
+export const fetchStoryData = async (id: string, idType?: PostIdType) => {
+  const story = await fetchGqlStory(id, idType);
 
   return story;
 };


### PR DESCRIPTION
Closes #421 

- Adds social share links to content pages
- Fixes story's related stories to not include card for the current story

## To Review

- [ ] Checkout and update lando to `main` branch and run `lando start`
- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Go to any recent story and ensure share link FAB is shown and its links share the correct URL and title.
- [ ] Ensure related stories doesn't have a card for the current story.
- [ ] Go to any episode and ensure share link FAB is shown and its links share the correct URL and title.
- [ ] Go to any segment and ensure share link FAB is shown and its links share the correct URL and title.
