### PR TITLE
HOTFIX: Add numeric id support to audio embed route

### DIFF
--- a/lib/routing/content.ts
+++ b/lib/routing/content.ts
@@ -9,8 +9,18 @@
  * @returns Return the app relative path for the resource, eg. pathname and query params.
  */
 export const generateContentLinkHref = (url?: string | null) => {
-  const urlBase = url?.startsWith('/') ? 'https://theworld.org' : undefined;
-  const parsedUrl = url ? new URL(url, urlBase) : undefined;
+  if (!url) return undefined;
+
+  const sanitizedUrl = [
+    // Extract URL from between quotes or appended weirdly to another string.
+    (u: string) => /(?<!=)https?:\/\/[\w/._\-?&]+/i.exec(u)?.[0] || u,
+    // Ensure relative protocol URL's have a protocol.
+    (u: string) => (u.startsWith('//') ? `https:${u}` : u)
+  ].reduce((a, fn) => a && fn(a), url);
+  const urlBase = sanitizedUrl.startsWith('/')
+    ? 'https://theworld.org'
+    : undefined;
+  const parsedUrl = new URL(sanitizedUrl, urlBase);
 
   if (parsedUrl?.pathname) {
     return parsedUrl.pathname + parsedUrl.search;

--- a/pages/embed/audio/[id].tsx
+++ b/pages/embed/audio/[id].tsx
@@ -9,11 +9,13 @@ import {
   fetchGqlAudio,
   fetchGqlEpisode,
   fetchGqlSegment,
-  fetchGqlStory
+  fetchGqlStory,
+  fetchTwApi
 } from '@lib/fetch';
 import { AudioPlayer } from '@components/AudioPlayer';
 import { IAudioPlayerProps } from '@components/AudioPlayer/AudioPlayer.interfaces';
 import { MediaItem } from '@interfaces';
+import { encode } from 'base-64';
 
 export interface IEmbedAudioPageProps {
   data: MediaItem;
@@ -41,7 +43,7 @@ export const getServerSideProps: GetServerSideProps = async ({
   params
 }): Promise<GetServerSidePropsResult<any>> => {
   const { id } = params || {};
-  const resourceId = Array.isArray(id) ? id[0] : id;
+  let resourceId = Array.isArray(id) ? id[0] : id;
 
   if (!resourceId) {
     return { notFound: true };
@@ -51,12 +53,32 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   if (isNumeric) {
     // TODO: Request is for an old embed using a Drupal nid. Try to get the WP ID and post type of the migrated post.
+    const aliasData = await fetchTwApi<{
+      id: number;
+      type?: string;
+    }>(`tw/v2/alias`, {
+      _fields: 'id,type',
+      ...params,
+      slug: resourceId
+    }).then((resp) => resp && resp.data);
+
+    resourceId = aliasData && encode(`${aliasData.type}:${aliasData.id}`);
+
+    if (resourceId) {
+      return {
+        redirect: {
+          permanent: true,
+          destination: `/embed/audio/${resourceId}`
+        }
+      };
+    }
   }
 
   if (resourceId) {
     const embeddedPlayerUrl = `https://theworld.org/embed/audio/${resourceId}`;
     let data: MediaItem | undefined;
     let message: string | undefined;
+
     // Attempt to fetch story data.
     const story = await fetchGqlStory(resourceId);
 


### PR DESCRIPTION
Blocked by PRX/cms.theworld.org#202

- audio embeds with numeric ids should redirect to new URL using base64 id to WP resource
- update content link URL parsing to prevent encountered errors

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.

> ...then...

- [x] Go to http://the-world-wp.lndo.site:3000/embed/audio/191147
- [x] Should redirect to http://the-world-wp.lndo.site:3000/embed/audio/cG9zdDo2Mzk5MDk=
- [x] Go to http://the-world-wp.lndo.site:3000/embed/audio/358024
- [x] Should redirect to http://the-world-wp.lndo.site:3000/embed/audio/c2VnbWVudDo2MzMyMDc=
- [x] Check the players against the data retrieved in PRX/cms.theworld.org#202
