### PR TITLE
Add Youtube to supported icons for Social Menu

### DIFF
--- a/components/AppHeader/DrawerSocialNav/DrawerSocialNav.tsx
+++ b/components/AppHeader/DrawerSocialNav/DrawerSocialNav.tsx
@@ -16,7 +16,8 @@ import {
   faFlipboard,
   faWhatsapp,
   faBluesky,
-  faTiktok
+  faTiktok,
+  faYoutube
 } from '@fortawesome/free-brands-svg-icons';
 import { getAppDataMenu } from '@store/reducers';
 import { drawerTopNavStyles } from './DrawerSocialNav.styles';
@@ -30,7 +31,8 @@ const iconComponentMap = new Map();
   ['flipboard', <FontAwesomeIcon icon={faFlipboard} aria-label="Flipboard" />],
   ['whatsapp', <FontAwesomeIcon icon={faWhatsapp} aria-label="WhatsApp" />],
   ['bluesky', <FontAwesomeIcon icon={faBluesky} aria-label="Bluesky" />],
-  ['tiktok', <FontAwesomeIcon icon={faTiktok} aria-label="TikTok" />]
+  ['tiktok', <FontAwesomeIcon icon={faTiktok} aria-label="TikTok" />],
+  ['youtube', <FontAwesomeIcon icon={faYoutube} aria-label="YouTube" />]
 ].forEach(([key, icon]) => {
   iconComponentMap.set(key, icon);
 });

--- a/lib/parse/menu/parseMenu.ts
+++ b/lib/parse/menu/parseMenu.ts
@@ -18,6 +18,8 @@ servicesMap.set('www.twitter.com', 'twitter');
 servicesMap.set('bsky.app', 'bluesky');
 servicesMap.set('tiktok.com', 'tiktok');
 servicesMap.set('www.tiktok.com', 'tiktok');
+servicesMap.set('youtube.com', 'youtube');
+servicesMap.set('www.youtube.com', 'youtube');
 
 function getServiceFromUrl(url?: Maybe<string>) {
   if (!url) return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,9 +4244,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001718"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz"
-  integrity sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==
+  version "1.0.30001726"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz"
+  integrity sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Lex requested we add the Youtube icon to their new page. I copied the patterns from #494 

- add `youtube` service detection to menu parser
- add icon for social links menu

## To Review

- [x] Checkout Branch.
- [x] Update your `.env` file to use API from lando site: `API_URL_BASE=https://api.theworld.org/` (I've added it to the WP live menu already)
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Open main nav and ensure link for YouTube is rendered with the appropriate logo icon.
