### PR TITLE
497: Add publish date relative cache headers to episodes, segments, and stories

### DIFF
--- a/lib/math/time/getDateAgeInSeconds.spec.ts
+++ b/lib/math/time/getDateAgeInSeconds.spec.ts
@@ -1,0 +1,19 @@
+import getDateAgeInSeconds from './getDateAgeInSeconds';
+
+describe('lib/math/time', () => {
+  describe('getDateAgeInSeconds', () => {
+    test('should return age in seconds', () => {
+      const date = new Date();
+
+      date.setSeconds(date.getSeconds() - 10);
+
+      const result1 = getDateAgeInSeconds(date);
+      const result2 = getDateAgeInSeconds(date.getTime());
+      const result3 = getDateAgeInSeconds(date.toString());
+
+      expect(result1).toBe(10);
+      expect(result2).toBe(10);
+      expect(result3).toBe(10);
+    });
+  });
+});

--- a/lib/math/time/getDateAgeInSeconds.ts
+++ b/lib/math/time/getDateAgeInSeconds.ts
@@ -1,0 +1,8 @@
+/**
+ * Get number of seconds of a date from now.
+ */
+
+const getDateAgeInSeconds = (date: string | number | Date) =>
+  Math.floor((new Date().getTime() - new Date(date).getTime()) / 1000);
+
+export default getDateAgeInSeconds;

--- a/pages/episodes/[year]/[month]/[day]/[slug].tsx
+++ b/pages/episodes/[year]/[month]/[day]/[slug].tsx
@@ -10,6 +10,7 @@ import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
 import { fetchEpisodeData } from '@store/actions/fetchEpisodeData';
 import { generateShareLinks } from '@lib/generate/social';
+import getDateAgeInSeconds from '@lib/math/time/getDateAgeInSeconds';
 
 const EpisodePage = ({ data }: IContentComponentProxyProps) => (
   <Episode data={data} />
@@ -18,7 +19,7 @@ const EpisodePage = ({ data }: IContentComponentProxyProps) => (
 export const getServerSideProps =
   wrapper.getServerSideProps<IContentComponentProxyProps>(
     (store) =>
-      async ({ req, params }) => {
+      async ({ res, req, params }) => {
         const slug =
           params?.slug &&
           (typeof params.slug === 'string' ? params.slug : params.slug[0]);
@@ -30,9 +31,25 @@ export const getServerSideProps =
           ]);
 
           if (data) {
-            const { link, title } = data;
+            const { link, title, date } = data;
             const shareLinks =
               link != null ? generateShareLinks(link, title) : undefined;
+
+            if (date) {
+              const ageInSeconds = getDateAgeInSeconds(date);
+              const maxAge =
+                ageInSeconds > 60 * 60 * 24 * 7 ? ageInSeconds : 60 * 60; // Cache for 1 hour for the first week.
+
+              if (process.env.NODE_ENV !== 'production') {
+                // eslint-disable-next-line no-console
+                console.log('Cache-Control s-maxage:', maxAge);
+              }
+
+              res.setHeader(
+                'Cache-Control',
+                `public, s-maxage=${maxAge} state-while-revalidate=3600`
+              );
+            }
 
             return {
               props: {

--- a/pages/segments/[year]/[month]/[day]/[slug].tsx
+++ b/pages/segments/[year]/[month]/[day]/[slug].tsx
@@ -10,6 +10,7 @@ import { wrapper } from '@store/configureStore';
 import { fetchAppData } from '@store/actions/fetchAppData';
 import { fetchSegmentData } from '@store/actions/fetchSegmentData';
 import { generateShareLinks } from '@lib/generate/social';
+import getDateAgeInSeconds from '@lib/math/time/getDateAgeInSeconds';
 
 const SegmentPage = ({ data }: IContentComponentProxyProps) => (
   <Segment data={data} />
@@ -18,7 +19,7 @@ const SegmentPage = ({ data }: IContentComponentProxyProps) => (
 export const getServerSideProps =
   wrapper.getServerSideProps<IContentComponentProxyProps>(
     (store) =>
-      async ({ req, params }) => {
+      async ({ res, req, params }) => {
         const slug =
           params?.slug &&
           (typeof params.slug === 'string' ? params.slug : params.slug[0]);
@@ -30,9 +31,25 @@ export const getServerSideProps =
           ]);
 
           if (data) {
-            const { link, title } = data;
+            const { link, title, date } = data;
             const shareLinks =
               link != null ? generateShareLinks(link, title) : undefined;
+
+            if (date) {
+              const ageInSeconds = getDateAgeInSeconds(date);
+              const maxAge =
+                ageInSeconds > 60 * 60 * 24 * 7 ? ageInSeconds : 60 * 60; // Cache for 1 hour for the first week.
+
+              if (process.env.NODE_ENV !== 'production') {
+                // eslint-disable-next-line no-console
+                console.log('Cache-Control s-maxage:', maxAge);
+              }
+
+              res.setHeader(
+                'Cache-Control',
+                `public, s-maxage=${maxAge} state-while-revalidate=3600`
+              );
+            }
 
             return {
               props: {

--- a/pages/stories/[year]/[month]/[day]/[slug].tsx
+++ b/pages/stories/[year]/[month]/[day]/[slug].tsx
@@ -10,6 +10,7 @@ import { fetchAppData } from '@store/actions/fetchAppData';
 import { wrapper } from '@store/configureStore';
 import { fetchStoryData } from '@store/actions/fetchStoryData';
 import { generateShareLinks } from '@lib/generate/social';
+import getDateAgeInSeconds from '@lib/math/time/getDateAgeInSeconds';
 
 const StoryPage = ({ data }: IContentComponentProxyProps) => (
   <Story data={data} />
@@ -18,7 +19,7 @@ const StoryPage = ({ data }: IContentComponentProxyProps) => (
 export const getServerSideProps =
   wrapper.getServerSideProps<IContentComponentProxyProps>(
     (store) =>
-      async ({ req, params }) => {
+      async ({ res, req, params }) => {
         const slug =
           params?.slug &&
           (typeof params.slug === 'string' ? params.slug : params.slug[0]);
@@ -30,9 +31,25 @@ export const getServerSideProps =
           ]);
 
           if (data) {
-            const { link, title } = data;
+            const { link, title, date } = data;
             const shareLinks =
               link != null ? generateShareLinks(link, title) : undefined;
+
+            if (date) {
+              const ageInSeconds = getDateAgeInSeconds(date);
+              const maxAge =
+                ageInSeconds > 60 * 60 * 24 * 7 ? ageInSeconds : 60 * 60; // Cache for 1 hour for the first week.
+
+              if (process.env.NODE_ENV !== 'production') {
+                // eslint-disable-next-line no-console
+                console.log('Cache-Control s-maxage:', maxAge);
+              }
+
+              res.setHeader(
+                'Cache-Control',
+                `public, s-maxage=${maxAge} state-while-revalidate=3600`
+              );
+            }
 
             return {
               props: {


### PR DESCRIPTION
Closes #497 

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Visit a story, episode, and segment.
- [x] Ensure terminal logs a "Cache-Control s-maxage".
- [x] Ensure the max age is 3600 for content published less than a week ago.
- [x] Ensure content publish over a week ago has a specific max age equal to the difference between now and the publish date.
