### PR TITLE
472: Homepage duplicate mobile CTA's

### DIFF
--- a/components/pages/Homepage/Homepage.tsx
+++ b/components/pages/Homepage/Homepage.tsx
@@ -32,7 +32,11 @@ import { QuickLinks } from '@components/QuickLinks';
 import { StoryCard } from '@components/StoryCard';
 import { StoryCardGrid } from '@components/StoryCardGrid';
 import { SidebarEpisode } from '@components/Sidebar/SidebarEpisode';
-import { getCollectionData, getCtaRegionData } from '@store/reducers';
+import {
+  getAppDataMenu,
+  getCollectionData,
+  getCtaRegionData
+} from '@store/reducers';
 import { AppContext } from '@contexts/AppContext';
 
 const CtaRegion = dynamic(
@@ -45,14 +49,12 @@ const SidebarCta = dynamic(
 
 export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
   const {
-    data: appData,
     page: { resource }
   } = useContext(AppContext);
   const { type, id } = resource || {};
-  const { menus: appMenus } = appData || {};
-  const { drawerMainNav } = appMenus || {};
   const store = useStore<RootState>();
   const state = store.getState();
+  const drawerMainNav = getAppDataMenu(state, 'drawerMainNav');
   const { landingPage, menus, latestStories, link } = data || {};
   const featuredPosts =
     landingPage?.featuredPosts &&
@@ -121,10 +123,10 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
           </Box>
           {inlineTop && (
             <>
-              <Hidden xsDown>
+              <Hidden mdDown>
                 <CtaRegion data={inlineTop} />
               </Hidden>
-              <Hidden smUp>
+              <Hidden mdUp>
                 <SidebarCta data={inlineTop} />
               </Hidden>
             </>
@@ -148,10 +150,10 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
           ))}
           {inlineBottom && (
             <>
-              <Hidden xsDown>
+              <Hidden mdDown>
                 <CtaRegion data={inlineBottom} />
               </Hidden>
-              <Hidden smUp>
+              <Hidden mdUp>
                 <SidebarCta data={inlineBottom} />
               </Hidden>
             </>
@@ -167,26 +169,23 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
       children: (
         <>
           {latestEpisode && (
-            <SidebarEpisode
-              data={latestEpisode}
-              label="Latest Episode"
-              {...(link &&
-                episodes.length > 1 && {
-                  collectionLink: `${link}?v=episodes`,
-                  collectionLinkShallow: true
-                })}
-            />
+            <>
+              <SidebarEpisode
+                data={latestEpisode}
+                label="Latest Episode"
+                {...(link &&
+                  episodes.length > 1 && {
+                    collectionLink: `${link}?v=episodes`,
+                    collectionLinkShallow: true
+                  })}
+              />
+              {sidebarTop && <SidebarCta data={sidebarTop} />}
+            </>
           )}
-          <Hidden only="sm">
-            {sidebarTop && <SidebarCta data={sidebarTop} />}
-            <SidebarLatestStories
-              data={latestStories}
-              label="Latest from our partners"
-            />
-          </Hidden>
-          <Hidden xsDown mdUp>
-            {sidebarTop && <CtaRegion data={sidebarTop} />}
-          </Hidden>
+          <SidebarLatestStories
+            data={latestStories}
+            label="Latest from our partners"
+          />
         </>
       )
     },
@@ -203,16 +202,7 @@ export const Homepage = ({ data }: IContentComponentProps<HomepageType>) => {
               <SidebarList data={categoriesMenu} />
             </Sidebar>
           )}
-          {sidebarBottom && (
-            <>
-              <Hidden only="sm">
-                <SidebarCta data={sidebarBottom} />
-              </Hidden>
-              <Hidden xsDown mdUp>
-                <CtaRegion data={sidebarBottom} />
-              </Hidden>
-            </>
-          )}
+          {sidebarBottom && <SidebarCta data={sidebarBottom} />}
         </>
       )
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,9 +4244,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001636"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz"
-  integrity sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==
+  version "1.0.30001651"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz"
+  integrity sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Closes #472 

- mobile view should no long have duplicate CTA's shown
- categories menu should be back in the sidebar

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure categories menu is shown in sidebar.
- [x] Resize window to mobile size.
- [x] Ensure all CTA's are shown as expected and do not duplicate.
