### PR TITLE
2026 Fundraiser: Switch donate buttons to links

### DIFF
--- a/next.redirects.ts
+++ b/next.redirects.ts
@@ -39,6 +39,11 @@ export const redirects: NextConfig["redirects"] = async () => {
 
     /* External Redirects */
     {
+      source: "/(give|donate/pris-world)",
+      destination: "https://give.prx.org/campaign/804766/donate",
+      permanent: false,
+    },
+    {
       source: "/rss/glohit.xml",
       destination: "https://feeds.theworld.org/categories/global-hit/feed",
       permanent: true,

--- a/src/app/(main)/_components/MainUI/MainUI.tsx
+++ b/src/app/(main)/_components/MainUI/MainUI.tsx
@@ -16,7 +16,7 @@ import Logo from "../Logo/Logo";
 import "./MainUI.css";
 import { useBreakpoint } from "@react-awesome/use-breakpoint";
 import { usePathname } from "next/navigation";
-import DonateModalLink from "@/components/Donate/DonateModalLink";
+// import DonateModalLink from "@/components/Donate/DonateModalLink";
 import CcnLogo from "@/assets/svg/logos/CCN-Logo.svg";
 import GbhLogo from "@/assets/svg/logos/GBH-Logo.svg";
 import ProgressiveLogo from "@/assets/svg/logos/Progressive-Logo.svg";
@@ -281,7 +281,15 @@ export default function MainUI({
             </h1>
             <span className="basis-xl">{search}</span>
             <span>
-              <DonateModalLink
+              <Button variant="action" asChild>
+                <Link href="https://give.prx.org/campaign/804766/donate?c_src=Referal&c_src2=website-donate-heart">
+                  <HeartHandshakeIcon aria-label="Donate" />
+                  <span className="hidden md:inline" aria-hidden>
+                    Donate
+                  </span>
+                </Link>
+              </Button>
+              {/* <DonateModalLink
                 campaign="727547"
                 size="lg"
                 variant="action"
@@ -294,7 +302,7 @@ export default function MainUI({
                 <span className="hidden md:inline" aria-hidden>
                   Donate
                 </span>
-              </DonateModalLink>
+              </DonateModalLink> */}
             </span>
           </div>
         </div>

--- a/src/app/(main)/_components/MainUI/MainUIMenu.tsx
+++ b/src/app/(main)/_components/MainUI/MainUIMenu.tsx
@@ -33,7 +33,7 @@ import TwitterXIcon from "@/assets/svg/icons/brands/twitter.svg";
 import TikTokIcon from "@/assets/svg/icons/brands/tiktok.svg";
 import YoutubeIcon from "@/assets/svg/icons/brands/youtube.svg";
 import MainUIContext from "../../_contexts/MainUIContext";
-import DonateModalLink from "@/components/Donate/DonateModalLink";
+// import DonateModalLink from "@/components/Donate/DonateModalLink";
 import LogoGlobe from "../Logo/LogoGlobe";
 import { usePathname } from "next/navigation";
 
@@ -109,7 +109,11 @@ export default function MainUIMenu() {
 
         <NavigationMenuItem>
           <NavigationMenuLink asChild>
-            <DonateModalLink
+            <Link href="https://give.prx.org/campaign/804766/donate?c_src=Referal&c_src2=website-menu-hamburger">
+              <HeartHandshakeIcon />
+              <NavigationMenuLabel>Donate</NavigationMenuLabel>
+            </Link>
+            {/* <DonateModalLink
               variant="unstyled"
               campaign="727547"
               queryParams={{
@@ -119,7 +123,7 @@ export default function MainUIMenu() {
             >
               <HeartHandshakeIcon />
               <NavigationMenuLabel>Donate</NavigationMenuLabel>
-            </DonateModalLink>
+            </DonateModalLink> */}
           </NavigationMenuLink>
         </NavigationMenuItem>
       </NavigationMenuList>


### PR DESCRIPTION
DO NOT MERGE TILL FRIDAY AFTERNOON!!

- Switches donate buttons to links to fundraiser form.
- TODO: Revert after fundraiser ends

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Donate buttons in menu and header should link to fundraiser form instead of opening the modal.
