### PR TITLE
HOTFIX: update twitter embed to detect older status url's

### DIFF
--- a/components/HtmlContent/transforms/twitterEmbed.tsx
+++ b/components/HtmlContent/transforms/twitterEmbed.tsx
@@ -6,8 +6,10 @@
 import React from 'react';
 import { TwitterTweetEmbed } from 'react-twitter-embed';
 import { DomElement } from 'htmlparser2';
-import { parse } from 'url';
 import { findDescendant } from '@lib/parse/html';
+
+const twitterEmbedUrlPattern =
+  /(?:twitter|x)\.com\/[^/]+\/(?:status(?:es)?)\/(\w+)/;
 
 export const twitterEmbed = (node: DomElement) => {
   let embedUrl: string | null;
@@ -29,7 +31,7 @@ export const twitterEmbed = (node: DomElement) => {
           n.type === 'tag' &&
           n.name === 'a' &&
           'href' in n.attribs &&
-          n.parent?.name === 'blockquote'
+          twitterEmbedUrlPattern.test(n.attribs.href)
         ) {
           return n;
         }
@@ -45,11 +47,17 @@ export const twitterEmbed = (node: DomElement) => {
       break;
   }
 
-  if (embedUrl && embedUrl.match(/twitter.com/)) {
-    const { pathname } = parse(embedUrl);
-    const [, id] = (pathname || '').match(/\/(\w+)\W*$/) || [];
+  if (embedUrl) {
+    const [, id] = embedUrl.match(twitterEmbedUrlPattern) || [];
 
-    return <TwitterTweetEmbed tweetId={id} key={node.attribs.key} />;
+    if (!id) return null;
+
+    return (
+      <TwitterTweetEmbed
+        tweetId={id}
+        key={`${node.attribs.key}-twitter-${id}`}
+      />
+    );
   }
 
   return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4239,9 +4239,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001610"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz"
-  integrity sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==
+  version "1.0.30001611"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001611.tgz"
+  integrity sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [ ] Go to http://the-world-wp.lndo.site:3000/stories/2013/09/27/whats-next-syrian-chemical-weapons-plan

> ...then...

- [x] Ensure twitter embeds are rendered. Those that show as not found were probably deleted.
