### PR TITLE
fix(images): set quality to 85% for header and content images

### DIFF
--- a/components/HtmlContent/transforms/enhanceImage.tsx
+++ b/components/HtmlContent/transforms/enhanceImage.tsx
@@ -54,6 +54,7 @@ export const enhanceImage =
             width={width || 16}
             height={height || 9}
             sizes={sizes}
+            quality={85}
           />
         </div>
       ) : (
@@ -65,6 +66,7 @@ export const enhanceImage =
           height={height || 9}
           sizes={sizes}
           key={key}
+          quality={85}
         />
       );
     }

--- a/components/LandingPageHeader/LandingPageHeader.tsx
+++ b/components/LandingPageHeader/LandingPageHeader.tsx
@@ -40,6 +40,7 @@ export const LandingPageHeader = ({
             layout="fill"
             objectFit="cover"
             priority
+            quality={85}
           />
         )}
         <Box className={classes.content}>

--- a/components/LedeImage/LedeImage.tsx
+++ b/components/LedeImage/LedeImage.tsx
@@ -52,6 +52,7 @@ export const LedeImage = ({ data }: ILedeImageProps) => {
         height={height}
         layout="responsive"
         sizes={sizes}
+        quality={85}
         priority
         alt={altText || ''}
         objectFit="cover"

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -82,6 +82,7 @@ export const StoryHeader = ({ data }: Props) => {
               layout="fill"
               objectFit="cover"
               priority
+              quality={85}
             />
           </Box>
         )}


### PR DESCRIPTION
## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev:start`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] View a story and inspect header and content images.
- [ ] Ensure image URL's include `q=85` parameter.
