### PR TITLE
fix(datetime): ensure times are denoted with `T`

### DIFF
--- a/components/DateTime/DateTime.tsx
+++ b/components/DateTime/DateTime.tsx
@@ -33,6 +33,12 @@ export const DateTime = ({
     typeof usedDateValue === 'string' &&
     /^\d{4}-\d{2}-\d{2}/.test(usedDateValue)
   ) {
+    // Ensure times are denoted with`T` instead of a space.
+    usedDateValue = usedDateValue.replace(
+      /\s(\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?)/,
+      'T$1'
+    );
+
     // Ensure ISO 8601 dates have a time.
     if (!/T\d{2}:\d{2}:\d{2}/.test(usedDateValue)) {
       usedDateValue = `${usedDateValue}T00:00:00`;

--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -93,7 +93,7 @@ export const StoryHeader = ({ data }: Props) => {
           )}
           {updatedDate && (
             <Typography
-              variant="subtitle1"
+              variant="subtitle2"
               component="div"
               className={classes.date}
             >

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,9 +4244,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001651"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz"
-  integrity sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==
+  version "1.0.30001660"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz"
+  integrity sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Some dates coming out of Wordpress are formatted `YYYY-MM-DD HH:mm:ss` (missing the `T` prefix to denote time.) This updates the date string sanitization to ensure the `T` is present as expected by the time-zone handling logic in this scope of the render. 

Also includes an update to caniuse-lite version (updated as part of the `dev:start` script.)

## To Review

- [ ] Checkout Branch.
- [ ] Update `.env` to use live API: `API_URL_BASE=https://api.theworld.org`
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to http://localhost:3000/stories/2016/08/02/do-spain-and-portugal-finally-share-destiny

> ...then...

- [ ] Ensure page loads without erroring.
