### PR TITLE
HOTFIX: Add more episodes button to latest episode card

### DIFF
--- a/components/EpisodeCard/EpisodeCard.styles.ts
+++ b/components/EpisodeCard/EpisodeCard.styles.ts
@@ -107,6 +107,7 @@ export const episodeCardStyles = makeStyles()((theme) => {
     },
 
     MuiCardActionsRoot: {
+      display: 'grid',
       margin: 0,
       padding: 0
     },

--- a/components/EpisodeCard/EpisodeCard.tsx
+++ b/components/EpisodeCard/EpisodeCard.tsx
@@ -146,6 +146,9 @@ export const EpisodeCard = ({
         {segments && (
           <CardActions classes={{ root: classes.MuiCardActionsRoot }}>
             <SidebarList
+              paginationProps={{
+                pageSize: 15
+              }}
               data={segments.map((segment) => ({
                 data: segment?.segmentContent?.audio?.parent?.node || segment,
                 audio: segment?.segmentContent?.audio

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -7,7 +7,7 @@ import type { Episode } from '@interfaces';
 import 'moment-timezone';
 import dynamic from 'next/dynamic';
 import { Card, CardActionArea, CardContent, Typography } from '@mui/material';
-import { Headset } from '@mui/icons-material';
+import { Headset, NavigateNext } from '@mui/icons-material';
 import { ContentButton } from '@components/ContentButton';
 import { ContentLink } from '@components/ContentLink';
 import { AudioControls } from '@components/Player/components';
@@ -81,6 +81,9 @@ export const SidebarEpisode = ({
       {segmentsList && (
         <SidebarList
           disablePadding
+          paginationProps={{
+            pageSize: 15
+          }}
           data={segmentsList.map((segment) => ({
             data: segment?.segmentContent?.audio?.parent?.node || segment,
             audio: segment?.segmentContent?.audio
@@ -96,7 +99,7 @@ export const SidebarEpisode = ({
             color="primary"
             fullWidth
           >
-            More Episodes
+            More Episodes <NavigateNext />
           </ContentButton>
         </SidebarFooter>
       )}

--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -53,7 +53,7 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
   const { drawerMainNav } = appMenus || {};
   const store = useStore<RootState>();
   const state = store.getState();
-  const { landingPage, menus, latestStories } = data || {};
+  const { landingPage, menus, latestStories, link } = data || {};
   const featuredPosts =
     landingPage?.featuredPosts &&
     (landingPage.featuredPosts || []).reduce(
@@ -167,7 +167,15 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
       children: (
         <>
           {latestEpisode && (
-            <SidebarEpisode data={latestEpisode} label="Latest Episode" />
+            <SidebarEpisode
+              data={latestEpisode}
+              label="Latest Episode"
+              {...(link &&
+                episodes.length > 1 && {
+                  collectionLink: `${link}?v=episodes`,
+                  collectionLinkShallow: true
+                })}
+            />
           )}
           <Hidden only="sm">
             {sidebarTop && <SidebarCta data={sidebarTop} />}

--- a/lib/fetch/homepage/fetchGqlHomepage.ts
+++ b/lib/fetch/homepage/fetchGqlHomepage.ts
@@ -24,6 +24,7 @@ const GET_HOMEPAGE = gql`
   query getHomepage($id: ID!, $idType: ProgramIdType) {
     program(id: $id, idType: $idType) {
       id
+      link
       landingPage {
         featuredPosts {
           ... on Post {


### PR DESCRIPTION
- increase episode card segment list page size to 15
- fix layout issue when episode cards list shows pagination

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure latest episode card shows a __More Episodes__ button.
- [x] Ensure episode cards with 15 or less segments do not show pagination controls.
