### PR TITLE
487: TwitterCard use `summary_large_image`

### DIFF
--- a/components/TwitterCard/TwitterCard.tsx
+++ b/components/TwitterCard/TwitterCard.tsx
@@ -18,7 +18,7 @@ export const TwitterCard = ({ data }: ITwitterCardProps) => {
         name="twitter:account_id"
         content={process.env.TWITTER_ACCOUNT_ID}
       />
-      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:card" content="summary_large_image" />
       {twitterTitle && <meta name="twitter:title" content={twitterTitle} />}
       {twitterDescription && (
         <meta name="twitter:description" content={twitterDescription} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,9 +4244,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001660"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz"
-  integrity sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==
+  version "1.0.30001692"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz"
+  integrity sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Closes #487

- changes `twitter:card` meta tag to `summary_large_image`

## To Review

- [ ] Code review.
