### PR TITLE
HOTFIX: Extract Music Heard On Air from content to Spotify embeds

### DIFF
--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -56,6 +56,7 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
           }:${index}`;
         }
       },
+      ...transforms,
       anchorToLink,
       audioDescendant,
       datawrapperEmbed,
@@ -65,8 +66,7 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
       instagramEmbed,
       scriptRemove,
       twitterEmbed,
-      videoSourceDescendant,
-      ...transforms
+      videoSourceDescendant
     ].reduce(
       (acc, func) => (acc || acc === null ? acc : func(node, transform, index)),
       undefined

--- a/components/Sidebar/SidebarList/SidebarList.tsx
+++ b/components/Sidebar/SidebarList/SidebarList.tsx
@@ -219,8 +219,8 @@ export const SidebarList = ({
                       <Image
                         src={avatarSrc}
                         alt={`Avatar of ${text}`}
-                        width={styleOptions.avatar.size}
-                        height={styleOptions.avatar.size}
+                        fill
+                        sizes={`${styleOptions.avatar.size * 2}px`}
                         style={{ objectFit: 'cover' }}
                       />
                     </Avatar>

--- a/components/pages/Episode/Episode.tsx
+++ b/components/pages/Episode/Episode.tsx
@@ -15,6 +15,8 @@ import type {
   PostStory,
   RootState
 } from '@interfaces';
+import type { DomElement } from 'htmlparser2';
+import { useRef } from 'react';
 import { useStore } from 'react-redux';
 import {
   Box,
@@ -41,6 +43,7 @@ import {
 import { SpotifyPlayer } from '@components/SpotifyPlayer';
 import { StoryCard } from '@components/StoryCard';
 import { parseDateParts } from '@lib/parse/date';
+import { findDescendant, findDescendants } from '@lib/parse/html';
 import { getCtaRegionData } from '@store/reducers';
 import { episodeStyles } from './Episode.styles';
 import { EpisodeLede } from './components/EpisodeLede';
@@ -85,9 +88,53 @@ export const Episode = ({
       (fieldGroup) => fieldGroup?.spotifyPlaylist && fieldGroup.spotifyPlaylist
     )
     .filter((v): v is string => !!v);
+  const musicHeardOnAir = useRef(new Set(spotifyPlaylist));
   const stories = relatedStories?.filter(
     (story): story is PostStory => !!story
   );
+
+  const removeMhoaHeading = (node: DomElement) => {
+    const mhoaTextNode =
+      !node.parent &&
+      findDescendant(
+        node,
+        (n) =>
+          n.type === 'text' && n.data?.match(/music\s+heard\s+on\s+air/i) && n
+      );
+
+    if (mhoaTextNode) {
+      return null;
+    }
+
+    return undefined;
+  };
+
+  const extractSpotifyLinks = (node: DomElement) => {
+    const spotifyLinks =
+      !node.parent &&
+      findDescendants(
+        node,
+        (n) =>
+          n.type === 'tag' &&
+          n.name === 'a' &&
+          n.attribs.href?.match(/open\.spotify\.com/i)
+      );
+
+    if (spotifyLinks) {
+      spotifyLinks.forEach((n) => {
+        const url = new URL(n.attribs.href);
+        const uri = `spotify:${url.pathname.replace('/', ':')}`;
+
+        musicHeardOnAir.current.add(uri);
+      });
+
+      return null;
+    }
+
+    return undefined;
+  };
+
+  const contentTransforms = [removeMhoaHeading, extractSpotifyLinks];
 
   // CTA data.
   const ctaInlineEnd = getCtaRegionData(state, 'content-inline-end', type, id);
@@ -157,10 +204,13 @@ export const Episode = ({
                 <EpisodeLede data={data} />
                 {content && (
                   <Box className={classes.body} my={2}>
-                    <HtmlContent html={content} />
+                    <HtmlContent
+                      html={content}
+                      transforms={contentTransforms}
+                    />
                   </Box>
                 )}
-                {spotifyPlaylist && !!spotifyPlaylist.length && (
+                {!!musicHeardOnAir.current.size && (
                   <Box my={3}>
                     <Divider classes={{ root: classes.MuiDividerRoot }} />
                     <Typography
@@ -171,7 +221,7 @@ export const Episode = ({
                       Music heard on air
                     </Typography>
                     <Grid container spacing={2}>
-                      {spotifyPlaylist.map((uri) => (
+                      {[...musicHeardOnAir.current].map((uri) => (
                         <Grid item xs={12} sm={6} lg={4} key={uri}>
                           <SpotifyPlayer uri={uri} size="large" stretch />
                         </Grid>

--- a/lib/parse/html/findDescendant.ts
+++ b/lib/parse/html/findDescendant.ts
@@ -16,10 +16,10 @@ import { DomElement } from 'htmlparser2';
 export const findDescendant = (
   node: DomElement,
   // eslint-disable-next-line no-unused-vars
-  func: (N: DomElement) => boolean
-) => {
+  func: (N: DomElement) => false | DomElement
+): false | DomElement => {
   const { children } = node;
-  let found = func(node) && node;
+  let found = func(node);
 
   if (!found && children?.length) {
     found = children.reduce(
@@ -30,4 +30,34 @@ export const findDescendant = (
   }
 
   return found;
+};
+
+/**
+ * Crawl node's descendant tree, passing each node to the matching function.
+ * Adds matches to a Set, returning false if no matches
+ *
+ * @param node
+ *      DomElement node to start search.
+ * @param func
+ *      Function to determine if node is a match, and return it.
+ *      Return `false` otherwise.
+ * @param allFound
+ *      Set to collect matches in.
+ */
+export const findDescendants = (
+  node: DomElement,
+  // eslint-disable-next-line no-unused-vars
+  func: (N: DomElement) => false | DomElement,
+  allFound?: Set<DomElement>
+) => {
+  const { children } = node;
+  const found = allFound || new Set<DomElement>();
+
+  if (func(node)) {
+    found.add(node);
+  }
+
+  children?.forEach((n: DomElement) => findDescendants(n, func, found));
+
+  return found.size > 0 && found;
 };


### PR DESCRIPTION
## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to any episode page that would have Music Heard On Air content.
- [x] Ensure __Music Heard On Air__ section shows Spotify embeds, and those links and heading do not show up in body content.
