### PR TITLE
441: Story card grid primary category link styles

### DIFF
--- a/components/AppPlayer/AppPlayer.styles.ts
+++ b/components/AppPlayer/AppPlayer.styles.ts
@@ -82,5 +82,13 @@ export const appPlayerStyles = makeStyles()(theme => ({
     [theme.breakpoints.down('xs')]: {
       display: 'none'
     }
+  },
+  menu: {
+    display: 'grid',
+    '& > *': {
+      display: 'grid',
+      gridTemplateColumns: 'min-content 1fr',
+      textAlign: 'start'
+    }
   }
 }));

--- a/components/AppPlayer/AppPlayer.tsx
+++ b/components/AppPlayer/AppPlayer.tsx
@@ -163,7 +163,7 @@ export const AppPlayer = () => {
         open={Boolean(menuButtonElm)}
         onClose={handleMenuClose}
         MenuListProps={
-          { component: 'nav', style: { display: 'grid' } } as ListProps
+          { component: 'nav', className: styles.menu } as ListProps
         }
       >
         <MenuItem component="button" onClick={handleClearPlaylistClick}>

--- a/components/StoryCard/StoryCard.styles.ts
+++ b/components/StoryCard/StoryCard.styles.ts
@@ -30,13 +30,19 @@ export const useStoryCardStyles = makeStyles()((theme) => ({
     lineHeight: '1.3'
   },
   primaryCategory: {
-    display: 'flex',
+    display: 'grid',
+    gridTemplateColumns: 'min-content 1fr',
     position: 'relative',
     alignItems: 'center',
     zIndex: 1,
     fontFamily: openSans.style.fontFamily,
     letterSpacing: 'unset',
     textTransform: 'unset'
+  },
+  primaryCategoryLink: {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap'
   },
   imageWrapper: {
     position: 'absolute',

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -172,7 +172,7 @@ export const StoryCard = ({
                   spacing={1}
                   // style={{ marginBottom: 0 }}
                 >
-                  <Grid item xs="auto" zeroMinWidth>
+                  <Grid item xs={12}>
                     <Typography component="span">
                       <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
                         {dateBroadcast || datePublished}
@@ -180,14 +180,13 @@ export const StoryCard = ({
                     </Typography>
                   </Grid>
                   {primaryCategory && (
-                    <Grid item xs="auto" zeroMinWidth>
+                    <Grid item xs={12}>
                       <Typography
                         variant="overline"
-                        noWrap
                         className={classes.primaryCategory}
                       >
                         <Label color="secondary" />
-                        <ContentLink data={primaryCategory}>
+                        <ContentLink className={classes.primaryCategoryLink} data={primaryCategory}  title={primaryCategory.title}>
                           {primaryCategory.title}
                         </ContentLink>
                       </Typography>

--- a/components/StoryCardGrid/StoryCardGrid.styles.ts
+++ b/components/StoryCardGrid/StoryCardGrid.styles.ts
@@ -40,13 +40,21 @@ export const storyCardGridStyles = makeStyles()((theme) => ({
   },
 
   primaryCategory: {
-    display: 'flex',
+    display: 'grid',
+    gridTemplateColumns: 'min-content 1fr',
+    gap: theme.spacing(0.5),
     position: 'relative',
     alignItems: 'center',
     zIndex: 1,
     fontFamily: openSans.style.fontFamily,
     letterSpacing: 'unset',
     textTransform: 'unset'
+  },
+
+  primaryCategoryLink: {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap'
   },
 
   audio: {

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -36,6 +36,7 @@ import {
 import { IAudioData } from '@components/Player/types';
 import { generateLinkHrefForContent } from '@lib/routing';
 import { storyCardGridStyles } from './StoryCardGrid.styles';
+import { Marquee } from '@components/Marquee';
 
 const Moment = dynamic(() => import('react-moment')) as any;
 
@@ -191,14 +192,13 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                     </Typography>
                   </Grid>
                   {primaryCategory && (
-                    <Grid item xs="auto" zeroMinWidth>
+                    <Grid item xs={12}>
                       <Typography
                         className={classes.primaryCategory}
                         variant="overline"
-                        noWrap
                       >
                         <Label color="secondary" />
-                        <ContentLink data={primaryCategory}>
+                        <ContentLink className={classes.primaryCategoryLink} data={primaryCategory} title={primaryCategory.title}>
                           {primaryCategory.title}
                         </ContentLink>
                       </Typography>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3234,9 +3234,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001464:
-  version "1.0.30001488"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz#d19d7b6e913afae3e98f023db97c19e9ddc5e91f"
-  integrity sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==
+  version "1.0.30001597"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz"
+  integrity sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==
 
 chalk@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
Closes #441 

- fix story card grid primary category link styles
  - add text overflow ellipsis
  - add title attribute to link
- fix layout of app player menu text
- caniuse db update

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Ensure featured story cards do not break when primary category label is longer than content area. Should ellipsis overflow. Hovering link should show full title in browser tooltip.
- [ ] Play some audio to show player.
- [ ] Open the player menu and ensure button text is aligned consistently and hover highlight is full width of menu.
