### PR TITLE
507: add dataviz embed to html render

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
     "cflds",
     "clsx",
     "customsearch",
+    "Dataviz",
     "Datawrapper",
     "denormalize",
     "Denormalized",

--- a/components/DatavizEmbed/DatavizEmbed.tsx
+++ b/components/DatavizEmbed/DatavizEmbed.tsx
@@ -1,0 +1,60 @@
+/**
+ * @file DatavizEmbed.tsx
+ * Component for datawrapperEmbed elements.
+ */
+
+import type { DetailedHTMLProps, IframeHTMLAttributes } from 'react';
+import { useEffect, useState } from 'react';
+
+export interface IDatavizEmbedProps
+  extends DetailedHTMLProps<
+    IframeHTMLAttributes<HTMLIFrameElement>,
+    HTMLIFrameElement
+  > {
+  frameborder?: string;
+  class?: string;
+}
+
+export type TwDatavizMessageData = { tw: { dataviz: { height: number } } };
+
+export const DatavizEmbed = ({
+  title,
+  height,
+  frameborder,
+  style,
+  class: className,
+  ...iframeAttribs
+}: IDatavizEmbedProps) => {
+  const [iframeHeight, setIframeHeight] = useState(height);
+
+  function handleMessage(a: MessageEvent<TwDatavizMessageData>) {
+    if (typeof a.data.tw?.dataviz?.height !== 'undefined') {
+      const {
+        dataviz: { height: newHeight }
+      } = a.data.tw;
+      setIframeHeight(newHeight);
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, []);
+
+  return (
+    <iframe
+      title={title}
+      style={{
+        height: `${iframeHeight}px`,
+        width: 0,
+        minWidth: '100%',
+        border: 'none'
+      }}
+      className={className}
+      {...iframeAttribs}
+    />
+  );
+};

--- a/components/DatavizEmbed/DatavizEmbed.tsx
+++ b/components/DatavizEmbed/DatavizEmbed.tsx
@@ -15,7 +15,10 @@ export interface IDatavizEmbedProps
   class?: string;
 }
 
-export type TwDatavizMessageData = { tw: { dataviz: { height: number } } };
+export type TwDatavizMessageData = {
+  type: 'TwDatavizUpdateHeight';
+  payload: number;
+};
 
 export const DatavizEmbed = ({
   title,
@@ -27,12 +30,10 @@ export const DatavizEmbed = ({
 }: IDatavizEmbedProps) => {
   const [iframeHeight, setIframeHeight] = useState(height);
 
-  function handleMessage(a: MessageEvent<TwDatavizMessageData>) {
-    if (typeof a.data.tw?.dataviz?.height !== 'undefined') {
-      const {
-        dataviz: { height: newHeight }
-      } = a.data.tw;
-      setIframeHeight(newHeight);
+  function handleMessage(event: MessageEvent<TwDatavizMessageData>) {
+    console.log(event);
+    if (event.data.type === 'TwDatavizUpdateHeight' && event.data.payload) {
+      setIframeHeight(event.data.payload);
     }
   }
 

--- a/components/DatavizEmbed/index.ts
+++ b/components/DatavizEmbed/index.ts
@@ -1,0 +1,1 @@
+export * from './DatavizEmbed';

--- a/components/HtmlContent/transforms/datavizEmbed.tsx
+++ b/components/HtmlContent/transforms/datavizEmbed.tsx
@@ -1,0 +1,51 @@
+/**
+ * @file datavizEmbed.tsx
+ *
+ * Converts a Dataviz iframe embed to a DatavizEmbed component.
+ */
+
+import type { DomElement } from 'htmlparser2';
+import { findDescendant } from '@lib/parse/html';
+import { Box } from '@mui/material';
+import { DatavizEmbed } from '@components/DatavizEmbed';
+
+export const datawrapperEmbed = (node: DomElement) => {
+  const isFigureNode = node.type === 'tag' && node.name === 'figure';
+  const isEmbedWrapper =
+    node.type === 'tag' && node.attribs.class?.includes('embed__wrapper');
+  const isIframeNode = node.type === 'tag' && node.name === 'iframe';
+
+  // Render legacy markup.
+  if (!isFigureNode && !isEmbedWrapper && !isIframeNode) {
+    const dwEmbedIframe = findDescendant(node, (n: DomElement) => {
+      if (
+        n.type === 'tag' &&
+        n.name === 'iframe' &&
+        n.attribs.src?.includes('interactive.pri.org')
+      ) {
+        return n;
+      }
+      return false;
+    });
+
+    if (dwEmbedIframe) {
+      // Return DatavizEmbed wrapped in basic wrapper.
+      const { attribs } = dwEmbedIframe;
+
+      return (
+        <Box sx={{ my: 6 }}>
+          <DatavizEmbed {...attribs} />
+        </Box>
+      );
+    }
+  }
+
+  // Render Iframe in WordPress generated markup.
+  if (isIframeNode && node.attribs.src?.includes('interactive.pri.org')) {
+    const { attribs } = node;
+
+    return <DatavizEmbed {...attribs} />;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
Closes #507 

- Add DatavizEmbed component
- Add datavizEmebd transform to HtmlContent component

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] [Add more review steps...]
