### PR TITLE
464: Story header audio controls not changing audio when story changes in Safari

### DIFF
--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -131,7 +131,11 @@ export const StoryHeader = ({ data }: Props) => {
         </Box>
         {audio && (
           <Box className={classes.audio}>
-            <AudioControls id={audio.id} fallbackProps={audioProps} />
+            <AudioControls
+              id={audio.id}
+              fallbackProps={audioProps}
+              key={audio.id}
+            />
           </Box>
         )}
       </Box>

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -176,6 +176,7 @@ export const StoryHeader = ({ data }: Props) => {
                     id={audio.id}
                     fallbackProps={audioProps}
                     variant="feature"
+                    key={audio.id}
                   />
                 </Box>
               )}

--- a/theme/App.theme.ts
+++ b/theme/App.theme.ts
@@ -70,7 +70,8 @@ export const useAppStyles = makeStyles<{
   socialShareMenu: {
     position: 'absolute',
     right: theme.spacing(2),
-    bottom: `calc(100% + ${theme.spacing(2)})`
+    bottom: `calc(100% + ${theme.spacing(2)})`,
+    pointerEvents: 'none'
   },
   loadUnderWrapper: {}
 }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,9 +4244,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001620"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz"
-  integrity sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==
+  version "1.0.30001636"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz"
+  integrity sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Closes #464

- story header audio controls should now update audio played/added when stories change
- fix issue with social links container blocking pointer interactions when not open

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] In Safari, go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] View any story with audio.
- [x] Click play button in header to play audio.
- [x] Scroll down to related stories grid and view any of the stories. (If te story doesn't have audio, select another.)
- [x] Ensure audio controls play button show play arrow and not the speaker icon.
- [x] Ensure clicking add button adds the correct audio to the playlist.
- [x] Ensure clicking play button plays the correct audio.
- [x] Repeat with a couple other stories.
- [x] When viewing the playlist, ensure the remove track buttons are clickable (not blocked but hidden social share menu.)
