### PR TITLE
FIX: TikTok embed render errors

### DIFF
--- a/components/HtmlContent/HtmlContent.tsx
+++ b/components/HtmlContent/HtmlContent.tsx
@@ -17,7 +17,7 @@ import {
   fixBlockInParagraph,
   fixNestedSpans,
   instagramEmbed,
-  scriptRemove,
+  removeScriptTag,
   tiktokEmbed,
   twitterEmbed,
   videoSourceDescendant,
@@ -42,7 +42,13 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
   const cleanHtml = (dirtyHtml: string) =>
     [
       (h: string) =>
-        h.replace(/\r?\n|\r/g, '').replace(/<[^>/]+>(\s|&nbsp;)*<\/[^>]+>/g, '')
+        h
+          // Remove new line characters.
+          .replace(/\r?\n|\r/g, '')
+          // Remove empty tags or tags containing only spaces.
+          .replace(/<[^>/]+>(\s|&nbsp;)*<\/[^>]+>/g, '')
+          // Remove style tags.
+          .replace(/<style[^>]*>.*<\/style>/g, '')
     ].reduce((acc, func) => func(acc), dirtyHtml);
 
   const transform = (node: DomElement, index: number) =>
@@ -65,6 +71,7 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
           delete n.attribs.style;
         }
       },
+      removeScriptTag,
       fixNestedSpans,
       fixBlockInParagraph,
       ...transforms,
@@ -75,7 +82,6 @@ export const HtmlContent = ({ html, transforms = [] }: IHtmlContentProps) => {
       facebookVideo,
       fbRootRemove,
       instagramEmbed,
-      scriptRemove,
       twitterEmbed,
       tiktokEmbed,
       videoSourceDescendant,

--- a/components/HtmlContent/transforms/index.ts
+++ b/components/HtmlContent/transforms/index.ts
@@ -8,7 +8,7 @@ export * from './fbRootRemove';
 export * from './fixBlockInParagraph';
 export * from './fixNestedSpans';
 export * from './instagramEmbed';
-export * from './scriptRemove';
+export * from './removeScriptTag';
 export * from './tiktokEmbed';
 export * from './twitterEmbed';
 export * from './videoSourceDescendant';

--- a/components/HtmlContent/transforms/removeScriptTag.ts
+++ b/components/HtmlContent/transforms/removeScriptTag.ts
@@ -1,10 +1,10 @@
 /**
- * @file scriptRemove.ts
+ * @file removeScriptTag.ts
  * Remove script tags.
  */
 import { DomElement } from 'htmlparser2';
 
-export const scriptRemove = (node: DomElement) => {
+export const removeScriptTag = (node: DomElement) => {
   if (node.type === 'tag' && node.name === 'script') {
     return null;
   }

--- a/components/TikTokEmbed/TikTokEmbed.tsx
+++ b/components/TikTokEmbed/TikTokEmbed.tsx
@@ -15,7 +15,7 @@ export const TikTokEmbed = ({ url, videoId }: ITikTokEmbedProps) => {
     width: number;
     height: number;
   }>();
-  const src = `https://www.tiktok.com/embed/v2/${videoId}?lang=${navigator.language}&embedFrom=oembed`;
+  const src = `https://www.tiktok.com/embed/v2/${videoId}?embedFrom=oembed`;
 
   useEffect(() => {
     function handleMessage(e: MessageEvent) {


### PR DESCRIPTION
- remove lang param from tiktok iframe src
- update htmlcontent cleanhtml to remove style tags

## To Review

- [x] Checkout Branch.
- [x] In your `.env` set `API_URL_BASE=https://api.theworld.org`.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to http://localhost:3000/stories/2024/05/13/donerflation-outcry-in-germany-over-rising-cost-of-doner-kebab

> ...then...

- [x] Ensure page renders with TikTok embed in content.
