### PR TITLE
Add og:ttl tag + block a few Meta bots

### DIFF
--- a/components/OpenGraph/OpenGraph.tsx
+++ b/components/OpenGraph/OpenGraph.tsx
@@ -35,6 +35,11 @@ export const OpenGraph = ({ data }: IOpenGraphProps) => {
         content="The World from PRX"
         key="og:site_name"
       />
+      <meta
+        property="og:ttl"
+        content="86400"
+        key="og:ttl"
+      />
       {opengraphType && (
         <meta property="og:type" content={opengraphType} key="og:type" />
       )}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,3 +8,12 @@ Disallow: /license
 Disallow: /node
 Disallow: /taxonomy/term
 Disallow: /api
+
+User-agent: meta-externalagent/1.1
+Disallow: /
+
+User-agent: meta-externalfetcher/1.1
+Disallow: /
+
+User-agent: meta-externalads/1.1
+Disallow: /

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,9 +4244,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001726"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz"
-  integrity sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==
+  version "1.0.30001727"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz"
+  integrity sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
- block a couple of Meta bots, but not the one that allows for them to scrape OG data.
- Add og:ttl tag to slow down the Facebook scraper

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Confirm the og:ttl tag is set to 24 hours in seconds.
