### PR TITLE
483: Audio broadcast date handling should support any format

### DIFF
--- a/components/DateTime/DateTime.tsx
+++ b/components/DateTime/DateTime.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { Maybe, RootState } from '@interfaces';
+import { sanitizeIso8601Date } from '@lib/sanitize';
 import { getSettingsTimeZone } from '@store/reducers';
 import { useStore } from 'react-redux';
 
@@ -24,43 +25,18 @@ export const DateTime = ({
   const state = store.getState();
   const timeZone = getSettingsTimeZone(state);
 
-  if (!date) return null;
+  const usedDateValue =
+    typeof date === 'string'
+      ? sanitizeIso8601Date(date, timeZone || undefined)
+      : date;
 
-  let usedDateValue = date;
-
-  // Date strings from the API should be in ISO 8601, but could be missing some elements.
-  if (
-    typeof usedDateValue === 'string' &&
-    /^\d{4}-\d{2}-\d{2}/.test(usedDateValue)
-  ) {
-    // Ensure times are denoted with`T` instead of a space.
-    usedDateValue = usedDateValue.replace(
-      /\s(\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?)/,
-      'T$1'
-    );
-
-    // Ensure ISO 8601 dates have a time.
-    if (!/T\d{2}:\d{2}:\d{2}/.test(usedDateValue)) {
-      usedDateValue = `${usedDateValue}T00:00:00`;
-    }
-
-    // Ensure ISO 8601 dates are set to settings time-zone if they do not already have a time-zone offset.
-    if (!/[+-]\d{2}:?\d{2}$/.test(usedDateValue)) {
-      // Time-zone from settings will be in long format, eg `America/New_York`.
-      // We need to convert that to a offset string.
-      const tz = new Date()
-        .toLocaleTimeString('en-US', {
-          ...(timeZone && { timeZone }),
-          timeZoneName: 'longOffset'
-        })
-        .match(/GMT(.+)/)?.[1];
-
-      usedDateValue = `${usedDateValue}${tz}`;
-    }
-  }
+  if (!usedDateValue) return null;
 
   const renderDate =
     usedDateValue instanceof Date ? usedDateValue : new Date(usedDateValue);
+
+  if (renderDate.toString() === 'Invalid Date') return null;
+
   const formattedDate = renderDate.toLocaleDateString(locale || 'en-US', {
     ...(timeZone && { timeZone }),
     ...options

--- a/lib/parse/audio/audioData.ts
+++ b/lib/parse/audio/audioData.ts
@@ -13,6 +13,7 @@ import {
   Segment
 } from '@interfaces';
 import { generateAudioUrl } from '@lib/generate/string';
+import { sanitizeIso8601Date } from '@lib/sanitize';
 
 export const parseAudioData = (
   data: MediaItem,
@@ -83,13 +84,13 @@ export const parseAudioData = (
         parent.node.date)) ||
     audioBroadcastDate ||
     dataDate;
-  const date = broadcastDate && new Date(`${broadcastDate}T00:00:00`);
+  const date = broadcastDate && sanitizeIso8601Date(broadcastDate);
   const info = [
     ...(program ? [program.name] : []),
     ...(audioAuthor
       ? audioAuthor.map(({ name }: Contributor) => name).filter((v) => !!v)
       : []),
-    ...(date ? [date] : [])
+    ...(date ? [new Date(date)] : [])
   ];
 
   return {

--- a/lib/sanitize/index.ts
+++ b/lib/sanitize/index.ts
@@ -1,0 +1,1 @@
+export * from './sanitizeIso8601Date';

--- a/lib/sanitize/sanitizeIso8601Date.spec.ts
+++ b/lib/sanitize/sanitizeIso8601Date.spec.ts
@@ -1,0 +1,51 @@
+import { sanitizeIso8601Date } from './index';
+
+describe('lib/sanitize', () => {
+  describe('sanitizeIso8601Date', () => {
+    test('should return dateString when format is not ISO 8601 compatible.', () => {
+      const result = sanitizeIso8601Date('March 25, 1977');
+
+      expect(result).toEqual('March 25, 1977');
+    });
+
+    test('should return null for supported falsey dateString values.', () => {
+      const result1 = sanitizeIso8601Date('');
+      const result2 = sanitizeIso8601Date(null);
+
+      expect(result1).toBeNull();
+      expect(result2).toBeNull();
+    });
+
+    test('should add midnight time string to date only strings.', () => {
+      const result = sanitizeIso8601Date('1977-03-25');
+
+      expect(result?.startsWith('1977-03-25T00:00:00')).toBe(true);
+    });
+
+    test('should add local time-zone offset when not passed a timeZone parameter.', () => {
+      const result = sanitizeIso8601Date('1977-03-25');
+      const localTimeZone = new Date()
+        .toLocaleTimeString('en-US', {
+          timeZoneName: 'longOffset'
+        })
+        .match(/GMT(.+)/)?.[1];
+
+      if (localTimeZone) expect(result?.endsWith(localTimeZone)).toBe(true);
+    });
+
+    test('should add time-zone offset for the passed time zone-string.', () => {
+      const result = sanitizeIso8601Date('1977-03-25', 'America/New_York');
+
+      expect(result?.endsWith('-04:00')).toBe(true);
+    });
+
+    test('should not add time-zone offset for the passed time-zone string when dateString has time-zone offset.', () => {
+      const result = sanitizeIso8601Date(
+        '1977-03-25T00:00:00+05:00',
+        'America/New_York'
+      );
+
+      expect(result?.endsWith('+05:00')).toBe(true);
+    });
+  });
+});

--- a/lib/sanitize/sanitizeIso8601Date.ts
+++ b/lib/sanitize/sanitizeIso8601Date.ts
@@ -1,0 +1,49 @@
+/**
+ * @file sanitizeIso8601Date.ts
+ * Sanitize an ISO 8601 date string to have a time and timezone.
+ */
+
+import { Maybe } from '@interfaces';
+
+export const sanitizeIso8601Date = (
+  dateString: Maybe<string>,
+  timeZone?: Maybe<string>
+) => {
+  if (!dateString) return null;
+  if (!/^\d{4}-\d{2}-\d{2}/.test(dateString)) return dateString as string;
+
+  let usedDateValue = dateString;
+
+  // Date strings from the API should be in ISO 8601, but could be missing some elements.
+  if (
+    typeof usedDateValue === 'string' &&
+    /^\d{4}-\d{2}-\d{2}/.test(usedDateValue)
+  ) {
+    // Ensure times are denoted with`T` instead of a space.
+    usedDateValue = usedDateValue.replace(
+      /\s(\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?)/,
+      'T$1'
+    );
+
+    // Ensure ISO 8601 dates have a time.
+    if (!/T\d{2}:\d{2}:\d{2}/.test(usedDateValue)) {
+      usedDateValue = `${usedDateValue}T00:00:00`;
+    }
+
+    // Ensure ISO 8601 dates are set to settings time-zone if they do not already have a time-zone offset.
+    if (!/[+-]\d{2}:?\d{2}$/.test(usedDateValue)) {
+      // Time-zone from settings will be in long format, eg `America/New_York`.
+      // We need to convert that to a offset string.
+      const tz = new Date()
+        .toLocaleTimeString('en-US', {
+          ...(timeZone && { timeZone }),
+          timeZoneName: 'longOffset'
+        })
+        .match(/GMT(.+)/)?.[1];
+
+      usedDateValue = `${usedDateValue}${tz}`;
+    }
+  }
+
+  return usedDateValue;
+};


### PR DESCRIPTION
Closes #483 

- audio data should now parse any date format
- move date sanitization from DateTime component to lib function
- update DateTime component to handle invalid date strings

## To Review

- [x] Checkout Branch.
- [x] Update `.env` to use live API: `API_URL_BASE=https://api.theworld.org`
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to http://localhost:3000/stories/2024/07/09/an-ancient-yemenite-delicacy-is-passed-down-through-generations

> ...then...

- [x] Play or add audio to queue.
- [x] Ensure it plays or gets added to playlist without causing errors.
- [x] Ensure dates for the story and the audio in player render correctly.
