### PR TITLE
492: Add unique id validation

### DIFF
--- a/lib/validate/index.ts
+++ b/lib/validate/index.ts
@@ -1,1 +1,2 @@
 export * from './email';
+export * from './uniqueId';

--- a/lib/validate/uniqueId.spec.ts
+++ b/lib/validate/uniqueId.spec.ts
@@ -1,0 +1,27 @@
+import { encode } from 'base-64';
+import { validateUniqueId } from './uniqueId';
+
+describe('lib/validate', () => {
+  describe('uniqueId', () => {
+    test('should return valid with unique id.', () => {
+      const id = encode('post:1234');
+      const result = validateUniqueId(id);
+
+      expect(result).toBe(true);
+    });
+
+    test('should return invalid with invalid encoded id.', () => {
+      const id = encode('not:correct:pattern:1234');
+      const result = validateUniqueId(id);
+
+      expect(result).toBe(false);
+    });
+
+    test('should return invalid with unencoded id.', () => {
+      const id = 'bad-id';
+      const result = validateUniqueId(id);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/lib/validate/uniqueId.ts
+++ b/lib/validate/uniqueId.ts
@@ -1,0 +1,26 @@
+/**
+ * @file uniqueId.ts
+ * Helper functions to validate API resource unique ids.
+ */
+
+import { decode } from 'base-64';
+
+/**
+ * Check if string is a unique id.
+ *
+ * @param id Unique id to validate.
+ */
+export const validateUniqueId = (id: string) => {
+  // Empty value is not a unique id.
+  if (!id?.trim()) return false;
+
+  try {
+    const parsedId = decode(id);
+
+    // Return if the decoded string matches expected pattern.
+    return /^[\w-]+:\d+$/.test(parsedId);
+  } catch (e) {
+    // String could not be decoded, so is not a unique id.
+    return false;
+  }
+};

--- a/pages/api/category/[id]/index.ts
+++ b/pages/api/category/[id]/index.ts
@@ -5,12 +5,13 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlCategory } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
-  const categoryId = !!id && (typeof id === 'string' ? id : id[0]);
+  const categoryId = Array.isArray(id) ? id[0] : id;
 
-  if (categoryId) {
+  if (categoryId && validateUniqueId(categoryId)) {
     const category = await fetchGqlCategory(categoryId);
 
     if (category) {

--- a/pages/api/category/[id]/posts.ts
+++ b/pages/api/category/[id]/posts.ts
@@ -4,15 +4,16 @@
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlCategoryPosts } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, c, f, e } = req.query;
-  const categoryId = !!id && (typeof id === 'string' ? id : id[0]);
+  const categoryId = Array.isArray(id) ? id[0] : id;
   const cursor = !!c && (typeof c === 'string' ? c : c[0]);
   const pageSize = !!f && parseInt(typeof f === 'string' ? f : f[0], 10);
   const exclude = !!e && (typeof e === 'string' ? [e] : e);
 
-  if (categoryId) {
+  if (categoryId && validateUniqueId(categoryId)) {
     const posts = await fetchGqlCategoryPosts(categoryId, {
       ...(cursor && { cursor }),
       ...(pageSize && { pageSize }),

--- a/pages/api/contributor/[id]/index.ts
+++ b/pages/api/contributor/[id]/index.ts
@@ -5,12 +5,13 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlContributor } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
-  const contributorId = !!id && (typeof id === 'string' ? id : id[0]);
+  const contributorId = Array.isArray(id) ? id[0] : id;
 
-  if (contributorId) {
+  if (contributorId && validateUniqueId(contributorId)) {
     const contributor = await fetchGqlContributor(contributorId);
 
     if (contributor) {

--- a/pages/api/contributor/[id]/posts.ts
+++ b/pages/api/contributor/[id]/posts.ts
@@ -4,15 +4,16 @@
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlContributorPosts } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, c, f, e } = req.query;
-  const contributorId = !!id && (typeof id === 'string' ? id : id[0]);
+  const contributorId = Array.isArray(id) ? id[0] : id;
   const cursor = !!c && (typeof c === 'string' ? c : c[0]);
   const pageSize = !!f && parseInt(typeof f === 'string' ? f : f[0], 10);
   const exclude = !!e && (typeof e === 'string' ? [e] : e);
 
-  if (contributorId) {
+  if (contributorId && validateUniqueId(contributorId)) {
     const posts = await fetchGqlContributorPosts(contributorId, {
       ...(cursor && { cursor }),
       ...(pageSize && { pageSize }),

--- a/pages/api/contributor/[id]/segments.ts
+++ b/pages/api/contributor/[id]/segments.ts
@@ -4,15 +4,16 @@
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlContributorSegments } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, c, f, e } = req.query;
-  const contributorId = !!id && (typeof id === 'string' ? id : id[0]);
+  const contributorId = Array.isArray(id) ? id[0] : id;
   const cursor = !!c && (typeof c === 'string' ? c : c[0]);
   const pageSize = !!f && parseInt(typeof f === 'string' ? f : f[0], 10);
   const exclude = !!e && (typeof e === 'string' ? [e] : e);
 
-  if (contributorId) {
+  if (contributorId && validateUniqueId(contributorId)) {
     const segments = await fetchGqlContributorSegments(contributorId, {
       ...(cursor && { cursor }),
       ...(pageSize && { pageSize }),

--- a/pages/api/episode/[id].ts
+++ b/pages/api/episode/[id].ts
@@ -5,12 +5,14 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlEpisode } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
+  const episodeId = Array.isArray(id) ? id[0] : id;
 
-  if (id) {
-    const data = await fetchGqlEpisode(id as string);
+  if (episodeId && validateUniqueId(episodeId)) {
+    const data = await fetchGqlEpisode(episodeId);
 
     if (data) {
       return res.status(200).json(data);

--- a/pages/api/file/audio/[id].ts
+++ b/pages/api/file/audio/[id].ts
@@ -4,12 +4,14 @@
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlAudio } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
+  const audioId = Array.isArray(id) ? id[0] : id;
 
-  if (id) {
-    const audio = await fetchGqlAudio(id as string);
+  if (audioId && validateUniqueId(audioId)) {
+    const audio = await fetchGqlAudio(audioId);
 
     if (audio) {
       return res.status(200).json(audio);

--- a/pages/api/newsletter/[id].ts
+++ b/pages/api/newsletter/[id].ts
@@ -5,12 +5,14 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlNewsletter } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
+  const newsletterId = Array.isArray(id) ? id[0] : id;
 
-  if (id) {
-    const data = await fetchGqlNewsletter(id as string);
+  if (newsletterId && validateUniqueId(newsletterId)) {
+    const data = await fetchGqlNewsletter(newsletterId);
 
     if (data) {
       return res.status(200).json(data);

--- a/pages/api/page/[id].ts
+++ b/pages/api/page/[id].ts
@@ -5,12 +5,14 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlPage } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
+  const pageId = Array.isArray(id) ? id[0] : id;
 
-  if (id) {
-    const data = await fetchGqlPage(id as string);
+  if (pageId && validateUniqueId(pageId)) {
+    const data = await fetchGqlPage(pageId);
 
     if (data) {
       return res.status(200).json(data);

--- a/pages/api/program/[id]/episodes.ts
+++ b/pages/api/program/[id]/episodes.ts
@@ -4,15 +4,16 @@
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlProgramEpisodes } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, c, f, e } = req.query;
-  const programId = !!id && (typeof id === 'string' ? id : id[0]);
+  const programId = Array.isArray(id) ? id[0] : id;
   const cursor = !!c && (typeof c === 'string' ? c : c[0]);
   const pageSize = !!f && parseInt(typeof f === 'string' ? f : f[0], 10);
   const exclude = !!e && (typeof e === 'string' ? [e] : e);
 
-  if (programId) {
+  if (programId && validateUniqueId(programId)) {
     const episodes = await fetchGqlProgramEpisodes(programId, {
       ...(cursor && { cursor }),
       ...(pageSize && { pageSize }),

--- a/pages/api/program/[id]/index.ts
+++ b/pages/api/program/[id]/index.ts
@@ -5,12 +5,13 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlContributor } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
-  const contributorId = !!id && (typeof id === 'string' ? id : id[0]);
+  const contributorId = Array.isArray(id) ? id[0] : id;
 
-  if (contributorId) {
+  if (contributorId && validateUniqueId(contributorId)) {
     const contributor = await fetchGqlContributor(contributorId);
 
     if (contributor) {

--- a/pages/api/program/[id]/posts.ts
+++ b/pages/api/program/[id]/posts.ts
@@ -4,15 +4,16 @@
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlProgramPosts } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, c, f, e } = req.query;
-  const programId = !!id && (typeof id === 'string' ? id : id[0]);
+  const programId = Array.isArray(id) ? id[0] : id;
   const cursor = !!c && (typeof c === 'string' ? c : c[0]);
   const pageSize = !!f && parseInt(typeof f === 'string' ? f : f[0], 10);
   const exclude = !!e && (typeof e === 'string' ? [e] : e);
 
-  if (programId) {
+  if (programId && validateUniqueId(programId)) {
     const posts = await fetchGqlProgramPosts(programId, {
       ...(cursor && { cursor }),
       ...(pageSize && { pageSize }),

--- a/pages/api/story/[id].ts
+++ b/pages/api/story/[id].ts
@@ -5,12 +5,14 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlStory } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
+  const storyId = Array.isArray(id) ? id[0] : id;
 
-  if (id) {
-    const story = await fetchGqlStory(id as string);
+  if (storyId && validateUniqueId(storyId)) {
+    const story = await fetchGqlStory(storyId);
 
     if (story) {
       return res.status(200).json(story);

--- a/pages/api/tag/[id]/episodes.ts
+++ b/pages/api/tag/[id]/episodes.ts
@@ -4,15 +4,16 @@
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlTagEpisodes } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, c, f, e } = req.query;
-  const tagId = !!id && (typeof id === 'string' ? id : id[0]);
+  const tagId = Array.isArray(id) ? id[0] : id;
   const cursor = !!c && (typeof c === 'string' ? c : c[0]);
   const pageSize = !!f && parseInt(typeof f === 'string' ? f : f[0], 10);
   const exclude = !!e && (typeof e === 'string' ? [e] : e);
 
-  if (tagId) {
+  if (tagId && validateUniqueId(tagId)) {
     const episodes = await fetchGqlTagEpisodes(tagId, {
       ...(cursor && { cursor }),
       ...(pageSize && { pageSize }),

--- a/pages/api/tag/[id]/index.ts
+++ b/pages/api/tag/[id]/index.ts
@@ -5,12 +5,13 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlTag } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query;
-  const tagId = !!id && (typeof id === 'string' ? id : id[0]);
+  const tagId = Array.isArray(id) ? id[0] : id;
 
-  if (tagId) {
+  if (tagId && validateUniqueId(tagId)) {
     const tag = await fetchGqlTag(tagId);
 
     if (tag) {

--- a/pages/api/tag/[id]/posts.ts
+++ b/pages/api/tag/[id]/posts.ts
@@ -4,15 +4,16 @@
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlTagPosts } from '@lib/fetch';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, c, f, e } = req.query;
-  const tagId = !!id && (typeof id === 'string' ? id : id[0]);
+  const tagId = Array.isArray(id) ? id[0] : id;
   const cursor = !!c && (typeof c === 'string' ? c : c[0]);
   const pageSize = !!f && parseInt(typeof f === 'string' ? f : f[0], 10);
   const exclude = !!e && (typeof e === 'string' ? [e] : e);
 
-  if (tagId) {
+  if (tagId && validateUniqueId(tagId)) {
     const posts = await fetchGqlTagPosts(tagId, {
       ...(cursor && { cursor }),
       ...(pageSize && { pageSize }),

--- a/pages/api/tag/tags/[taxonomySlug]/[id]/episodes.ts
+++ b/pages/api/tag/tags/[taxonomySlug]/[id]/episodes.ts
@@ -5,10 +5,11 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlTagEpisodes } from '@lib/fetch';
 import { taxonomySlugToSingularName } from '@lib/map/taxonomy';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, taxonomySlug: ts, c, f, e } = req.query;
-  const tagId = !!id && (typeof id === 'string' ? id : id[0]);
+  const tagId = Array.isArray(id) ? id[0] : id;
   const taxonomySlug =
     (!!ts && (typeof ts === 'string' ? ts : ts[0])) || undefined;
   const taxonomySingleName =
@@ -17,7 +18,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const pageSize = !!f && parseInt(typeof f === 'string' ? f : f[0], 10);
   const exclude = !!e && (typeof e === 'string' ? [e] : e);
 
-  if (tagId) {
+  if (tagId && validateUniqueId(tagId)) {
     const episodes = await fetchGqlTagEpisodes(
       tagId,
       {

--- a/pages/api/tag/tags/[taxonomySlug]/[id]/index.ts
+++ b/pages/api/tag/tags/[taxonomySlug]/[id]/index.ts
@@ -6,16 +6,17 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlTag } from '@lib/fetch';
 import { taxonomySlugToSingularName } from '@lib/map/taxonomy';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, taxonomySlug: ts } = req.query;
-  const tagId = !!id && (typeof id === 'string' ? id : id[0]);
+  const tagId = Array.isArray(id) ? id[0] : id;
   const taxonomySlug =
     (!!ts && (typeof ts === 'string' ? ts : ts[0])) || undefined;
   const taxonomySingleName =
     taxonomySlug && taxonomySlugToSingularName.get(taxonomySlug);
 
-  if (tagId) {
+  if (tagId && validateUniqueId(tagId)) {
     const tag = await fetchGqlTag(tagId, undefined, taxonomySingleName);
 
     if (tag) {

--- a/pages/api/tag/tags/[taxonomySlug]/[id]/posts.ts
+++ b/pages/api/tag/tags/[taxonomySlug]/[id]/posts.ts
@@ -5,10 +5,11 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchGqlTagPosts } from '@lib/fetch';
 import { taxonomySlugToSingularName } from '@lib/map/taxonomy';
+import { validateUniqueId } from '@lib/validate';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { id, taxonomySlug: ts, c, f, e } = req.query;
-  const tagId = !!id && (typeof id === 'string' ? id : id[0]);
+  const tagId = Array.isArray(id) ? id[0] : id;
   const taxonomySlug =
     (!!ts && (typeof ts === 'string' ? ts : ts[0])) || undefined;
   const taxonomySingleName =
@@ -17,7 +18,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const pageSize = !!f && parseInt(typeof f === 'string' ? f : f[0], 10);
   const exclude = !!e && (typeof e === 'string' ? [e] : e);
 
-  if (tagId) {
+  if (tagId && validateUniqueId(tagId)) {
     const posts = await fetchGqlTagPosts(
       tagId,
       {

--- a/pages/embed/audio/[id].tsx
+++ b/pages/embed/audio/[id].tsx
@@ -16,6 +16,7 @@ import { AudioPlayer } from '@components/AudioPlayer';
 import { IAudioPlayerProps } from '@components/AudioPlayer/AudioPlayer.interfaces';
 import { MediaItem } from '@interfaces';
 import { encode } from 'base-64';
+import { validateUniqueId } from '@lib/validate';
 
 export interface IEmbedAudioPageProps {
   data: MediaItem;
@@ -74,7 +75,7 @@ export const getServerSideProps: GetServerSideProps = async ({
     }
   }
 
-  if (resourceId) {
+  if (resourceId && validateUniqueId(resourceId)) {
     const embeddedPlayerUrl = `https://theworld.org/embed/audio/${resourceId}`;
     let data: MediaItem | undefined;
     let message: string | undefined;


### PR DESCRIPTION
Closes #492 

- Adds validation of ids past to page routes that use and `id` parameter to fetch api data.

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure you can still navigate to all pages.
- [x] Go to http://localhost:3000/embed/audio/undefined
- [x] Ensure you get a 404 error, not a 500.
- [x] Go to http://localhost:3000/api/story/12345
- [x] Ensure you get a 400 error response, not a 500.
