### PR TITLE
506: Story headers render broadcast date when set

### DIFF
--- a/components/pages/Episode/components/EpisodeHeader/EpisodeHeader.tsx
+++ b/components/pages/Episode/components/EpisodeHeader/EpisodeHeader.tsx
@@ -30,6 +30,7 @@ export const EpisodeHeader = ({ data }: Props) => {
     data;
   const { broadcastDate } = episodeDates as EpisodeEpisodeDates;
   const { audio } = episodeAudio as EpisodeEpisodeAudio;
+  const publishedDate = broadcastDate || date;
   const audioProps = {
     title,
     queuedFrom: 'Page Header Controls',
@@ -54,15 +55,17 @@ export const EpisodeHeader = ({ data }: Props) => {
               {program.name}
             </ContentLink>
           )}
-          <DateTime
-            className={classes.date}
-            date={broadcastDate || date}
-            options={{
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            }}
-          />
+          {publishedDate && (
+            <DateTime
+              className={classes.date}
+              date={publishedDate}
+              options={{
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric'
+              }}
+            />
+          )}
         </Box>
         {audio && (
           <Box className={classes.audio}>

--- a/components/pages/Segment/components/SegmentHeader/SegmentHeader.tsx
+++ b/components/pages/Segment/components/SegmentHeader/SegmentHeader.tsx
@@ -86,14 +86,16 @@ export const AudioHeader = ({ data }: Props) => {
                   {program.name}
                 </ContentLink>
               )}
-              <DateTime
-                date={broadcastDate}
-                options={{
-                  month: 'long',
-                  day: 'numeric',
-                  year: 'numeric'
-                }}
-              />
+              {broadcastDate && (
+                <DateTime
+                  date={broadcastDate}
+                  options={{
+                    month: 'long',
+                    day: 'numeric',
+                    year: 'numeric'
+                  }}
+                />
+              )}
               {!!contributors?.nodes.length && (
                 <ul className={classes.byline}>
                   {contributors.nodes.map(

--- a/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
+++ b/components/pages/Story/layouts/default/components/StoryHeader/StoryHeader.default.tsx
@@ -37,7 +37,8 @@ export const StoryHeader = ({ data }: Props) => {
     contributors
   } = data;
   const { audio } = additionalMedia as PostAdditionalMedia;
-  const { updatedDate } = additionalDates as PostAdditionalDates;
+  const { broadcastDate, updatedDate } = additionalDates as PostAdditionalDates;
+  const publishedDate = broadcastDate || date;
   const program = programs?.nodes[0];
   const bylines: [string, Contributor[]][] = [];
   const audioProps = {
@@ -75,14 +76,14 @@ export const StoryHeader = ({ data }: Props) => {
               {program.name}
             </ContentLink>
           )}
-          {date && (
+          {publishedDate && (
             <Typography
               variant="subtitle1"
               component="div"
               className={classes.date}
             >
               <DateTime
-                date={date}
+                date={publishedDate}
                 options={{
                   month: 'long',
                   day: 'numeric',

--- a/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
+++ b/components/pages/Story/layouts/feature/components/StoryHeader/StoryHeader.feature.tsx
@@ -46,7 +46,8 @@ export const StoryHeader = ({ data }: Props) => {
     contributors
   } = data;
   const { audio } = additionalMedia as PostAdditionalMedia;
-  const { updatedDate } = additionalDates as PostAdditionalDates;
+  const { broadcastDate, updatedDate } = additionalDates as PostAdditionalDates;
+  const publishedDate = broadcastDate || date;
   const image = featuredImage?.node;
   const program = programs?.nodes[0];
   const bylines: [string, Contributor[]][] = [];
@@ -116,14 +117,14 @@ export const StoryHeader = ({ data }: Props) => {
                     {program.name}
                   </ContentLink>
                 )}
-                {date && (
+                {publishedDate && (
                   <Typography
                     variant="subtitle1"
                     component="div"
                     className={classes.date}
                   >
                     <DateTime
-                      date={date}
+                      date={publishedDate}
                       options={{
                         month: 'long',
                         day: 'numeric',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,9 +4244,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001737"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz"
-  integrity sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==
+  version "1.0.30001739"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz"
+  integrity sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Closes #506 

- Story pages render broadcast date when set.
- Update date render logic of all content page headers to be consistent.

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Go to a story with a broadcast date set.
- [ ] Ensure that date is displayed on both standard and feature layouts.
