### PR TITLE
uncapitalize headlines

### DIFF
--- a/src/app/(main)/@hero/contributors/page.tsx
+++ b/src/app/(main)/@hero/contributors/page.tsx
@@ -16,7 +16,7 @@ export default async function ContributorsHero() {
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">
-        <h1 className="flex gap-4 items-center capitalize text-3xl md:text-4xl font-bold text-balance">
+        <h1 className="flex gap-4 items-center text-3xl md:text-4xl font-bold text-balance">
           <UsersIcon className="size-9" />
           <span>Content By Contributor</span>
         </h1>

--- a/src/app/(main)/@hero/episodes/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(main)/@hero/episodes/[year]/[month]/[day]/[slug]/page.tsx
@@ -32,7 +32,7 @@ export default async function EpisodeHero({
 
   return (
     <HeroHeader image={featuredImage?.node}>
-      <h1 className="capitalize text-3xl md:text-4xl font-bold text-balance">
+      <h1 className="text-3xl md:text-4xl font-bold text-balance">
         {title}
       </h1>
       <div className="flex gap-x-4 text-md/snug">

--- a/src/app/(main)/@hero/programs/page.tsx
+++ b/src/app/(main)/@hero/programs/page.tsx
@@ -16,7 +16,7 @@ export default async function ProgramsHero() {
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">
-        <h1 className="flex gap-4 items-center capitalize text-3xl md:text-4xl font-bold text-balance">
+        <h1 className="flex gap-4 items-center text-3xl md:text-4xl font-bold text-balance">
           <MicIcon className="size-9" />
           <span>Content By Program</span>
         </h1>

--- a/src/app/(main)/@hero/segments/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(main)/@hero/segments/[year]/[month]/[day]/[slug]/page.tsx
@@ -33,7 +33,7 @@ export default async function SegmentHero({
 
   return (
     <HeroHeader image={featuredImage?.node}>
-      <h1 className="capitalize text-3xl md:text-4xl font-bold text-balance">
+      <h1 className="text-3xl md:text-4xl font-bold text-balance">
         {title}
       </h1>
       <div className="flex gap-x-4 text-md/snug">

--- a/src/app/(main)/@hero/stories/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(main)/@hero/stories/[year]/[month]/[day]/[slug]/page.tsx
@@ -51,7 +51,7 @@ export default async function StoryHero({
 
   return (
     <HeroHeader image={image}>
-      <h1 className="capitalize text-3xl md:text-4xl font-bold text-balance">
+      <h1 className="text-3xl md:text-4xl font-bold text-balance">
         {title}
       </h1>
       <div className="flex @max-xl/hero-content:flex-wrap content-start gap-x-12 gap-y-2">

--- a/src/app/(main)/@hero/tags/people/page.tsx
+++ b/src/app/(main)/@hero/tags/people/page.tsx
@@ -16,7 +16,7 @@ export default async function PeopleHero() {
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">
-        <h1 className="flex gap-4 items-center capitalize text-3xl md:text-4xl font-bold text-balance">
+        <h1 className="flex gap-4 items-center text-3xl md:text-4xl font-bold text-balance">
           <UserIcon className="size-9" />
           <span>Content By Person</span>
         </h1>

--- a/src/app/(main)/@hero/tags/social_tags/page.tsx
+++ b/src/app/(main)/@hero/tags/social_tags/page.tsx
@@ -16,7 +16,7 @@ export default async function SocialTagsHero() {
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">
-        <h1 className="flex gap-4 items-center capitalize text-3xl md:text-4xl font-bold text-balance">
+        <h1 className="flex gap-4 items-center text-3xl md:text-4xl font-bold text-balance">
           <HashIcon className="size-9" />
           <span>Content By Social Tag</span>
         </h1>


### PR DESCRIPTION
Closes #548 

- uncapitalize headlines, but leaves it in other cases where it makes sense (terms)

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Visit a story page and ensure the headline isn't capitalizing every word
- [ ] Visit an episode page and ensure the headline isn't capitalizing every word