### PR TITLE
474: Support 4:3 embed aspect ratio

### DIFF
--- a/components/pages/Story/layouts/default/styles/body/Story.body.media.ts
+++ b/components/pages/Story/layouts/default/styles/body/Story.body.media.ts
@@ -175,6 +175,11 @@ export const storyBodyMediaStyles = (theme: Theme) =>
         '& .wp-block-embed__wrapper': {
           aspectRatio: 16 / 9
         }
+      },
+      '&:where(.wp-embed-aspect-4-3)': {
+        '& .wp-block-embed__wrapper': {
+          aspectRatio: 4 / 3
+        }
       }
     },
 

--- a/components/pages/Story/layouts/feature/styles/body/Story.body.media.ts
+++ b/components/pages/Story/layouts/feature/styles/body/Story.body.media.ts
@@ -181,6 +181,11 @@ export const storyBodyMediaStyles = (theme: Theme) =>
         '& .wp-block-embed__wrapper': {
           aspectRatio: 16 / 9
         }
+      },
+      '&:where(.wp-embed-aspect-4-3)': {
+        '& .wp-block-embed__wrapper': {
+          aspectRatio: 4 / 3
+        }
       }
     },
 


### PR DESCRIPTION
Closes #474 

- adds styles for 4:3 embeds

## To Review

- [ ] Checkout Branch.
- [ ] Update your`.env` file to use live API URL: `API_URL_BASE=https://api.theworld.org`
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to http://localhost:3000/stories/2024/08/20/serduchka-is-ukraine-pop-star-comedian-says-his-job-is-to-lift-ukrainian-morale

> ...then...

- [ ] Ensure embedded video is shown at the correct size and is not longer a thin bar.
