### PR TITLE
541: episode browser start date

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Configure Node to use the timezone the app expects from the API host region.
+# Keeps React from complaining about markup diffs when rendering dates on the server.
+TZ=America/New_York
+
+### Application Config ###
+APP_DOMAIN=theworld.org
+
+### API Config ###
+## Use `http://the-world-wp.lndo.site` to develop with local WordPress API.
+API_URL_BASE=https://live-the-world.pantheonsite.io
+
+### API Endpoints ###
+WP_REST_ENDPOINT=wp-json
+WP_GRAPHQL_ENDPOINT=graphql
+
+### Newsletter Subscriptions ###
+
+### Default Campaign Cmonitor API Key ###
+CM_API_KEY=GET_KEY_FROM_CAMPAIGN_MONITOR_ACCOUNT_INFO
+
+### Additional Campaing Monitor client API keys ###
+## Replace `[CLIENT_KEY]` with the client id key found in the client dashboard URL.
+# CM_API_KEY_[CLIENT_KEY]=GET_KEY_FROM_CAMPAIGN_MONITOR_CLIENT_INFO
+
+### Facebook ###
+# FB_ACCESS_TOKEN=
+# FB_ADMINS=
+# FB_APP_ID=
+
+### Twitter ###
+# TWITTER_ACCOUNT_ID=

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,13 +4,9 @@ Closes #[ISSUE_ID]
 
 ## To Review
 
-- [ ] Use the Preview link located in the Now comment below.
-
-> ...or...
-
 - [ ] Checkout Branch.
 - [ ] Run `yarn`.
-- [ ] Run `yarn dev:start`.
+- [ ] Run `yarn dev`.
 - [ ] Go to [localhost:3000](https://localhost:3000).
 
 > ...then...

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -81,7 +81,7 @@ export async function register() {
     transport: [
       new PinoTransport({
         logger: pino({
-          ...(deploymentEnv !== "production" && {
+          ...(deploymentEnv === "development" && {
             transport: {
               target: "pino-pretty",
               options: {

--- a/next.redirects.ts
+++ b/next.redirects.ts
@@ -39,11 +39,6 @@ export const redirects: NextConfig["redirects"] = async () => {
 
     /* External Redirects */
     {
-      source: "/(give|donate/pris-world)",
-      destination: "https://give.prx.org/campaign/793401/donate",
-      permanent: false,
-    },
-    {
       source: "/rss/glohit.xml",
       destination: "https://feeds.theworld.org/categories/global-hit/feed",
       permanent: true,

--- a/src/app/(main)/@browser/episodes/[year]/[month]/[day]/[slug]/_components/EpisodeBrowserUI.tsx
+++ b/src/app/(main)/@browser/episodes/[year]/[month]/[day]/[slug]/_components/EpisodeBrowserUI.tsx
@@ -81,7 +81,7 @@ export default function EpisodeBrowserUI({
     mode: "single",
     showOutsideDays: false,
     captionLayout: "dropdown",
-    startMonth: new Date(2010, 0),
+    startMonth: new Date(2012, 8),
     month: selectedMonth,
     endMonth: today,
     disabled: (d: Date) => !episodes?.has(d.toDateString()),

--- a/src/app/(main)/_components/MainUI/MainUI.tsx
+++ b/src/app/(main)/_components/MainUI/MainUI.tsx
@@ -204,6 +204,13 @@ export default function MainUI({
     window.scrollTo(0, 0);
   }, [pathname]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Scroll to top when route changes.
+  useEffect(() => {
+    if (!isDesktopLayout) {
+      setIsMenuOpen(false);
+    }
+  }, [pathname, isDesktopLayout]);
+
   return (
     <MainUIContext.Provider
       value={{

--- a/src/lib/parse/url/sanitizeUrl.ts
+++ b/src/lib/parse/url/sanitizeUrl.ts
@@ -8,7 +8,7 @@ import { unescape as lodashUnescape } from "lodash";
 export const sanitizeUrl = (url: string) =>
   [
     // Extract URL from between quotes or appended weirdly to another string.
-    (u: string) => /(?<=^.*)https?:\/\/[\w/._\-?&=%\s]+/i.exec(u)?.[0] || u,
+    (u: string) => /(?<=^.*)https?:\/\/[\w/._\-?&=%:\s]+/i.exec(u)?.[0] || u,
     // Ensure relative protocol URL's have a protocol.
     (u: string) => (u.startsWith("//") ? `https:${u}` : u),
     // Bad links to base 64 encoded image.


### PR DESCRIPTION
### REVIEW AFTER #554 IS MERGED

Closes #541

- limits episode browser calendar to dates on or after Sept 2012
- removes `/give` redirect so `[...alias]` route can get redirect from WordPress

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Visit any episode.
- [x] Open menu.
- [x] Ensure Sept 2012 is the earliest date that can be selected.
- [x] Got to https://localhost:3000/give
- [x] Ensure you are redirected to new donation form (https://give.prx.org/campaign/804766/donate)
