### PR TITLE
351: Styling for Gutenberg content blocks

### DIFF
--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -43,6 +43,13 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
 
   const transform = (node: DomElement, index: number) =>
     [
+      // Transform to add `key` attribute to all tag nodes.
+      (n: DomElement, t: Transform, i: number) => {
+        if (n.type === 'tag') {
+          // eslint-disable-next-line no-param-reassign
+          n.attribs.key = `${n.name}:${i}`;
+        }
+      },
       anchorToLink,
       audioDescendant,
       datawrapperEmbed,

--- a/components/HtmlContent/transforms/anchorToLink.tsx
+++ b/components/HtmlContent/transforms/anchorToLink.tsx
@@ -9,15 +9,6 @@ import { generateContentLinkHref } from '@lib/routing';
 import { isLocalUrl } from '@lib/parse/url';
 import { DomElement } from 'htmlparser2';
 
-function* genId() {
-  let id = 0;
-  while (true) {
-    id += 1;
-    yield id;
-  }
-}
-const gen = genId();
-
 export const anchorToLink = (
   node: DomElement,
   transform: Transform,
@@ -32,7 +23,7 @@ export const anchorToLink = (
     // Return an app link.
     const {
       attribs,
-      attribs: { href }
+      attribs: { href, key }
     } = node;
     let url: URL | undefined = new URL(href, 'https://theworld.org');
 
@@ -43,7 +34,6 @@ export const anchorToLink = (
     }
 
     if (url?.href && isLocalUrl(url.href)) {
-      const id = gen.next().value as number;
       const linkHref = generateContentLinkHref(url.href);
       const children = convertNodeToElement(
         { ...node, attribs },
@@ -54,7 +44,7 @@ export const anchorToLink = (
       delete attribs.target;
 
       return linkHref ? (
-        <Link href={linkHref} passHref key={id} legacyBehavior>
+        <Link href={linkHref} passHref key={key} legacyBehavior>
           {children}
         </Link>
       ) : (

--- a/components/HtmlContent/transforms/audioDescendant.tsx
+++ b/components/HtmlContent/transforms/audioDescendant.tsx
@@ -19,14 +19,13 @@ export const audioDescendant = (node: DomElement) => {
   if (
     audioSource &&
     node.type === 'tag' &&
-    node.name === 'div' &&
     'class' in node.attribs &&
-    /\bfile-audio\b/.test(node.attribs.class)
+    /\b(?:file-audio|block-audio)\b/.test(node.attribs.class)
   ) {
     const {
       attribs: { src }
     } = audioSource;
-    return <AudioPlayer data={src as string} />;
+    return <AudioPlayer data={src as string} key={node.attribs.key} />;
   }
 
   return undefined;

--- a/components/HtmlContent/transforms/enhanceImage.tsx
+++ b/components/HtmlContent/transforms/enhanceImage.tsx
@@ -25,7 +25,7 @@ export const enhanceImage =
       const sizes = imageWidths
         .map(([q, w]) => (q ? `(${q}) ${w}` : w))
         .join(', ');
-      const { class: className, width, height, src, alt } = attribs;
+      const { class: className, width, height, src, alt, key } = attribs;
       const absoluteSrc = /^\/[^/]/.test(src)
         ? `https://theworld.org${src}`
         : src;
@@ -45,7 +45,7 @@ export const enhanceImage =
       }
 
       return wrapperClass ? (
-        <div className={wrapperClass} key={attribs.src}>
+        <div className={wrapperClass} key={key}>
           <Image
             src={absoluteSrc}
             alt={alt || ''}
@@ -63,7 +63,7 @@ export const enhanceImage =
           height={height || 9}
           layout="responsive"
           sizes={sizes}
-          key={attribs.src}
+          key={key}
         />
       );
     }

--- a/components/HtmlContent/transforms/twitterEmbed.tsx
+++ b/components/HtmlContent/transforms/twitterEmbed.tsx
@@ -49,7 +49,7 @@ export const twitterEmbed = (node: DomElement) => {
     const { pathname } = parse(embedUrl);
     const [, id] = (pathname || '').match(/\/(\w+)\W*$/) || [];
 
-    return <TwitterTweetEmbed tweetId={id} />;
+    return <TwitterTweetEmbed tweetId={id} key={node.attribs.key} />;
   }
 
   return undefined;

--- a/components/HtmlContent/transforms/videoSourceDescendant.tsx
+++ b/components/HtmlContent/transforms/videoSourceDescendant.tsx
@@ -54,7 +54,7 @@ export const videoSourceDescendant = (node: DomElement) => {
 
     if (src) {
       return (
-        <div className="media-youtube-video" key={src}>
+        <div className="media-youtube-video" key={node.attribs.key}>
           <iframe
             title={src}
             allow="encrypted-media; accelerometer; gyroscope; picture-in-picture"

--- a/components/pages/Story/layouts/default/styles/body/Story.body.media.ts
+++ b/components/pages/Story/layouts/default/styles/body/Story.body.media.ts
@@ -17,7 +17,6 @@ export const storyBodyMediaStyles = (theme: Theme) =>
 
     // Reset for img tag dimension attributes.
     '& img:not([width="1"])': {
-      width: '100%',
       maxWidth: '100%',
       height: 'auto',
       margin: '0 auto',
@@ -25,14 +24,11 @@ export const storyBodyMediaStyles = (theme: Theme) =>
     },
 
     // Media styles.
-    '& .media': {
+    '& :where(.file-image, .media, .wp-block-image, .wp-block-embed)': {
       clear: 'both',
-      width: '100%',
-      marginTop: theme.typography.pxToRem(32),
-      marginBottom: theme.typography.pxToRem(32)
-    },
-    '& .file-image': {
-      '& .content': {
+      marginBlock: theme.typography.pxToRem(32),
+      marginInline: 0,
+      '&:where(.wp-block-image, .wp-block-embed), & :where(.content)': {
         ...theme.typography.caption,
         display: 'grid',
         rowGap: '0.5rem',
@@ -42,9 +38,6 @@ export const storyBodyMediaStyles = (theme: Theme) =>
         '& p + p': {
           marginTop: '1rem'
         },
-        '& .field-caption': {
-          marginTop: '0.25rem'
-        },
         '& .image__credit': {
           display: 'flex',
           fontSize: '0.75rem',
@@ -53,24 +46,28 @@ export const storyBodyMediaStyles = (theme: Theme) =>
         '& .image__credit-label': {
           marginRight: '0.25rem'
         }
+      },
+      '&  > .wp-block-embed__wrapper': {
+        lineHeight: 0
       }
     },
 
     // YouTube embed styles.
-    '& .media-youtube-video': {
-      position: 'relative',
-      height: 0,
-      paddingTop: `${(9 / 16) * 100}%`,
-      '& iframe': {
-        display: 'block',
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-        border: 0
-      }
-    },
+    '& .media-youtube-video, & :where(.wp-block-embed-youtube, .wp-block-embed-vimeo) > .wp-block-embed__wrapper':
+      {
+        position: 'relative',
+        height: 0,
+        paddingTop: `${(9 / 16) * 100}%`,
+        '& iframe': {
+          display: 'block',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          border: 0
+        }
+      },
 
     // Twitter embeds.
     '& .twitter-tweet': {
@@ -97,21 +94,21 @@ export const storyBodyMediaStyles = (theme: Theme) =>
     },
 
     [theme.breakpoints.up('md')]: {
-      '& .media-wysiwyg-align-left, & .media-image_on_left': {
+      '& :where(.media-wysiwyg-align-left, .media-image_on_left, .alignleft)': {
         float: 'left',
         clear: 'left',
         width: '44%',
-        margin: `${theme.typography.pxToRem(7)} ${theme.typography.pxToRem(
-          30
-        )} 0.5rem 0`
+        margin: `0 ${theme.typography.pxToRem(30)} 0.5rem 0`
       },
-      '& .media-wysiwyg-align-right, & .media-image_on_right': {
-        float: 'right',
-        clear: 'right',
-        width: '44%',
-        margin: `${theme.typography.pxToRem(
-          7
-        )} 0 0.5rem ${theme.typography.pxToRem(30)}`
+      '& :where(.media-wysiwyg-align-right, .media-image_on_right, .alignright)':
+        {
+          float: 'right',
+          clear: 'right',
+          width: '44%',
+          margin: `0 0 0.5rem ${theme.typography.pxToRem(30)}`
+        },
+      '& :where(.aligncenter)': {
+        marginInline: theme.spacing(4)
       }
     }
   } as any);

--- a/components/pages/Story/layouts/default/styles/body/Story.body.qa.ts
+++ b/components/pages/Story/layouts/default/styles/body/Story.body.qa.ts
@@ -15,9 +15,10 @@ export const storyBodyQAStyles = (theme: Theme) =>
       marginBlockEnd: theme.typography.pxToRem(32),
       paddingBlockStart: theme.typography.pxToRem(16),
       paddingBlockEnd: theme.typography.pxToRem(16),
-      borderInlineStartWidth: theme.typography.pxToRem(accentBorderWidth),
-      borderInlineStartStyle: 'solid',
-      borderInlineStartColor: theme.palette.primary.main,
+      borderInlineStar: 'none',
+      boxShadow: `-${theme.typography.pxToRem(accentBorderWidth)} 0 0 ${
+        theme.palette.primary.main
+      }`,
 
       '& .qa-question': {
         marginBlockEnd: theme.typography.pxToRem(16),
@@ -32,7 +33,7 @@ export const storyBodyQAStyles = (theme: Theme) =>
         fontSize: '1.2rem'
       },
 
-      '&--border-around': {
+      '&.qa-wrap--border-around': {
         border: `${theme.typography.pxToRem(1)} solid ${
           theme.palette.grey[200]
         }`,

--- a/components/pages/Story/layouts/default/styles/body/Story.body.typography.ts
+++ b/components/pages/Story/layouts/default/styles/body/Story.body.typography.ts
@@ -23,25 +23,42 @@ export const storyBodyTypography = (theme: Theme) => ({
     ...headingProps
   },
 
+  '& .has-text-align-center': {
+    textAlign: 'center'
+  },
+  '& .has-text-align-right': {
+    textAlign: 'right'
+  },
+
   '& hr': {
+    height: '2px',
+    backgroundColor: theme.palette.divider,
+    border: 'none'
+  },
+  '& hr.is-style-wide': {
+    height: '4px'
+  },
+  '& hr.aligncenter': {
+    marginInline: theme.spacing(4)
+  },
+  '& hr.is-style-dots': {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     height: '2rem',
-    border: 'none',
+    background: 'none',
+    color: theme.palette.divider,
     '&::before': {
-      content: '"* * *"',
-      position: 'relative',
-      top: '0.25rem',
+      content: '"•••"',
       fontSize: '1.5rem',
-      lineHeight: 0
+      lineHeight: 0,
+      letterSpacing: '3rem'
     }
   },
 
-  '& blockquote, & aside:not(.node-story-act)': {
+  '& > blockquote, & > aside:not(.node-story-act), & > .wp-block-pullquote': {
     display: 'flow-root',
     backgroundColor: theme.palette.grey[200],
-    margin: 0,
     padding: theme.typography.pxToRem(24),
     color: theme.palette.grey[700],
     fontSize: '1.2rem',
@@ -52,25 +69,40 @@ export const storyBodyTypography = (theme: Theme) => ({
         marginTop: '1rem'
       }
     },
-    '& footer': {
-      marginTop: '0.75rem',
-      '& cite': {
-        '&::before': {
-          content: '"-"',
-          marginRight: '0.25rem'
-        }
+    '& :where(footer)': {
+      marginTop: '0.75rem'
+    },
+    '& cite': {
+      '&::before': {
+        content: '"-"',
+        marginRight: '0.25rem'
       }
     },
-    '&.pullquote': {
+    '&:where(.pullquote, .wp-block-pullquote)': {
       background: 'none',
+      marginBlock: theme.typography.pxToRem(32),
+      paddingBlock: `${theme.typography.pxToRem(64)}`,
+      paddingInline: `${theme.typography.pxToRem(16)}`,
+      borderBlock: `1px solid ${theme.palette.divider}`,
       color: theme.palette.primary.dark,
       fontFamily: alegreya.style.fontFamily,
       fontSize: '1.5rem',
       textAlign: 'center',
+      '&:not(.alignleft, .alignright)': {
+        marginInline: 0
+      },
+      '&:where(.alignleft, .alignright)': {
+        marginBlockStart: 0,
+        paddingBlock: theme.typography.pxToRem(24)
+      },
+      '& blockquote': {
+        display: 'grid',
+        gap: theme.typography.pxToRem(16)
+      },
       '& p': {
         lineHeight: theme.typography.pxToRem(32.4)
       },
-      '& footer': {
+      '& :where(footer, cite)': {
         color: theme.palette.grey[700],
         fontSize: '1rem'
       }

--- a/components/pages/Story/layouts/feature/styles/body/Story.body.media.ts
+++ b/components/pages/Story/layouts/feature/styles/body/Story.body.media.ts
@@ -17,49 +17,64 @@ export const storyBodyMediaStyles = (theme: Theme) =>
 
     // Reset for img tag dimension attributes.
     '& img:not([width="1"])': {
-      width: '100%',
       maxWidth: '100%',
       height: 'auto',
       margin: '0 auto',
       backgroundColor: theme.palette.grey[200]
     },
 
+    // Alignment styles.
+    '& .alignwide': {},
+
     // Media styles.
-    '& .media': {
+    '& :where(.file-image, .media, .wp-block-image, .wp-block-embed)': {
       position: 'relative',
       clear: 'both',
       width: '100%',
-      marginTop: theme.typography.pxToRem(32),
-      marginBottom: theme.typography.pxToRem(32),
+      marginBlock: theme.typography.pxToRem(32),
+      marginInline: 0,
 
-      '&.media-full_width': {
+      '&:where(.alignwide, .alignfull), & .file-full-width-wrapper': {
+        transform: 'translateX(-50%)',
         position: 'relative',
+        left: '50%',
+        width: '100vw',
 
-        '& .file-full-width-wrapper': {
-          transform: 'translateX(-50%)',
-          position: 'relative',
-          left: '50%',
-          width: '100vw',
-          maxWidth: '1200px'
+        '& > span': {
+          maxHeight: '90vh',
+
+          '& img': {
+            objectFit: 'cover'
+          }
         }
       },
 
-      '&.media-browser_width': {
-        position: 'relative',
+      '&.alignwide, & .file-browser-width-wrapper': {
+        maxWidth: '1200px'
+      },
 
-        '& .file-browser-width-wrapper': {
-          transform: 'translateX(-50%)',
-          position: 'relative',
-          left: '50%',
-          width: '100vw'
-        }
-      }
-    },
-    '& .file-image': {
-      '& .content': {
+      '&.aligncenter': {
+        paddingInline: theme.spacing(4)
+      },
+
+      '&:where(.wp-block-image, .wp-block-embed), & :where(.content)': {
         ...theme.typography.caption,
-        '& > * + *': {
-          marginTop: theme.typography.pxToRem(16)
+        display: 'grid',
+        rowGap: theme.spacing(1),
+        '&:where(.alignwide, .alignfull) :where(figcaption)': {
+          paddingInline: theme.spacing(2),
+          marginInline: 'auto',
+          [theme.breakpoints.up('sm')]: {
+            width: '100%',
+            maxWidth: 600,
+            paddingInline: theme.spacing(3)
+          },
+          [theme.breakpoints.up('md')]: {
+            maxWidth: 960
+          },
+          [theme.breakpoints.up('lg')]: {
+            maxWidth: 960
+          }
         },
         '& p': {
           margin: 0
@@ -82,22 +97,21 @@ export const storyBodyMediaStyles = (theme: Theme) =>
     },
 
     // YouTube embed styles.
-    '& .media-youtube-video': {
-      position: 'relative',
-      height: 0,
-      marginBlockStart: theme.typography.pxToRem(24),
-      marginBlockEnd: theme.typography.pxToRem(24),
-      paddingTop: `${(9 / 16) * 100}%`,
-      '& iframe': {
-        display: 'block',
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-        border: 0
-      }
-    },
+    '& .media-youtube-video, & :where(.wp-block-embed-youtube, .wp-block-embed-vimeo) > .wp-block-embed__wrapper':
+      {
+        position: 'relative',
+        height: 0,
+        paddingTop: `${(9 / 16) * 100}%`,
+        '& iframe': {
+          display: 'block',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          border: 0
+        }
+      },
 
     // Twitter embeds.
     '& .twitter-tweet': {
@@ -124,7 +138,7 @@ export const storyBodyMediaStyles = (theme: Theme) =>
     },
 
     [theme.breakpoints.up('md')]: {
-      '& .media-wysiwyg-align-left, & .media-image_on_left': {
+      '& :where(.media-wysiwyg-align-left, .media-image_on_left, .alignleft)': {
         float: 'left',
         clear: 'left',
         width: '44%',
@@ -133,18 +147,25 @@ export const storyBodyMediaStyles = (theme: Theme) =>
           theme.typography.pxToRem(48),
           theme.typography.pxToRem(32),
           0
-        ].join(' ')}`
+        ].join(' ')}`,
+        [theme.breakpoints.up(1028)]: {
+          marginInlineStart: theme.spacing(-4)
+        }
       },
-      '& .media-wysiwyg-align-right, & .media-image_on_right': {
-        float: 'right',
-        clear: 'right',
-        width: '44%',
-        margin: `${[
-          theme.typography.pxToRem(8),
-          0,
-          theme.typography.pxToRem(32),
-          theme.typography.pxToRem(48)
-        ].join(' ')}`
-      }
+      '& :where(.media-wysiwyg-align-right, .media-image_on_right, .alignright)':
+        {
+          float: 'right',
+          clear: 'right',
+          width: '44%',
+          margin: `${[
+            theme.typography.pxToRem(8),
+            0,
+            theme.typography.pxToRem(32),
+            theme.typography.pxToRem(48)
+          ].join(' ')}`,
+          [theme.breakpoints.up(1028)]: {
+            marginInlineEnd: theme.spacing(-4)
+          }
+        }
     }
   } as any);

--- a/components/pages/Story/layouts/feature/styles/body/Story.body.qa.ts
+++ b/components/pages/Story/layouts/feature/styles/body/Story.body.qa.ts
@@ -15,9 +15,10 @@ export const storyBodyQAStyles = (theme: Theme) =>
       marginBlockEnd: theme.typography.pxToRem(32),
       paddingBlockStart: theme.typography.pxToRem(16),
       paddingBlockEnd: theme.typography.pxToRem(16),
-      borderInlineStartWidth: theme.typography.pxToRem(accentBorderWidth),
-      borderInlineStartStyle: 'solid',
-      borderInlineStartColor: theme.palette.primary.main,
+      borderInlineStar: 'none',
+      boxShadow: `-${theme.typography.pxToRem(accentBorderWidth)} 0 0 ${
+        theme.palette.primary.main
+      }`,
 
       '& .qa-question': {
         marginBlockEnd: theme.typography.pxToRem(16),

--- a/components/pages/Story/layouts/feature/styles/body/Story.body.typography.ts
+++ b/components/pages/Story/layouts/feature/styles/body/Story.body.typography.ts
@@ -26,25 +26,51 @@ export const storyBodyTypography = (theme: Theme) =>
       marginTop: theme.typography.pxToRem(64)
     },
 
+    '& .has-text-align-center': {
+      textAlign: 'center'
+    },
+    '& .has-text-align-right': {
+      textAlign: 'right'
+    },
+
     '& hr': {
+      height: '2px',
+      backgroundColor: theme.palette.divider,
+      border: 'none'
+    },
+    '& hr.is-style-wide': {
+      height: '4px'
+    },
+    '& hr:where(.alignwide, .alignfull)': {
+      transform: 'translateX(-50%)',
+      position: 'relative',
+      left: '50%',
+      width: '100vw'
+    },
+    '& hr.alignwide': {
+      maxWidth: '1200px'
+    },
+    '& hr.aligncenter': {
+      marginInline: theme.spacing(4)
+    },
+    '& hr.is-style-dots': {
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
       height: '2rem',
-      border: 'none',
+      background: 'none',
+      color: theme.palette.divider,
       '&::before': {
-        content: '"* * *"',
-        position: 'relative',
-        top: '0.25rem',
+        content: '"•••"',
         fontSize: '1.5rem',
-        lineHeight: 0
+        lineHeight: 0,
+        letterSpacing: '3rem'
       }
     },
 
-    '& blockquote, & aside:not(.node-story-act)': {
+    '& > blockquote, & > aside:not(.node-story-act), & > .wp-block-pullquote': {
       display: 'flow-root',
       backgroundColor: theme.palette.grey[200],
-      margin: 0,
       padding: theme.typography.pxToRem(24),
       color: theme.palette.grey[700],
       fontSize: '0.9rem',
@@ -55,41 +81,54 @@ export const storyBodyTypography = (theme: Theme) =>
           marginTop: '1rem'
         }
       },
-      '& footer': {
-        marginTop: '0.75rem',
-        '& cite': {
-          '&::before': {
-            content: '"-"',
-            marginRight: '0.25rem'
-          }
+      '& :where(footer)': {
+        marginTop: '0.75rem'
+      },
+      '& cite': {
+        '&::before': {
+          content: '"-"',
+          marginRight: '0.25rem'
         }
       },
-      '&.pullquote': {
-        position: 'relative',
-        left: '50%',
-        transform: 'translateX(-50%)',
-        width: '100vw',
-        marginTop: theme.typography.pxToRem(32),
-        marginBottom: theme.typography.pxToRem(32),
+      '&:where(.pullquote, .wp-block-pullquote)': {
+        marginBlock: theme.typography.pxToRem(32),
         paddingBlock: `${theme.typography.pxToRem(64)}`,
         paddingInline: `${theme.typography.pxToRem(16)}`,
-        borderTop: `1px solid ${theme.palette.divider}`,
-        borderBottom: `1px solid ${theme.palette.divider}`,
+        borderBlock: `1px solid ${theme.palette.divider}`,
         background: 'none',
         color: theme.palette.primary.dark,
         fontFamily: alegreya.style.fontFamily,
         fontSize: '1.75rem',
         textAlign: 'center',
         textWrap: 'balance',
-        '& > *': {
-          maxWidth: '1200px',
-          marginLeft: 'auto',
-          marginRight: 'auto'
+        '&:where(.alignwide, .alignfull)': {
+          position: 'relative',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: '100vw',
+          '& > *': {
+            maxWidth: '1200px',
+            marginInline: 'auto'
+          }
+        },
+        '&.alignwide': {
+          maxWidth: '1200px'
+        },
+        '&:not(.alignleft, .alignright)': {
+          marginInline: 0
+        },
+        '&:where(.alignleft, .alignright)': {
+          marginBlockStart: 0,
+          paddingBlock: `${theme.typography.pxToRem(24)}`
+        },
+        '& blockquote': {
+          display: 'grid',
+          gap: theme.typography.pxToRem(16)
         },
         '& p': {
           lineHeight: theme.typography.pxToRem(32.4)
         },
-        '& footer': {
+        '& :where(footer, cite)': {
           color: theme.palette.grey[700],
           fontSize: '1rem'
         }


### PR DESCRIPTION
Closes #351 

- updates body content styling for Gutenberg blocks from WordPress
- fixes missing `key` prop warning when rendering HTML content

## To Review

- [x] Checkout and pulldown latest `main` branch for your lando env.
- [x] Download and import this database: https://drive.google.com/file/d/1GnfBbd8UC-DhlduUzssfEM2yqz78EWwZ/view?usp=drive_link
- [x] Log into http://the-world-wp.lndo.site/wp-admin/
- [x] Edit this post: http://the-world-wp.lndo.site/wp-admin/post.php?post=654192&action=edit

> ...then...

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to http://the-world-wp.lndo.site:3000/stories/2024/01/30/history-of-star-wars

> ...then...

- [x] Ensure stying for all the blocks looks good and layout responsively as expected.
- [x] Ensure no warnings are shown in your dev console for missing `"key"` prop when rendering HtmlContent component.
