### PR TITLE
Fix date rendering

### DIFF
--- a/components/DateTime/DateTime.tsx
+++ b/components/DateTime/DateTime.tsx
@@ -3,7 +3,7 @@
  * Component for rendering dates.
  */
 
-import { Maybe, RootState } from '@interfaces';
+import type { Maybe, RootState } from '@interfaces';
 import { getSettingsTimeZone } from '@store/reducers';
 import { useStore } from 'react-redux';
 
@@ -26,10 +26,33 @@ export const DateTime = ({
 
   if (!date) return null;
 
-  const usedDateValue =
-    typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)
-      ? `${date}T00:00:00`
-      : date;
+  let usedDateValue = date;
+
+  // Date strings from the API should be in ISO 8601, but could be missing some elements.
+  if (
+    typeof usedDateValue === 'string' &&
+    /^\d{4}-\d{2}-\d{2}/.test(usedDateValue)
+  ) {
+    // Ensure ISO 8601 dates have a time.
+    if (!/T\d{2}:\d{2}:\d{2}/.test(usedDateValue)) {
+      usedDateValue = `${usedDateValue}T00:00:00`;
+    }
+
+    // Ensure ISO 8601 dates are set to settings time-zone if they do not already have a time-zone offset.
+    if (!/[+-]\d{2}:?\d{2}$/.test(usedDateValue)) {
+      // Time-zone from settings will be in long format, eg `America/New_York`.
+      // We need to convert that to a offset string.
+      const tz = new Date()
+        .toLocaleTimeString('en-US', {
+          ...(timeZone && { timeZone }),
+          timeZoneName: 'longOffset'
+        })
+        .match(/GMT(.+)/)?.[1];
+
+      usedDateValue = `${usedDateValue}${tz}`;
+    }
+  }
+
   const renderDate =
     usedDateValue instanceof Date ? usedDateValue : new Date(usedDateValue);
   const formattedDate = renderDate.toLocaleDateString(locale || 'en-US', {
@@ -38,7 +61,7 @@ export const DateTime = ({
   });
 
   return (
-    <time className={className} dateTime={`${usedDateValue}`}>
+    <time className={className} dateTime={`${renderDate.toISOString()}`}>
       {formattedDate}
     </time>
   );

--- a/components/DateTime/DateTime.tsx
+++ b/components/DateTime/DateTime.tsx
@@ -3,7 +3,9 @@
  * Component for rendering dates.
  */
 
-import { Maybe } from '@interfaces';
+import { Maybe, RootState } from '@interfaces';
+import { getSettingsTimeZone } from '@store/reducers';
+import { useStore } from 'react-redux';
 
 export type DateTimeProps = {
   className?: string;
@@ -18,6 +20,10 @@ export const DateTime = ({
   locale,
   options
 }: DateTimeProps) => {
+  const store = useStore<RootState>();
+  const state = store.getState();
+  const timeZone = getSettingsTimeZone(state);
+
   if (!date) return null;
 
   const usedDateValue =
@@ -26,10 +32,10 @@ export const DateTime = ({
       : date;
   const renderDate =
     usedDateValue instanceof Date ? usedDateValue : new Date(usedDateValue);
-  const formattedDate = renderDate.toLocaleDateString(
-    locale || 'en-US',
-    options
-  );
+  const formattedDate = renderDate.toLocaleDateString(locale || 'en-US', {
+    ...(timeZone && { timeZone }),
+    ...options
+  });
 
   return (
     <time className={className} dateTime={`${usedDateValue}`}>

--- a/components/DateTime/DateTime.tsx
+++ b/components/DateTime/DateTime.tsx
@@ -1,0 +1,39 @@
+/**
+ * @file DateTime.tsx
+ * Component for rendering dates.
+ */
+
+import { Maybe } from '@interfaces';
+
+export type DateTimeProps = {
+  className?: string;
+  date?: Maybe<Date | string | number>;
+  locale?: Intl.LocalesArgument;
+  options?: Intl.DateTimeFormatOptions;
+};
+
+export const DateTime = ({
+  className,
+  date,
+  locale,
+  options
+}: DateTimeProps) => {
+  if (!date) return null;
+
+  const usedDateValue =
+    typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)
+      ? `${date}T00:00:00`
+      : date;
+  const renderDate =
+    usedDateValue instanceof Date ? usedDateValue : new Date(usedDateValue);
+  const formattedDate = renderDate.toLocaleDateString(
+    locale || 'en-US',
+    options
+  );
+
+  return (
+    <time className={className} dateTime={`${usedDateValue}`}>
+      {formattedDate}
+    </time>
+  );
+};

--- a/components/DateTime/index.ts
+++ b/components/DateTime/index.ts
@@ -1,0 +1,1 @@
+export * from './DateTime';

--- a/components/EpisodeCard/EpisodeCard.tsx
+++ b/components/EpisodeCard/EpisodeCard.tsx
@@ -7,7 +7,6 @@ import type React from 'react';
 import type { Episode } from '@interfaces';
 import type { IAudioControlsProps } from '@components/Player/components';
 import type { IAudioData } from '@components/Player/types';
-import 'moment-timezone';
 import dynamic from 'next/dynamic';
 import Image from 'next/legacy/image';
 import {
@@ -24,11 +23,10 @@ import {
 import { EqualizerRounded } from '@mui/icons-material';
 import { ThemeProvider } from '@mui/styles';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { HtmlContent } from '@components/HtmlContent';
 import { SidebarList } from '@components/Sidebar';
 import { episodeCardStyles, episodeCardTheme } from './EpisodeCard.styles';
-
-const Moment = dynamic(() => import('react-moment')) as any;
 
 const AudioControls = dynamic(() =>
   import('@components/Player/components').then((mod) => mod.AudioControls)
@@ -108,15 +106,15 @@ export const EpisodeCard = ({
                       <Divider orientation="vertical" flexItem />
                     </>
                   )}
-                  <Moment
-                    format={
-                      showProgramLink ? 'MMMM D, YYYY' : 'dddd, MMMM D, YYYY'
-                    }
-                    tz="America/New_York"
-                    {...(broadcastDate && { parse: 'YYYY-MM-DD' })}
-                  >
-                    {broadcastDate || date}
-                  </Moment>
+                  <DateTime
+                    date={broadcastDate || date}
+                    options={{
+                      weekday: 'long',
+                      month: 'long',
+                      day: 'numeric',
+                      year: 'numeric'
+                    }}
+                  />
                 </Typography>
                 <Typography
                   variant="h5"

--- a/components/MediaCard/MediaCard.tsx
+++ b/components/MediaCard/MediaCard.tsx
@@ -5,8 +5,6 @@
 
 import type { MediaItem } from '@interfaces';
 import { useEffect, useState } from 'react';
-import 'moment-timezone';
-import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import {
   Card,
@@ -20,9 +18,8 @@ import PlayCircleOutlineRounded from '@mui/icons-material/PlayCircleOutlineRound
 import ImageRounded from '@mui/icons-material/ImageRounded';
 import VideocamRounded from '@mui/icons-material/VideocamRounded';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { mediaCardStyles } from './MediaCard.styles';
-
-const Moment = dynamic(() => import('react-moment')) as any;
 
 export interface MediaCardProps {
   data: MediaItem;
@@ -94,9 +91,14 @@ export const MediaCard = ({ data }: MediaCardProps) => {
               color="textSecondary"
               noWrap
             >
-              <Moment format="MMMM D, YYYY" tz="America/New_York" unix>
-                {cardDate}
-              </Moment>
+              <DateTime
+                date={cardDate}
+                options={{
+                  month: 'long',
+                  day: 'numeric',
+                  year: 'numeric'
+                }}
+              />
             </Typography>
           )}
           <Typography

--- a/components/Player/components/Playlist/PlaylistItem.tsx
+++ b/components/Player/components/Playlist/PlaylistItem.tsx
@@ -8,6 +8,7 @@ import Image from 'next/legacy/image';
 import { Box, BoxProps, IconButton, Tooltip, Typography } from '@mui/material';
 import { DeleteSharp, DragHandleSharp } from '@mui/icons-material';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { PlayerContext } from '@components/Player/contexts/PlayerContext';
 import { IAudioData } from '@components/Player/types';
 import { usePlaylistItemStyles } from './PlaylistItem.styles';
@@ -76,11 +77,24 @@ export const PlaylistItem = ({
             >
               {info
                 .filter((t) => !!t)
-                .map((text) => (
-                  <span className={styles.infoItem} key={text}>
-                    {text}
-                  </span>
-                ))}
+                .map((value) =>
+                  value instanceof Date ? (
+                    <DateTime
+                      className={styles.infoItem}
+                      date={value}
+                      options={{
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric'
+                      }}
+                      key={`${value.toUTCString()}`}
+                    />
+                  ) : (
+                    <span className={styles.infoItem} key={value}>
+                      {value}
+                    </span>
+                  )
+                )}
             </Typography>
           ) : null}
         </Box>

--- a/components/Player/components/TrackInfo/TrackInfo.tsx
+++ b/components/Player/components/TrackInfo/TrackInfo.tsx
@@ -7,8 +7,9 @@ import React, { useContext } from 'react';
 import Image from 'next/legacy/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Box, Typography } from '@mui/material';
-import { Marquee } from '@components/Marquee';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
+import { Marquee } from '@components/Marquee';
 import { PlayerContext } from '@components/Player/contexts/PlayerContext';
 import { useTrackInfoStyles } from './TrackInfo.styles';
 
@@ -78,11 +79,24 @@ export const TrackInfo = ({ className }: ITrackInfoProps) => {
                 >
                   {info
                     .filter((t) => !!t)
-                    .map((text) => (
-                      <span className={styles.infoItem} key={text}>
-                        {text}
-                      </span>
-                    ))}
+                    .map((value) =>
+                      value instanceof Date ? (
+                        <DateTime
+                          className={styles.infoItem}
+                          date={value}
+                          options={{
+                            month: 'short',
+                            day: 'numeric',
+                            year: 'numeric'
+                          }}
+                          key={`${value.toUTCString()}`}
+                        />
+                      ) : (
+                        <span className={styles.infoItem} key={value}>
+                          {value}
+                        </span>
+                      )
+                    )}
                 </Typography>
               </Marquee>
             ) : null}

--- a/components/Player/types/IAudioData.ts
+++ b/components/Player/types/IAudioData.ts
@@ -46,7 +46,7 @@ export interface IAudioData {
   /**
    * Info strings.
    */
-  info?: string[];
+  info?: (string | Date)[];
 
   /**
    * Source URL for image to use in thumbnail or feature art.

--- a/components/SegmentCard/SegmentCard.tsx
+++ b/components/SegmentCard/SegmentCard.tsx
@@ -5,8 +5,6 @@
 
 import type { Segment } from '@interfaces';
 import { useEffect, useState } from 'react';
-import 'moment-timezone';
-import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import {
   Card,
@@ -18,9 +16,8 @@ import {
 } from '@mui/material';
 import PlayCircleOutlineRounded from '@mui/icons-material/PlayCircleOutlineRounded';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { segmentCardStyles } from './SegmentCard.styles';
-
-const Moment = dynamic(() => import('react-moment')) as any;
 
 export interface SegmentCardProps {
   data: Segment;
@@ -83,9 +80,14 @@ export const SegmentCard = ({ data }: SegmentCardProps) => {
               color="textSecondary"
               noWrap
             >
-              <Moment format="MMMM D, YYYY" tz="America/New_York">
-                {cardDate}
-              </Moment>
+              <DateTime
+                date={cardDate}
+                options={{
+                  month: 'long',
+                  day: 'numeric',
+                  year: 'numeric'
+                }}
+              />
             </Typography>
           )}
           <Typography

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -4,19 +4,16 @@
  */
 
 import type { Episode } from '@interfaces';
-import 'moment-timezone';
-import dynamic from 'next/dynamic';
 import { Card, CardActionArea, CardContent, Typography } from '@mui/material';
 import { Headset, NavigateNext } from '@mui/icons-material';
 import { ContentButton } from '@components/ContentButton';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { AudioControls } from '@components/Player/components';
 import { sidebarEpisodeStyles } from './SidebarEpisode.styles';
 import { SidebarHeader } from '../SidebarHeader';
 import { SidebarFooter } from '../SidebarFooter';
 import { SidebarList } from '../SidebarList';
-
-const Moment = dynamic(() => import('react-moment')) as any;
 
 export interface SidebarEpisodeProps {
   data: Episode;
@@ -38,6 +35,11 @@ export const SidebarEpisode = ({
   const { id: audioId, audioFields } = audio || {};
   const { segmentsList } = audioFields || {};
   const { broadcastDate } = episodeDates || {};
+  const usedDateString = (broadcastDate && `${broadcastDate}T00:00:00`) || date;
+  const episodeDate =
+    usedDateString && typeof usedDateString !== 'undefined'
+      ? new Date(usedDateString)
+      : undefined;
   const { classes } = sidebarEpisodeStyles();
 
   return (
@@ -64,14 +66,27 @@ export const SidebarEpisode = ({
             component="p"
             gutterBottom
             className={classes.title}
+            {...(episodeDate && {
+              'aria-label': `Episode from ${episodeDate.toLocaleDateString(
+                'en-US',
+                {
+                  weekday: 'long',
+                  month: 'long',
+                  day: 'numeric',
+                  year: 'numeric'
+                }
+              )}`
+            })}
           >
-            <Moment
-              format="dddd, MMMM D, YYYY"
-              tz="America/New_York"
-              {...(broadcastDate && { parse: 'YYYY-MM-DD' })}
-            >
-              {broadcastDate || date}
-            </Moment>
+            <DateTime
+              date={usedDateString}
+              options={{
+                weekday: 'long',
+                month: 'long',
+                day: 'numeric',
+                year: 'numeric'
+              }}
+            />
           </Typography>
           <ContentLink url={data.link} className={classes.link}>
             {data.title}

--- a/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
+++ b/components/Sidebar/SidebarEpisode/SidebarEpisode.tsx
@@ -3,13 +3,15 @@
  * Component for story card links.
  */
 
-import type { Episode } from '@interfaces';
+import type { Episode, RootState } from '@interfaces';
+import { useStore } from 'react-redux';
 import { Card, CardActionArea, CardContent, Typography } from '@mui/material';
 import { Headset, NavigateNext } from '@mui/icons-material';
 import { ContentButton } from '@components/ContentButton';
 import { ContentLink } from '@components/ContentLink';
 import { DateTime } from '@components/DateTime';
 import { AudioControls } from '@components/Player/components';
+import { getSettingsTimeZone } from '@store/reducers';
 import { sidebarEpisodeStyles } from './SidebarEpisode.styles';
 import { SidebarHeader } from '../SidebarHeader';
 import { SidebarFooter } from '../SidebarFooter';
@@ -28,6 +30,9 @@ export const SidebarEpisode = ({
   collectionLink,
   collectionLinkShallow
 }: SidebarEpisodeProps) => {
+  const store = useStore<RootState>();
+  const state = store.getState();
+  const timeZone = getSettingsTimeZone(state);
   const { title, date, featuredImage, episodeDates, episodeAudio } = data;
   const image = featuredImage?.node;
   const imageUrl = image?.sourceUrl || image?.mediaItemUrl;
@@ -70,6 +75,7 @@ export const SidebarEpisode = ({
               'aria-label': `Episode from ${episodeDate.toLocaleDateString(
                 'en-US',
                 {
+                  ...(timeZone && { timeZone }),
                   weekday: 'long',
                   month: 'long',
                   day: 'numeric',

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -11,7 +11,6 @@ import type {
 import type { IAudioControlsProps } from '@components/Player/components';
 import type { IAudioData } from '@components/Player/types';
 import { useEffect, useState } from 'react';
-import 'moment-timezone';
 import dynamic from 'next/dynamic';
 import Image from 'next/legacy/image';
 import { useRouter } from 'next/router';
@@ -33,10 +32,9 @@ import {
 import { Label } from '@mui/icons-material';
 import { ThemeProvider } from '@mui/styles';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { HtmlContent } from '@components/HtmlContent';
 import { useStoryCardStyles, storyCardTheme } from './StoryCard.styles';
-
-const Moment = dynamic(() => import('react-moment')) as any;
 
 const AudioControls = dynamic(() =>
   import('@components/Player/components').then((mod) => mod.AudioControls)
@@ -176,9 +174,14 @@ export const StoryCard = ({
                 </Typography>
                 <Box className={classes.info}>
                   <Typography component="span" className={classes.date}>
-                    <Moment format="MMMM D, YYYY" tz="America/New_York">
-                      {date}
-                    </Moment>
+                    <DateTime
+                      date={date}
+                      options={{
+                        month: 'long',
+                        day: 'numeric',
+                        year: 'numeric'
+                      }}
+                    />
                   </Typography>
                   {primaryCategory && (
                     <Typography

--- a/components/StoryCardGrid/StoryCardGrid.tsx
+++ b/components/StoryCardGrid/StoryCardGrid.tsx
@@ -12,7 +12,6 @@ import type {
 } from '@components/Player/components';
 import type { IAudioData } from '@components/Player/types';
 import { useEffect, useState } from 'react';
-import 'moment-timezone';
 import dynamic from 'next/dynamic';
 import Image from 'next/legacy/image';
 import { useRouter } from 'next/router';
@@ -34,9 +33,8 @@ import {
 } from '@mui/material';
 import { Label } from '@mui/icons-material';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { storyCardGridStyles } from './StoryCardGrid.styles';
-
-const Moment = dynamic(() => import('react-moment')) as any;
 
 const PlayAudioButton = dynamic(() =>
   import('@components/Player/components').then((mod) => mod.PlayAudioButton)
@@ -180,9 +178,14 @@ export const StoryCardGrid = ({ data, ...other }: StoryCardGridProps) => {
                   </Box>
                   <Box className={classes.info}>
                     <Typography className={classes.date} component="span">
-                      <Moment format="MMMM D, YYYY" tz="America/New_York">
-                        {date}
-                      </Moment>
+                      <DateTime
+                        date={date}
+                        options={{
+                          month: 'long',
+                          day: 'numeric',
+                          year: 'numeric'
+                        }}
+                      />
                     </Typography>
                     {primaryCategory && (
                       <Typography

--- a/components/pages/Audio/Audio.tsx
+++ b/components/pages/Audio/Audio.tsx
@@ -46,7 +46,7 @@ export const Audio = () => {
   const metatags = {
     ...dataMetatags,
     ...(broadcastDate && {
-      pubdate: parseDateParts(broadcastDate * 1000).join('-')
+      pubdate: broadcastDate
     })
   };
 
@@ -68,7 +68,7 @@ export const Audio = () => {
     }),
     ...(broadcastDate &&
       (() => {
-        const dt = parseDateParts(broadcastDate * 1000);
+        const dt = parseDateParts(broadcastDate);
         return {
           'Broadcast Year': dt[0],
           'Broadcast Month': dt.slice(0, 2).join('-'),

--- a/components/pages/Audio/components/AudioHeader/AudioHeader.tsx
+++ b/components/pages/Audio/components/AudioHeader/AudioHeader.tsx
@@ -12,14 +12,10 @@ import type React from 'react';
 import dynamic from 'next/dynamic';
 import { Box, Typography } from '@mui/material';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { IAudioControlsProps } from '@components/Player/components';
 import { IAudioData } from '@components/Player/types';
 import { audioHeaderStyles } from './AudioHeader.styles';
-
-const Moment = dynamic(() => {
-  import('moment-timezone');
-  return import('react-moment');
-}) as any;
 
 const AudioControls = dynamic(() =>
   import('@components/Player/components').then((mod) => mod.AudioControls)
@@ -54,16 +50,14 @@ export const AudioHeader = ({ data }: Props) => {
               {program.name}
             </ContentLink>
           )}
-          {broadcastDate && (
-            <Moment
-              className={classes.date}
-              format="MMM. D, YYYY · h:mm A z"
-              tz="America/New_York"
-              unix
-            >
-              {broadcastDate}
-            </Moment>
-          )}
+          <DateTime
+            date={broadcastDate}
+            options={{
+              month: 'long',
+              day: 'numeric',
+              year: 'numeric'
+            }}
+          />
           {!!contributors?.nodes.length && (
             <ul className={classes.byline}>
               {contributors.nodes.map(

--- a/components/pages/Episode/components/EpisodeHeader/EpisodeHeader.tsx
+++ b/components/pages/Episode/components/EpisodeHeader/EpisodeHeader.tsx
@@ -14,12 +14,8 @@ import type {
 import dynamic from 'next/dynamic';
 import { Box, Typography } from '@mui/material';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { episodeHeaderStyles } from './EpisodeHeader.styles';
-
-const Moment = dynamic(() => {
-  import('moment-timezone');
-  return import('react-moment');
-}) as any;
 
 const AudioControls = dynamic(() =>
   import('@components/Player/components').then((mod) => mod.AudioControls)
@@ -58,14 +54,15 @@ export const EpisodeHeader = ({ data }: Props) => {
               {program.name}
             </ContentLink>
           )}
-          <Moment
+          <DateTime
             className={classes.date}
-            format="MMM. D, YYYY"
-            tz="America/New_York"
-            {...(broadcastDate && { parse: 'YYYY-MM-DD' })}
-          >
-            {broadcastDate || date}
-          </Moment>
+            date={broadcastDate || date}
+            options={{
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric'
+            }}
+          />
         </Box>
         {audio && (
           <Box className={classes.audio}>

--- a/components/pages/Segment/Segment.tsx
+++ b/components/pages/Segment/Segment.tsx
@@ -42,7 +42,7 @@ export const Segment = ({
   const metatags = {
     ...seo,
     ...(broadcastDate && {
-      pubdate: parseDateParts(broadcastDate).join('-')
+      pubdate: broadcastDate
     })
   };
 

--- a/components/pages/Segment/components/SegmentHeader/SegmentHeader.tsx
+++ b/components/pages/Segment/components/SegmentHeader/SegmentHeader.tsx
@@ -14,16 +14,12 @@ import dynamic from 'next/dynamic';
 import Image from 'next/legacy/image';
 import { Box, Typography } from '@mui/material';
 import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { HtmlContent } from '@components/HtmlContent';
 import { ImageCredit } from '@components/ImageCredit';
 import { IAudioControlsProps } from '@components/Player/components';
 import { IAudioData } from '@components/Player/types';
 import { audioHeaderStyles } from './SegmentHeader.styles';
-
-const Moment = dynamic(() => {
-  import('moment-timezone');
-  return import('react-moment');
-}) as any;
 
 const AudioControls = dynamic(() =>
   import('@components/Player/components').then((mod) => mod.AudioControls)
@@ -90,16 +86,14 @@ export const AudioHeader = ({ data }: Props) => {
                   {program.name}
                 </ContentLink>
               )}
-              {broadcastDate && (
-                <Moment
-                  className={classes.date}
-                  format="MMM. D, YYYY"
-                  tz="America/New_York"
-                  parse="YYYY-MM-DD"
-                >
-                  {broadcastDate}
-                </Moment>
-              )}
+              <DateTime
+                date={broadcastDate}
+                options={{
+                  month: 'long',
+                  day: 'numeric',
+                  year: 'numeric'
+                }}
+              />
               {!!contributors?.nodes.length && (
                 <ul className={classes.byline}>
                   {contributors.nodes.map(

--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -10,17 +10,13 @@ import type {
   Contributor,
   Post_Additionalmedia as PostAdditionalMedia
 } from '@interfaces';
+import { DateTime } from '@components/DateTime';
 import type { IAudioControlsProps } from '@components/Player/components';
 import type { IAudioData } from '@components/Player/types';
 import { ContentLink } from '@components/ContentLink';
 import dynamic from 'next/dynamic';
 import { Box, Typography } from '@mui/material';
 import { storyHeaderStyles } from './StoryHeader.default.styles';
-
-const Moment = dynamic(() => {
-  import('moment-timezone');
-  return import('react-moment');
-}) as any;
 
 const AudioControls = dynamic(() =>
   import('@components/Player/components').then((mod) => mod.AudioControls)
@@ -85,9 +81,14 @@ export const StoryHeader = ({ data }: Props) => {
               component="div"
               className={classes.date}
             >
-              <Moment format="MMMM D, YYYY" tz="America/New_York">
-                {date}
-              </Moment>
+              <DateTime
+                date={date}
+                options={{
+                  month: 'long',
+                  day: 'numeric',
+                  year: 'numeric'
+                }}
+              />
             </Typography>
           )}
           {updatedDate && (
@@ -98,9 +99,14 @@ export const StoryHeader = ({ data }: Props) => {
             >
               {' '}
               Updated on{' '}
-              <Moment format="MMM. D, YYYY · h:mm A z" tz="America/New_York">
-                {updatedDate}
-              </Moment>
+              <DateTime
+                date={updatedDate}
+                options={{
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric'
+                }}
+              />
             </Typography>
           )}
           {bylines && (

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -13,19 +13,17 @@ import type {
 } from '@interfaces';
 import type { IAudioControlsProps } from '@components/Player/components';
 import type { IAudioData } from '@components/Player/types';
-import { ContentLink } from '@components/ContentLink';
-import Image from 'next/legacy/image';
 import dynamic from 'next/dynamic';
-import 'moment-timezone';
+import Image from 'next/legacy/image';
 import { Box, Container, Typography, ThemeProvider } from '@mui/material';
+import { ContentLink } from '@components/ContentLink';
+import { DateTime } from '@components/DateTime';
 import { HtmlContent } from '@components/HtmlContent';
 import { ImageCredit } from '@components/ImageCredit';
 import {
   storyHeaderStyles,
   storyHeaderTheme
 } from './StoryHeader.feature.styles';
-
-const Moment = dynamic(() => import('react-moment')) as any;
 
 const AudioControls = dynamic(() =>
   import('@components/Player/components').then((mod) => mod.AudioControls)
@@ -123,9 +121,14 @@ export const StoryHeader = ({ data }: Props) => {
                     component="div"
                     className={classes.date}
                   >
-                    <Moment format="MMMM D, YYYY" tz="America/New_York">
-                      {date}
-                    </Moment>
+                    <DateTime
+                      date={date}
+                      options={{
+                        month: 'long',
+                        day: 'numeric',
+                        year: 'numeric'
+                      }}
+                    />
                   </Typography>
                 )}
                 {updatedDate && (
@@ -136,12 +139,14 @@ export const StoryHeader = ({ data }: Props) => {
                   >
                     {' '}
                     Updated on{' '}
-                    <Moment
-                      format="MMM. D, YYYY · h:mm A z"
-                      tz="America/New_York"
-                    >
-                      {updatedDate}
-                    </Moment>
+                    <DateTime
+                      date={updatedDate}
+                      options={{
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric'
+                      }}
+                    />
                   </Typography>
                 )}
                 {!!bylines.length && (

--- a/interfaces/app/IApp.ts
+++ b/interfaces/app/IApp.ts
@@ -1,6 +1,7 @@
-import type { IButton, ICtaMessage, PostStory } from '@interfaces';
+import type { IButton, ICtaMessage, PostStory, Settings } from '@interfaces';
 
 export interface IApp {
+  settings?: Settings;
   latestStories?: PostStory[];
   menus?: {
     [k: string]: IButton[];

--- a/lib/fetch/app/fetchGqlApp.ts
+++ b/lib/fetch/app/fetchGqlApp.ts
@@ -8,7 +8,8 @@ import type {
   Maybe,
   Menu,
   Program,
-  RootQueryToCtaRegionConnection
+  RootQueryToCtaRegionConnection,
+  Settings
 } from '@interfaces';
 import { gql } from '@apollo/client';
 import { gqlClient } from '@lib/fetch/api';
@@ -19,6 +20,9 @@ import { CTA_PROPS, CTA_REGION_PROPS, MENU_PROPS } from '../api/graphql';
 
 const GET_APP = gql`
   query getApp {
+    allSettings {
+      generalSettingsTimezone
+    }
     program(id: "the-world", idType: SLUG) {
       id
       posts(first: 10, where: { orderby: { field: DATE, order: DESC } }) {
@@ -56,6 +60,7 @@ const GET_APP = gql`
 
 export const fetchGqlApp = async () => {
   const response = await gqlClient.query<{
+    allSettings: Settings;
     program: Maybe<Program>;
     headerMenu: Maybe<Menu>;
     footerMenu: Maybe<Menu>;
@@ -91,6 +96,7 @@ export const fetchGqlApp = async () => {
   );
 
   return {
+    ...(data.allSettings && { settings: data.allSettings }),
     ...(latestStories && { latestStories }),
     menus: {
       ...(drawerMainNav && { drawerMainNav: parseMenu(drawerMainNav) }),

--- a/lib/parse/audio/audioData.ts
+++ b/lib/parse/audio/audioData.ts
@@ -86,7 +86,7 @@ export const parseAudioData = (
   const dateString =
     broadcastDate &&
     ((d) => {
-      const date = new Date(d);
+      const date = new Date(`${d}T00:00:00`);
       return date.toLocaleDateString(undefined, { dateStyle: 'medium' });
     })(broadcastDate);
   const info = [

--- a/lib/parse/audio/audioData.ts
+++ b/lib/parse/audio/audioData.ts
@@ -83,18 +83,13 @@ export const parseAudioData = (
         parent.node.date)) ||
     audioBroadcastDate ||
     dataDate;
-  const dateString =
-    broadcastDate &&
-    ((d) => {
-      const date = new Date(`${d}T00:00:00`);
-      return date.toLocaleDateString(undefined, { dateStyle: 'medium' });
-    })(broadcastDate);
+  const date = broadcastDate && new Date(`${broadcastDate}T00:00:00`);
   const info = [
     ...(program ? [program.name] : []),
     ...(audioAuthor
       ? audioAuthor.map(({ name }: Contributor) => name).filter((v) => !!v)
       : []),
-    ...(dateString ? [dateString] : [])
+    ...(date ? [date] : [])
   ];
 
   return {

--- a/lib/parse/date/parseDateParts.spec.ts
+++ b/lib/parse/date/parseDateParts.spec.ts
@@ -11,5 +11,15 @@ describe('lib/parse/date', () => {
       expect(result[1]).toEqual('02');
       expect(result[2]).toEqual('16');
     });
+
+    test('should date string w/o time into array of padded date parts with correct day', () => {
+      const result = parseDateParts('1977-03-25');
+
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual('1977');
+      expect(result[1]).toEqual('03');
+      expect(result[2]).toEqual('25');
+    });
   });
 });

--- a/lib/parse/date/parseDateParts.ts
+++ b/lib/parse/date/parseDateParts.ts
@@ -8,7 +8,10 @@ import padStart from 'lodash/padStart';
  *    Duration in seconds.
  */
 export const parseDateParts = (date: number | string | Date): string[] => {
-  const dt = new Date(date);
+  const dt =
+    typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)
+      ? new Date(`${date}T00:00:00`)
+      : new Date(date);
   const dtYear = `${dt.getFullYear()}`;
   const dtMonth = padStart(`${dt.getMonth() + 1}`, 2, '0');
   const dtDate = padStart(`${dt.getDate()}`, 2, '0');

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
     "graphql": "^16.6.0",
     "isomorphic-unfetch": "^3.0.0",
     "lodash": "^4.17.21",
-    "moment": "^2.29.1",
-    "moment-timezone": "^0.5.27",
     "next": "^13.2.4",
     "next-absolute-url": "^1.0.2",
     "next-compose-plugins": "^2.2.0",

--- a/store/reducers/appData.ts
+++ b/store/reducers/appData.ts
@@ -23,6 +23,7 @@ export const appData = (state: AppDataState, action: AppDataAction) => {
   }
 };
 
+export const getAppSettings = (state: Maybe<AppDataState>) => state?.settings;
 export const getAppDataMenu = (state: Maybe<AppDataState>, menu: string) =>
   state?.menus?.[menu];
 export const getAppDataLatestStories = (state: Maybe<AppDataState>) =>

--- a/store/reducers/index.ts
+++ b/store/reducers/index.ts
@@ -44,6 +44,10 @@ export const reducers = combineReducers({
 });
 
 export const getAppData = (state: RootState) => state?.appData;
+export const getSettings = (state: RootState) =>
+  fromAppData.getAppSettings(state.appData);
+export const getSettingsTimeZone = (state: RootState) =>
+  state.appData?.settings?.generalSettingsTimezone;
 export const getAppDataMenu = (state: RootState, menu: string) =>
   fromAppData.getAppDataMenu(getAppData(state), menu);
 export const getAppDataLatestStories = (state: RootState) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8222,18 +8222,6 @@ mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-moment-timezone@^0.5.27:
-  version "0.5.45"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.45.tgz#cb685acd56bac10e69d93c536366eb65aa6bcf5c"
-  integrity sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==
-  dependencies:
-    moment "^2.29.4"
-
-moment@^2.29.1, moment@^2.29.4:
-  version "2.30.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
-  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
-
 moo@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"


### PR DESCRIPTION
- add DateTime component to format date using toLocaleDateString
- update components to use DateTime component
- update conversions of broadcastDate to Date to append midnight time to date string
- remove moment and moment-timezone

## To Review

- [x] Checkout Branch.
- [x] Update .env to use live API: `API_URL_BASE=https://api.theworld.org`
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure dates in all cards are correct.
- [x] Refresh page and ensure wrong date is not flashed momentarily
- [x] View a story and ensure dates are correct
- [x] View a episode and ensure dates are correct
- [x] View a segment and ensure dates are correct
- [x] Play some audio and ensure correct date is shown in player
- [x] Search for `olympics` and ensure dates on cards for stories, episodes, and segments are correct
