### PR TITLE
545: Fix janky carousels on mobile

### DIFF
--- a/src/app/(main)/@hero/categories/page.tsx
+++ b/src/app/(main)/@hero/categories/page.tsx
@@ -8,11 +8,11 @@ export default async function ContributorsHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/@hero/contributors/page.tsx
+++ b/src/app/(main)/@hero/contributors/page.tsx
@@ -8,11 +8,11 @@ export default async function ContributorsHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/@hero/programs/page.tsx
+++ b/src/app/(main)/@hero/programs/page.tsx
@@ -8,11 +8,11 @@ export default async function ProgramsHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/@hero/tags/cities/page.tsx
+++ b/src/app/(main)/@hero/tags/cities/page.tsx
@@ -8,11 +8,11 @@ export default async function CountriesHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/@hero/tags/continents/page.tsx
+++ b/src/app/(main)/@hero/tags/continents/page.tsx
@@ -8,11 +8,11 @@ export default async function ContinentsHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/@hero/tags/countries/page.tsx
+++ b/src/app/(main)/@hero/tags/countries/page.tsx
@@ -8,11 +8,11 @@ export default async function CountriesHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/@hero/tags/page.tsx
+++ b/src/app/(main)/@hero/tags/page.tsx
@@ -8,11 +8,11 @@ export default async function TagsHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/@hero/tags/people/page.tsx
+++ b/src/app/(main)/@hero/tags/people/page.tsx
@@ -8,11 +8,11 @@ export default async function PeopleHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/@hero/tags/provinces_or_states/page.tsx
+++ b/src/app/(main)/@hero/tags/provinces_or_states/page.tsx
@@ -8,11 +8,11 @@ export default async function ProvincesOrStatesHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/@hero/tags/regions/page.tsx
+++ b/src/app/(main)/@hero/tags/regions/page.tsx
@@ -8,11 +8,11 @@ export default async function RegionsHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/@hero/tags/social_tags/page.tsx
+++ b/src/app/(main)/@hero/tags/social_tags/page.tsx
@@ -8,11 +8,11 @@ export default async function SocialTagsHero() {
     <HeroHeader
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
-      className="pl-(--_gutter-left)"
+      className="pl-2 snap-always snap-start md:pl-(--_gutter-left)"
       classes={{ content: "max-w-none mx-0 md:px-4" }}
     >
       <div className="grid gap-y-4 max-w-3xl text-pretty">

--- a/src/app/(main)/_components/CtaRegion/_components/NewsletterCta.tsx
+++ b/src/app/(main)/_components/CtaRegion/_components/NewsletterCta.tsx
@@ -66,7 +66,6 @@ export default function NewsletterCta({
               }
             })
             .catch((reason) => {
-              console.log("CATCH CALLBACK", reason);
               return reason;
             })
             .finally(() => {
@@ -82,8 +81,6 @@ export default function NewsletterCta({
           duration: 10000,
         }),
         error: (reason) => {
-          console.log("ERROR CALLBACK", reason);
-
           if (typeof reason === "string") return { message: reason };
 
           const { error } = reason;

--- a/src/app/(main)/_components/Explorer/ExplorerDateFilter.tsx
+++ b/src/app/(main)/_components/Explorer/ExplorerDateFilter.tsx
@@ -66,8 +66,6 @@ export function ExplorerDateFilter({
         newSearchParams.delete("sf");
       }
 
-      console.log(newSearchFilters);
-
       router.push(`${pathname}?${newSearchParams.toString()}`, {
         scroll: true,
       });

--- a/src/app/(main)/_components/HeroEpisodesCarousel/HeroEpisodesCarousel.tsx
+++ b/src/app/(main)/_components/HeroEpisodesCarousel/HeroEpisodesCarousel.tsx
@@ -103,7 +103,7 @@ export default function HeroEpisodesCarousel({
           className={cn(
             "grid grid-cols-[min-content_1fr] items-end p-4 pr-0",
             "md:pl-(--_gutter-left) md:mask-[linear-gradient(90deg,transparent_calc(var(--_menu-width)/1.5),black_var(--_gutter-left))] lg:mask-none",
-            "max-lg:overflow-hidden max-lg:overflow-x-auto max-lg:gap-4 max-lg:snap-mandatory max-lg:snap-x max-lg:scroll-pl-(--_gutter-left) max-sm:scroll-pl-4 no-scrollbar",
+            "max-lg:overflow-x-auto max-lg:gap-4 max-lg:snap-mandatory max-lg:snap-x max-lg:scroll-pl-(--_gutter-left) max-sm:scroll-pl-4 no-scrollbar",
           )}
         >
           {/* Full Episode Card */}
@@ -177,11 +177,11 @@ export default function HeroEpisodesCarousel({
           {!!segmentsList?.nodes?.length && (
             <div
               className={cn(
-                "grid grid-cols-[0_1fr] align-items-start gap-y-2 -mb-1",
+                "grid grid-cols-[0_max-content] align-items-start gap-y-2 w-fit -mb-1",
                 "lg:overflow-hidden lg:grid-cols-[--spacing(8)_1fr] lg:mask-[linear-gradient(90deg,transparent_--spacing(2),black_--spacing(8))]",
               )}
             >
-              <h2 className="col-start-2 sticky left-4 self-start text-cyan font-serif font-bold italic uppercase ml-2">
+              <h2 className="col-start-2 sticky left-4 justify-self-start text-cyan font-serif font-bold italic uppercase ml-2">
                 In This Episode&hellip;
               </h2>
               <AnimatePresence mode="popLayout">
@@ -216,7 +216,7 @@ export default function HeroEpisodesCarousel({
                       slidesToScroll: 1,
                       skipSnaps: true,
                       breakpoints: {
-                        "(min-width: 1024px, pointer: fine)": {
+                        "(min-width: 1024px) and (pointer: fine)": {
                           active: true,
                         },
                       },
@@ -224,7 +224,8 @@ export default function HeroEpisodesCarousel({
                     plugins={[WheelGestures()]}
                     key={episodeId}
                     className={cn(
-                      "**:data-[slot=carousel-content]:max-lg:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x **:data-[slot=carousel-content]:scroll-pl-8",
+                      "**:data-[slot=carousel-content]:overflow-visible",
+                      "**:data-[slot=carousel-content]:lg:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:lg:pointer-coarse:snap-proximity **:data-[slot=carousel-content]:lg:pointer-coarse:snap-x **:data-[slot=carousel-content]:lg:pointer-coarse:scroll-pl-8",
                     )}
                   >
                     <CarouselPrevious className="rounded-s-sm pointer-coarse:hidden" />
@@ -261,7 +262,7 @@ export default function HeroEpisodesCarousel({
                         return (
                           <CarouselItem
                             className={cn(
-                              "basis-[calc(min(280px,80dvw))] grid snap-always snap-start",
+                              "basis-[calc(min(280px,80dvw))] grid snap-always snap-center lg:snap-start",
                               "first:lg:ml-8",
                             )}
                             key={id}

--- a/src/app/(main)/_components/HeroEpisodesCarousel/HeroEpisodesCarousel.tsx
+++ b/src/app/(main)/_components/HeroEpisodesCarousel/HeroEpisodesCarousel.tsx
@@ -101,7 +101,7 @@ export default function HeroEpisodesCarousel({
         <div
           ref={scrollWrapper}
           className={cn(
-            "grid grid-cols-[min-content_1fr] items-end gap-8 p-4 pr-0",
+            "grid grid-cols-[min-content_1fr] items-end p-4 pr-0",
             "md:pl-(--_gutter-left) md:mask-[linear-gradient(90deg,transparent_calc(var(--_menu-width)/1.5),black_var(--_gutter-left))] lg:mask-none",
             "max-lg:overflow-hidden max-lg:overflow-x-auto max-lg:gap-4 max-lg:snap-mandatory max-lg:snap-x max-lg:scroll-pl-(--_gutter-left) max-sm:scroll-pl-4 no-scrollbar",
           )}
@@ -177,16 +177,17 @@ export default function HeroEpisodesCarousel({
           {!!segmentsList?.nodes?.length && (
             <div
               className={cn(
-                "flex flex-col align-items-start gap-y-2 -mb-1",
-                "lg:overflow-hidden",
+                "grid grid-cols-[0_1fr] align-items-start gap-y-2 -mb-1",
+                "lg:overflow-hidden lg:grid-cols-[--spacing(8)_1fr] lg:mask-[linear-gradient(90deg,transparent_--spacing(2),black_--spacing(8))]",
               )}
             >
-              <h2 className="sticky left-4 self-start text-cyan font-serif font-bold italic uppercase ml-2">
+              <h2 className="col-start-2 sticky left-4 self-start text-cyan font-serif font-bold italic uppercase ml-2">
                 In This Episode&hellip;
               </h2>
               <AnimatePresence mode="popLayout">
                 <motion.div
                   key={episodeId}
+                  className="row-start-2 col-span-2"
                   variants={{
                     hidden: {
                       opacity: 0,
@@ -215,15 +216,19 @@ export default function HeroEpisodesCarousel({
                       slidesToScroll: 1,
                       skipSnaps: true,
                       breakpoints: {
-                        "(min-width: 1024px)": { active: true },
+                        "(min-width: 1024px, pointer: fine)": {
+                          active: true,
+                        },
                       },
                     }}
                     plugins={[WheelGestures()]}
                     key={episodeId}
-                    className="max-lg:**:data-[slot=carousel-content]:overflow-visible"
+                    className={cn(
+                      "**:data-[slot=carousel-content]:max-lg:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x **:data-[slot=carousel-content]:scroll-pl-8",
+                    )}
                   >
-                    <CarouselPrevious className="rounded-s-sm" />
-                    <CarouselContent className="">
+                    <CarouselPrevious className="rounded-s-sm pointer-coarse:hidden" />
+                    <CarouselContent>
                       {(segmentsList.nodes as Segment[]).map((segment) => {
                         if (!segment) return null;
 
@@ -255,7 +260,10 @@ export default function HeroEpisodesCarousel({
 
                         return (
                           <CarouselItem
-                            className="basis-[calc(min(280px,80dvw))] grid max-lg:snap-always max-lg:snap-center"
+                            className={cn(
+                              "basis-[calc(min(280px,80dvw))] grid snap-always snap-start",
+                              "first:lg:ml-8",
+                            )}
                             key={id}
                           >
                             <motion.div
@@ -337,7 +345,7 @@ export default function HeroEpisodesCarousel({
                         );
                       })}
                     </CarouselContent>
-                    <CarouselNext />
+                    <CarouselNext className="pointer-coarse:hidden" />
                   </Carousel>
                 </motion.div>
               </AnimatePresence>

--- a/src/app/(main)/_components/HeroImageBackground/HeroImageBackground.tsx
+++ b/src/app/(main)/_components/HeroImageBackground/HeroImageBackground.tsx
@@ -23,10 +23,12 @@ export default function HeroImageBackground({ data }: { data: MediaItem }) {
   useEffect(() => {
     // Listen for new load events.
     imageRef.current?.addEventListener("load", () => {
-      console.log(
-        "Image loaded, setting current src:",
-        imageRef.current?.currentSrc,
-      );
+      if (process.env.NODE_ENV !== "production") {
+        console.log(
+          "Image loaded, setting current src:",
+          imageRef.current?.currentSrc,
+        );
+      }
       setLoading(false);
       setLoaded(true);
       setCurrentSrc(imageRef.current?.currentSrc);
@@ -36,7 +38,7 @@ export default function HeroImageBackground({ data }: { data: MediaItem }) {
   useEffect(() => {
     const isLoaded = !!imageRef.current?.complete;
     setLoaded(isLoaded);
-    if (isLoaded) {
+    if (isLoaded && process.env.NODE_ENV !== "production") {
       console.log(
         "Image loaded from cache, setting current src:",
         imageRef.current?.currentSrc,

--- a/src/app/(main)/_components/Logo/Logo.tsx
+++ b/src/app/(main)/_components/Logo/Logo.tsx
@@ -20,10 +20,15 @@ export default function Logo({
     <div className={classNames}>
       <LogoGlobe
         className="aspect-square h-[2em]"
+        data-slot="globe"
         {...{ animated, duration }}
       />
-      <svg className="inline-block h-[1.25em]" viewBox="0 0 300 46">
-        <title>The World from PRX</title>
+      <svg
+        className="inline-block h-[1.25em]"
+        viewBox="0 0 300 46"
+        data-slot="text"
+        aria-hidden={true}
+      >
         <use href="#tw-logo-text" />
       </svg>
     </div>

--- a/src/app/(main)/_components/MainUI/MainUI.tsx
+++ b/src/app/(main)/_components/MainUI/MainUI.tsx
@@ -253,7 +253,7 @@ export default function MainUI({
           </div>
           <div
             ref={topNavRef}
-            className="isolate sticky top-0 z-(--z-ui) flex justify-between gap-x-10 w-screen p-3"
+            className="isolate sticky top-0 z-(--z-ui) flex justify-between gap-x-4 w-screen p-3"
           >
             <div className="absolute md:hidden inset-0 -z-1 bg-navy-blue/30 backdrop-blur-lg mask-b-from-60%"></div>
             <NextTopLoader

--- a/src/app/(main)/_components/MainUI/MainUI.tsx
+++ b/src/app/(main)/_components/MainUI/MainUI.tsx
@@ -275,8 +275,12 @@ export default function MainUI({
               >
                 <MenuIcon />
               </button>
-              <Link href="/">
-                <Logo className="max-h-10 max-w-48" animated duration="10s" />
+              <Link href="/" aria-label="The World from PRX">
+                <Logo
+                  className="max-h-10 max-w-48 max-sm:*:data-[slot=text]:hidden"
+                  animated
+                  duration="10s"
+                />
               </Link>
             </h1>
             <span className="basis-xl">{search}</span>
@@ -506,7 +510,7 @@ export default function MainUI({
           {children}
         </div>
 
-        <footer className="grid justify-items-center gap-16 py-20 ml-(--gutter-left) mb-(--gutter-bottom)">
+        <footer className="grid justify-items-center gap-16 py-20 ml-(--gutter-left) mb-(--gutter-bottom) pointer-coarse:snap-always pointer-coarse:snap-end">
           <div className="flex flex-wrap justify-center gap-x-20 gap-y-10">
             <MainUIFooterLogoGroup heading="Produced By">
               <PrxLogo aria-label="PRX" />

--- a/src/app/(main)/_components/SearchInput/SearchInput.tsx
+++ b/src/app/(main)/_components/SearchInput/SearchInput.tsx
@@ -224,7 +224,7 @@ export default function SearchInput({
       action={searchPathname}
       onSubmit={handleSubmit}
       autoComplete="off"
-      className={cn("max-sm:hidden", className)}
+      className={cn("", className)}
       {...props}
     >
       <Command
@@ -250,7 +250,7 @@ export default function SearchInput({
           <InputGroupAddon
             align="inline-end"
             className={cn("p-0 px-1 has-[>button]:mr-0", {
-              invisible: !searchInput && !isLoading,
+              hidden: !searchInput && !isLoading,
             })}
           >
             <InputGroupButton
@@ -275,7 +275,7 @@ export default function SearchInput({
                 <DropdownMenuTrigger asChild>
                   <InputGroupButton
                     variant="outline"
-                    className="rounded-full w-min max-w-[45cqw]"
+                    className="rounded-full w-min max-w-[30cqw]"
                   >
                     <span className="overflow-hidden text-ellipsis">
                       {inContextSearch ? searchContext.label : "The Site"}

--- a/src/app/(main)/categories/page.tsx
+++ b/src/app/(main)/categories/page.tsx
@@ -107,7 +107,7 @@ export default async function CategoriesPage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
@@ -181,17 +181,18 @@ export default async function CategoriesPage({
               <div className="row-start-2 col-span-2 overflow-hidden">
                 <CardCarousel
                   opts={{
+                    active: false,
                     align: "start",
                     slidesToScroll: 1,
                     skipSnaps: true,
                     breakpoints: {
-                      "(max-width: 768px)": { align: "center" },
+                      "(pointer: fine)": { active: true },
                     },
                   }}
-                  className=""
+                  className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
                 >
-                  <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) max-md:hidden" />
-                  <CarouselContent className="">
+                  <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) pointer-coarse:hidden" />
+                  <CarouselContent>
                     {slides.map((node, index, all) => {
                       if (!node) return null;
 
@@ -246,6 +247,7 @@ export default async function CategoriesPage({
                             "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                             "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                             "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                            "snap-always snap-center",
                           )}
                           key={id}
                         >
@@ -331,7 +333,7 @@ export default async function CategoriesPage({
                       );
                     })}
                   </CarouselContent>
-                  <CarouselNext />
+                  <CarouselNext className="pointer-coarse:hidden" />
                 </CardCarousel>
               </div>
             </section>
@@ -352,7 +354,7 @@ export default async function CategoriesPage({
       )}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--_gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/app/(main)/contributors/page.tsx
+++ b/src/app/(main)/contributors/page.tsx
@@ -88,7 +88,6 @@ export default async function ContributorsPage({
   const { search: searchParam } = resolvedSearchParams;
   const search = isArray(searchParam) ? searchParam.join(", ") : searchParam;
 
-  console.log(search);
   const data = await getCachedContributors({
     first: 20,
     where: {

--- a/src/app/(main)/contributors/page.tsx
+++ b/src/app/(main)/contributors/page.tsx
@@ -87,6 +87,8 @@ export default async function ContributorsPage({
   const resolvedSearchParams = await searchParams;
   const { search: searchParam } = resolvedSearchParams;
   const search = isArray(searchParam) ? searchParam.join(", ") : searchParam;
+
+  console.log(search);
   const data = await getCachedContributors({
     first: 20,
     where: {
@@ -104,7 +106,7 @@ export default async function ContributorsPage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
@@ -196,17 +198,18 @@ export default async function ContributorsPage({
                 <div className="row-start-2 col-span-2 overflow-hidden">
                   <CardCarousel
                     opts={{
+                      active: false,
                       align: "start",
                       slidesToScroll: 1,
                       skipSnaps: true,
                       breakpoints: {
-                        "(max-width: 768px)": { align: "center" },
+                        "(pointer: fine)": { active: true },
                       },
                     }}
-                    className=""
+                    className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
                   >
-                    <CarouselPrevious className="w-auto opacity-100 pl-(--_menu-width) max-md:hidden" />
-                    <CarouselContent className="">
+                    <CarouselPrevious className="w-auto opacity-100 pl-(--_menu-width) pointer-coarse:hidden" />
+                    <CarouselContent>
                       {slides.map((node, index, all) => {
                         if (!node) return null;
 
@@ -265,6 +268,7 @@ export default async function ContributorsPage({
                               "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                               "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                               "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                              "snap-always snap-center",
                             )}
                             key={id}
                           >
@@ -350,7 +354,7 @@ export default async function ContributorsPage({
                         );
                       })}
                     </CarouselContent>
-                    <CarouselNext />
+                    <CarouselNext className="pointer-coarse:hidden" />
                   </CardCarousel>
                 </div>
               </section>
@@ -371,7 +375,7 @@ export default async function ContributorsPage({
       )}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/app/(main)/episodes/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(main)/episodes/[year]/[month]/[day]/[slug]/page.tsx
@@ -144,20 +144,23 @@ export default async function EpisodePage({ params }: Props) {
               <div className={cn("mt-2")}>
                 <CardCarousel
                   opts={{
+                    active: false,
                     align: "start",
                     slidesToScroll: 1,
                     skipSnaps: true,
                     breakpoints: {
+                      "(pointer: fine)": { active: true },
                       "(max-width: 768px)": { align: "center" },
                     },
                   }}
                   className={cn(
                     "relative w-lvw -translate-x-[calc(var(--gutter-left)+var(--body-gutter)+var(--body-margin))]",
                     "group-data-[color-scheme=dark]/body:[--card:hsl(from_var(--color-navy-blue)_h_s_calc(l*1.5))]",
+                    "**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x **:data-[slot=carousel-content]:scroll-pl-[calc(var(--gutter-left)+var(--body-gutter))]",
                     // "group-data-menu-open/ui:mask-[linear-gradient(to_right,transparent_calc(var(--gutter-left)-var(--body-gutter)),black_calc(var(--gutter-left)+var(--body-gutter)))]",
                   )}
                 >
-                  <CarouselPrevious className="pl-(--gutter-left) from-[calc(var(--gutter-left))] max-md:hidden" />
+                  <CarouselPrevious className="pl-(--gutter-left) from-[calc(var(--gutter-left))] pointer-coarse:hidden" />
                   <CarouselContent className="pl-[calc(var(--gutter-left)+var(--body-gutter))] justify-between">
                     {(segmentsList.nodes as Segment[]).map((segment) => {
                       if (!segment) return null;
@@ -189,7 +192,7 @@ export default async function EpisodePage({ params }: Props) {
                       } as Partial<PlayerAudio>;
                       return (
                         <CarouselItem
-                          className="basis-[calc(min(280px,80dvw))] grid max-lg:snap-always max-lg:snap-center"
+                          className="basis-[calc(min(280px,80dvw))] grid snap-always snap-start"
                           key={id}
                         >
                           <Card className={cn("aspect-260/360")}>
@@ -255,7 +258,7 @@ export default async function EpisodePage({ params }: Props) {
                       );
                     })}
                   </CarouselContent>
-                  <CarouselNext className="max-md:hidden" />
+                  <CarouselNext className="pointer-coarse:hidden" />
                 </CardCarousel>
               </div>
             </div>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -10,6 +10,7 @@ import { fetchGqlApp } from "@/lib/fetch";
 import { Player } from "@/components/Player";
 import { SITE_METADATA } from "./_metadata";
 import { merge } from "lodash";
+import { cn } from "@/lib/util/css";
 
 export const getCachedAppData = unstable_cache(
   async () => fetchGqlApp(),
@@ -63,7 +64,11 @@ export default async function MainLayout({
   return (
     <html
       lang="en"
-      className="antialiased max-sm:snap-proximity max-sm:snap-y max-md:has-data-menu-open:overflow-y-clip  max-sm:scroll-pt-(--gutter-top) max-sm:scroll-pb-(--gutter-bottom)"
+      className={cn(
+        "antialiased",
+        "max-md:has-data-menu-open:overflow-y-clip",
+        "pointer-coarse:snap-proximity pointer-coarse:snap-y pointer-coarse:scroll-pt-(--gutter-top) pointer-coarse:scroll-pb-(--gutter-bottom)",
+      )}
     >
       <head>
         <script

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -92,9 +92,17 @@ export default async function Home() {
     >
       {/* Quick Links Menu */}
       <div className="md:sticky top-(--gutter-top) z-2 overflow-hidden">
-        <CardCarousel>
-          <CarouselPrevious className="w-auto opacity-100 md:pl-(--_gutter-left) [&>svg]:size-8" />
-          <CarouselContent>
+        <CardCarousel
+          opts={{
+            active: false,
+            breakpoints: {
+              "(pointer: fine)": { active: true },
+            },
+          }}
+          className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto"
+        >
+          <CarouselPrevious className="w-auto opacity-100 md:pl-(--_gutter-left) [&>svg]:size-8 pointer-coarse:hidden" />
+          <CarouselContent className="pointer-coarse:w-fit">
             {quickLinksMenu.map(({ key, label, url }) => (
               <CarouselItem
                 className={cn(
@@ -109,7 +117,7 @@ export default async function Home() {
               </CarouselItem>
             ))}
           </CarouselContent>
-          <CarouselNext className="[&>svg]:size-8" />
+          <CarouselNext className="[&>svg]:size-8 pointer-coarse:hidden" />
         </CardCarousel>
       </div>
 
@@ -134,27 +142,28 @@ export default async function Home() {
               <section
                 className={cn(
                   "grid grid-cols-[0_1fr] md:grid-cols-[var(--_menu-width)_1fr] justify-start gap-y-2 -mb-1",
-                  "max-sm:snap-always max-sm:snap-center",
+                  "pointer-coarse:snap-always pointer-coarse:snap-center",
                 )}
                 key={key}
               >
                 <h2 className="col-start-2 justify-self-start pl-4 font-bold text-2xl [&_svg:first-child]:size-8 [&_svg:first-child]:text-cyan">
                   {header}
                 </h2>
-                <div className="row-start-2 col-span-2 overflow-hidden">
+                <div className="row-start-2 col-span-2">
                   <CardCarousel
                     opts={{
+                      active: false,
                       align: "start",
                       slidesToScroll: 1,
                       skipSnaps: true,
                       breakpoints: {
-                        "(min-width: 1024px)": { active: true },
+                        "(pointer: fine)": { active: true },
                       },
                     }}
-                    className=""
+                    className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
                   >
-                    <CarouselPrevious className="w-auto opacity-100 pl-(--_menu-width) max-md:hidden" />
-                    <CarouselContent className="">
+                    <CarouselPrevious className="w-auto opacity-100 pl-(--_menu-width) pointer-coarse:hidden" />
+                    <CarouselContent>
                       {slides.map((post, index) => {
                         if (!post) return null;
 
@@ -188,6 +197,7 @@ export default async function Home() {
                               "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                               "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                               "md:nth-of-type-[1]:ml-[calc(var(--_menu-width)+var(--spacing)*2)]",
+                              "snap-always snap-center",
                             )}
                             key={id}
                           >
@@ -258,7 +268,7 @@ export default async function Home() {
                         );
                       })}
                     </CarouselContent>
-                    <CarouselNext />
+                    <CarouselNext className="opacity-100 pointer-coarse:hidden" />
                   </CardCarousel>
                 </div>
               </section>
@@ -270,16 +280,27 @@ export default async function Home() {
         {!!team?.nodes?.length && (
           <div
             className={cn(
-              "grid grid-cols-[var(--_menu-width)_1fr] justify-start gap-y-2 -mb-1",
-              "max-sm:snap-always max-sm:snap-end",
+              "grid grid-cols-[0_1fr] md:grid-cols-[var(--_menu-width)_1fr] justify-start gap-y-2 -mb-1",
+              "pointer-coarse:snap-always pointer-coarse:snap-center",
             )}
           >
             <h2 className="col-start-2 justify-self-start pl-4 font-bold text-2xl [&_svg:first-child]:size-8 [&_svg:first-child]:text-cyan">
               <Link href="/programs/the-world/team">Meet the Team</Link>
             </h2>
             <div className="row-start-2 col-span-2 overflow-hidden">
-              <CardCarousel>
-                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left)" />
+              <CardCarousel
+                opts={{
+                  active: false,
+                  align: "start",
+                  slidesToScroll: 1,
+                  skipSnaps: true,
+                  breakpoints: {
+                    "(pointer: fine)": { active: true },
+                  },
+                }}
+                className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
+              >
+                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) pointer-coarse:hidden" />
                 <CarouselContent>
                   {(team.nodes as Contributor[])
                     ?.filter((v) => !!v)
@@ -295,6 +316,7 @@ export default async function Home() {
                           className={cn(
                             "grid basis-45 h-83",
                             "md:nth-of-type-[1]:ml-[calc(max(var(--gutter-left),var(--spacing)*28)+var(--spacing)*2)]",
+                            "snap-always snap-center",
                           )}
                           key={id}
                         >
@@ -326,7 +348,7 @@ export default async function Home() {
                       );
                     })}
                 </CarouselContent>
-                <CarouselNext className="max-md:hidden" />
+                <CarouselNext className="pointer-coarse:hidden" />
               </CardCarousel>
             </div>
           </div>

--- a/src/app/(main)/programs/page.tsx
+++ b/src/app/(main)/programs/page.tsx
@@ -95,7 +95,7 @@ export default async function ProgramsPage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
@@ -131,6 +131,7 @@ export default async function ProgramsPage({
                 "nth-of-type-[5n+3]:**:data-[slot=avatar]:bg-red",
                 "nth-of-type-[5n+4]:**:data-[slot=avatar]:bg-burnt-orange",
                 "nth-of-type-[5n+5]:**:data-[slot=avatar]:bg-navy-blue",
+                "snap-always snap-center",
               )}
               key={id}
             >
@@ -172,17 +173,18 @@ export default async function ProgramsPage({
               <div className="row-start-2 col-span-2 overflow-hidden">
                 <CardCarousel
                   opts={{
+                    active: false,
                     align: "start",
                     slidesToScroll: 1,
                     skipSnaps: true,
                     breakpoints: {
-                      "(max-width: 768px)": { align: "center" },
+                      "(pointer: fine)": { active: true },
                     },
                   }}
-                  className=""
+                  className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
                 >
-                  <CarouselPrevious className="w-auto opacity-100 pl-(--_menu-width) max-md:hidden" />
-                  <CarouselContent className="">
+                  <CarouselPrevious className="w-auto opacity-100 pl-(--_menu-width) pointer-coarse:hidden" />
+                  <CarouselContent>
                     {slides.map((node, index, all) => {
                       if (!node) return null;
 
@@ -237,6 +239,7 @@ export default async function ProgramsPage({
                             "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                             "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                             "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                            "snap-always snap-center",
                           )}
                           key={id}
                         >
@@ -322,7 +325,7 @@ export default async function ProgramsPage({
                       );
                     })}
                   </CarouselContent>
-                  <CarouselNext />
+                  <CarouselNext className="pointer-coarse:hidden" />
                 </CardCarousel>
               </div>
             </section>
@@ -343,7 +346,7 @@ export default async function ProgramsPage({
       )}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--_gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/app/(main)/tags/cities/page.tsx
+++ b/src/app/(main)/tags/cities/page.tsx
@@ -88,14 +88,14 @@ export default async function CitiesPage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
       className="grid gap-y-10 mt-10"
     >
-      {nodes?.map((city: City, carouselIndex) => {
-        const { id, name, link, count, contentNodes, taxonomyImages } = city;
+      {nodes?.map((tag: City, carouselIndex) => {
+        const { id, name, link, count, contentNodes, taxonomyImages } = tag;
         const countString = count?.toLocaleString(undefined, {
           notation: "compact",
         });
@@ -119,6 +119,7 @@ export default async function CitiesPage({
               "nth-of-type-[5n+3]:**:data-[slot=avatar]:bg-red",
               "nth-of-type-[5n+4]:**:data-[slot=avatar]:bg-burnt-orange",
               "nth-of-type-[5n+5]:**:data-[slot=avatar]:bg-navy-blue",
+              "snap-always snap-center",
             )}
             key={id}
           >
@@ -146,7 +147,7 @@ export default async function CitiesPage({
                 </Avatar>
               </div>
               <div className="flex flex-col justify-center gap-2">
-                <h2 className="text-xl font-semibold">{name}</h2>
+                <h2 className="text-xl font-semibold capitalize">{name}</h2>
                 {!!info.length && (
                   <div className="text-sm/none font-light [&>*+*]:before:content-['\2022'] [&>*+*]:before:mx-1">
                     {info.map((v) => (
@@ -160,16 +161,17 @@ export default async function CitiesPage({
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
                 opts={{
+                  active: false,
                   align: "start",
                   slidesToScroll: 1,
                   skipSnaps: true,
                   breakpoints: {
-                    "(max-width: 768px)": { align: "center" },
+                    "(pointer: fine)": { active: true },
                   },
                 }}
-                className=""
+                className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
               >
-                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) max-md:hidden" />
+                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) pointer-coarse:hidden" />
                 <CarouselContent className="">
                   {slides.map((node, index, all) => {
                     if (!node) return null;
@@ -225,6 +227,7 @@ export default async function CitiesPage({
                           "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                           "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                           "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                          "snap-always snap-center",
                         )}
                         key={id}
                       >
@@ -308,7 +311,7 @@ export default async function CitiesPage({
                     );
                   })}
                 </CarouselContent>
-                <CarouselNext />
+                <CarouselNext className="pointer-coarse:hidden" />
               </CardCarousel>
             </div>
           </section>
@@ -316,7 +319,7 @@ export default async function CitiesPage({
       })}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--_gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/app/(main)/tags/continents/page.tsx
+++ b/src/app/(main)/tags/continents/page.tsx
@@ -88,15 +88,14 @@ export default async function ContinentsPage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
       className="grid gap-y-10 mt-10"
     >
-      {nodes?.map((continent: Continent, carouselIndex) => {
-        const { id, name, link, count, contentNodes, taxonomyImages } =
-          continent;
+      {nodes?.map((tag: Continent, carouselIndex) => {
+        const { id, name, link, count, contentNodes, taxonomyImages } = tag;
         const countString = count?.toLocaleString(undefined, {
           notation: "compact",
         });
@@ -120,6 +119,7 @@ export default async function ContinentsPage({
               "nth-of-type-[5n+3]:**:data-[slot=avatar]:bg-red",
               "nth-of-type-[5n+4]:**:data-[slot=avatar]:bg-burnt-orange",
               "nth-of-type-[5n+5]:**:data-[slot=avatar]:bg-navy-blue",
+              "snap-always snap-center",
             )}
             key={id}
           >
@@ -147,7 +147,7 @@ export default async function ContinentsPage({
                 </Avatar>
               </div>
               <div className="flex flex-col justify-center gap-2">
-                <h2 className="text-xl font-semibold">{name}</h2>
+                <h2 className="text-xl font-semibold capitalize">{name}</h2>
                 {!!info.length && (
                   <div className="text-sm/none font-light [&>*+*]:before:content-['\2022'] [&>*+*]:before:mx-1">
                     {info.map((v) => (
@@ -161,16 +161,17 @@ export default async function ContinentsPage({
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
                 opts={{
+                  active: false,
                   align: "start",
                   slidesToScroll: 1,
                   skipSnaps: true,
                   breakpoints: {
-                    "(max-width: 768px)": { align: "center" },
+                    "(pointer: fine)": { active: true },
                   },
                 }}
-                className=""
+                className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
               >
-                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) max-md:hidden" />
+                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) pointer-coarse:hidden" />
                 <CarouselContent className="">
                   {slides.map((node, index, all) => {
                     if (!node) return null;
@@ -226,6 +227,7 @@ export default async function ContinentsPage({
                           "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                           "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                           "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                          "snap-always snap-center",
                         )}
                         key={id}
                       >
@@ -309,7 +311,7 @@ export default async function ContinentsPage({
                     );
                   })}
                 </CarouselContent>
-                <CarouselNext />
+                <CarouselNext className="pointer-coarse:hidden" />
               </CardCarousel>
             </div>
           </section>
@@ -317,7 +319,7 @@ export default async function ContinentsPage({
       })}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--_gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/app/(main)/tags/countries/page.tsx
+++ b/src/app/(main)/tags/countries/page.tsx
@@ -88,14 +88,14 @@ export default async function CountriesPage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
       className="grid gap-y-10 mt-10"
     >
-      {nodes?.map((country: Country, carouselIndex) => {
-        const { id, name, link, count, contentNodes, taxonomyImages } = country;
+      {nodes?.map((tag: Country, carouselIndex) => {
+        const { id, name, link, count, contentNodes, taxonomyImages } = tag;
         const countString = count?.toLocaleString(undefined, {
           notation: "compact",
         });
@@ -119,6 +119,7 @@ export default async function CountriesPage({
               "nth-of-type-[5n+3]:**:data-[slot=avatar]:bg-red",
               "nth-of-type-[5n+4]:**:data-[slot=avatar]:bg-burnt-orange",
               "nth-of-type-[5n+5]:**:data-[slot=avatar]:bg-navy-blue",
+              "snap-always snap-center",
             )}
             key={id}
           >
@@ -146,7 +147,7 @@ export default async function CountriesPage({
                 </Avatar>
               </div>
               <div className="flex flex-col justify-center gap-2">
-                <h2 className="text-xl font-semibold">{name}</h2>
+                <h2 className="text-xl font-semibold capitalize">{name}</h2>
                 {!!info.length && (
                   <div className="text-sm/none font-light [&>*+*]:before:content-['\2022'] [&>*+*]:before:mx-1">
                     {info.map((v) => (
@@ -160,21 +161,21 @@ export default async function CountriesPage({
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
                 opts={{
+                  active: false,
                   align: "start",
                   slidesToScroll: 1,
                   skipSnaps: true,
                   breakpoints: {
-                    "(max-width: 768px)": { align: "center" },
+                    "(pointer: fine)": { active: true },
                   },
                 }}
-                className=""
+                className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
               >
-                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) max-md:hidden" />
+                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) pointer-coarse:hidden" />
                 <CarouselContent className="">
                   {slides.map((node, index, all) => {
                     if (!node) return null;
 
-                    const { id } = node;
                     const { additionalMedia, primaryCategory } = node as Post;
                     const { episodeAudio } = node as Episode;
                     const { segmentContent } = node as Segment;
@@ -197,7 +198,7 @@ export default async function CountriesPage({
                       (isParentOfSegmentAudioAStory &&
                         (parent?.node as Post)) ||
                       (node as Post);
-                    const { title, date, link, featuredImage } =
+                    const { id, title, date, link, featuredImage } =
                       slideNode || {};
 
                     const { name: pcName, link: pcLink } =
@@ -226,6 +227,7 @@ export default async function CountriesPage({
                           "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                           "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                           "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                          "snap-always snap-center",
                         )}
                         key={id}
                       >
@@ -309,7 +311,7 @@ export default async function CountriesPage({
                     );
                   })}
                 </CarouselContent>
-                <CarouselNext />
+                <CarouselNext className="pointer-coarse:hidden" />
               </CardCarousel>
             </div>
           </section>
@@ -317,7 +319,7 @@ export default async function CountriesPage({
       })}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--_gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/app/(main)/tags/page.tsx
+++ b/src/app/(main)/tags/page.tsx
@@ -88,7 +88,7 @@ export default async function TagsPage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
@@ -119,6 +119,7 @@ export default async function TagsPage({
               "nth-of-type-[5n+3]:**:data-[slot=avatar]:bg-red",
               "nth-of-type-[5n+4]:**:data-[slot=avatar]:bg-burnt-orange",
               "nth-of-type-[5n+5]:**:data-[slot=avatar]:bg-navy-blue",
+              "snap-always snap-center",
             )}
             key={id}
           >
@@ -160,16 +161,17 @@ export default async function TagsPage({
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
                 opts={{
+                  active: false,
                   align: "start",
                   slidesToScroll: 1,
                   skipSnaps: true,
                   breakpoints: {
-                    "(max-width: 768px)": { align: "center" },
+                    "(pointer: fine)": { active: true },
                   },
                 }}
-                className=""
+                className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
               >
-                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) max-md:hidden" />
+                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) pointer-coarse:hidden" />
                 <CarouselContent className="">
                   {slides.map((node, index, all) => {
                     if (!node) return null;
@@ -225,6 +227,7 @@ export default async function TagsPage({
                           "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                           "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                           "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                          "snap-always snap-center",
                         )}
                         key={id}
                       >
@@ -308,7 +311,7 @@ export default async function TagsPage({
                     );
                   })}
                 </CarouselContent>
-                <CarouselNext />
+                <CarouselNext className="pointer-coarse:hidden" />
               </CardCarousel>
             </div>
           </section>
@@ -316,7 +319,7 @@ export default async function TagsPage({
       })}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--_gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/app/(main)/tags/people/page.tsx
+++ b/src/app/(main)/tags/people/page.tsx
@@ -88,14 +88,14 @@ export default async function PeoplePage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
       className="grid gap-y-10 mt-10"
     >
-      {nodes?.map((person: Person, carouselIndex) => {
-        const { id, name, link, count, contentNodes, taxonomyImages } = person;
+      {nodes?.map((tag: Person, carouselIndex) => {
+        const { id, name, link, count, contentNodes, taxonomyImages } = tag;
         const countString = count?.toLocaleString(undefined, {
           notation: "compact",
         });
@@ -119,6 +119,7 @@ export default async function PeoplePage({
               "nth-of-type-[5n+3]:**:data-[slot=avatar]:bg-red",
               "nth-of-type-[5n+4]:**:data-[slot=avatar]:bg-burnt-orange",
               "nth-of-type-[5n+5]:**:data-[slot=avatar]:bg-navy-blue",
+              "snap-always snap-center",
             )}
             key={id}
           >
@@ -146,7 +147,7 @@ export default async function PeoplePage({
                 </Avatar>
               </div>
               <div className="flex flex-col justify-center gap-2">
-                <h2 className="text-xl font-semibold">{name}</h2>
+                <h2 className="text-xl font-semibold capitalize">{name}</h2>
                 {!!info.length && (
                   <div className="text-sm/none font-light [&>*+*]:before:content-['\2022'] [&>*+*]:before:mx-1">
                     {info.map((v) => (
@@ -160,16 +161,17 @@ export default async function PeoplePage({
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
                 opts={{
+                  active: false,
                   align: "start",
                   slidesToScroll: 1,
                   skipSnaps: true,
                   breakpoints: {
-                    "(max-width: 768px)": { align: "center" },
+                    "(pointer: fine)": { active: true },
                   },
                 }}
-                className=""
+                className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
               >
-                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) max-md:hidden" />
+                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) pointer-coarse:hidden" />
                 <CarouselContent className="">
                   {slides.map((node, index, all) => {
                     if (!node) return null;
@@ -225,6 +227,7 @@ export default async function PeoplePage({
                           "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                           "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                           "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                          "snap-always snap-center",
                         )}
                         key={id}
                       >
@@ -308,7 +311,7 @@ export default async function PeoplePage({
                     );
                   })}
                 </CarouselContent>
-                <CarouselNext />
+                <CarouselNext className="pointer-coarse:hidden" />
               </CardCarousel>
             </div>
           </section>
@@ -316,7 +319,7 @@ export default async function PeoplePage({
       })}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--_gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/app/(main)/tags/provinces_or_states/page.tsx
+++ b/src/app/(main)/tags/provinces_or_states/page.tsx
@@ -92,15 +92,14 @@ export default async function ProvincesOrStatesPage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
       className="grid gap-y-10 mt-10"
     >
-      {nodes?.map((provinceOrState: ProvinceOrState, carouselIndex) => {
-        const { id, name, link, count, contentNodes, taxonomyImages } =
-          provinceOrState;
+      {nodes?.map((tag: ProvinceOrState, carouselIndex) => {
+        const { id, name, link, count, contentNodes, taxonomyImages } = tag;
         const countString = count?.toLocaleString(undefined, {
           notation: "compact",
         });
@@ -124,6 +123,7 @@ export default async function ProvincesOrStatesPage({
               "nth-of-type-[5n+3]:**:data-[slot=avatar]:bg-red",
               "nth-of-type-[5n+4]:**:data-[slot=avatar]:bg-burnt-orange",
               "nth-of-type-[5n+5]:**:data-[slot=avatar]:bg-navy-blue",
+              "snap-always snap-center",
             )}
             key={id}
           >
@@ -151,7 +151,7 @@ export default async function ProvincesOrStatesPage({
                 </Avatar>
               </div>
               <div className="flex flex-col justify-center gap-2">
-                <h2 className="text-xl font-semibold">{name}</h2>
+                <h2 className="text-xl font-semibold capitalize">{name}</h2>
                 {!!info.length && (
                   <div className="text-sm/none font-light [&>*+*]:before:content-['\2022'] [&>*+*]:before:mx-1">
                     {info.map((v) => (
@@ -165,16 +165,17 @@ export default async function ProvincesOrStatesPage({
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
                 opts={{
+                  active: false,
                   align: "start",
                   slidesToScroll: 1,
                   skipSnaps: true,
                   breakpoints: {
-                    "(max-width: 768px)": { align: "center" },
+                    "(pointer: fine)": { active: true },
                   },
                 }}
-                className=""
+                className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
               >
-                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) max-md:hidden" />
+                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) pointer-coarse:hidden" />
                 <CarouselContent className="">
                   {slides.map((node, index, all) => {
                     if (!node) return null;
@@ -230,6 +231,7 @@ export default async function ProvincesOrStatesPage({
                           "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                           "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                           "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                          "snap-always snap-center",
                         )}
                         key={id}
                       >
@@ -313,7 +315,7 @@ export default async function ProvincesOrStatesPage({
                     );
                   })}
                 </CarouselContent>
-                <CarouselNext />
+                <CarouselNext className="pointer-coarse:hidden" />
               </CardCarousel>
             </div>
           </section>
@@ -321,7 +323,7 @@ export default async function ProvincesOrStatesPage({
       })}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--_gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/app/(main)/tags/regions/page.tsx
+++ b/src/app/(main)/tags/regions/page.tsx
@@ -88,14 +88,14 @@ export default async function RegionsPage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
       className="grid gap-y-10 mt-10"
     >
-      {nodes?.map((region: Region, carouselIndex) => {
-        const { id, name, link, count, contentNodes, taxonomyImages } = region;
+      {nodes?.map((tag: Region, carouselIndex) => {
+        const { id, name, link, count, contentNodes, taxonomyImages } = tag;
         const countString = count?.toLocaleString(undefined, {
           notation: "compact",
         });
@@ -119,6 +119,7 @@ export default async function RegionsPage({
               "nth-of-type-[5n+3]:**:data-[slot=avatar]:bg-red",
               "nth-of-type-[5n+4]:**:data-[slot=avatar]:bg-burnt-orange",
               "nth-of-type-[5n+5]:**:data-[slot=avatar]:bg-navy-blue",
+              "snap-always snap-center",
             )}
             key={id}
           >
@@ -146,7 +147,7 @@ export default async function RegionsPage({
                 </Avatar>
               </div>
               <div className="flex flex-col justify-center gap-2">
-                <h2 className="text-xl font-semibold">{name}</h2>
+                <h2 className="text-xl font-semibold capitalize">{name}</h2>
                 {!!info.length && (
                   <div className="text-sm/none font-light [&>*+*]:before:content-['\2022'] [&>*+*]:before:mx-1">
                     {info.map((v) => (
@@ -160,16 +161,17 @@ export default async function RegionsPage({
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
                 opts={{
+                  active: false,
                   align: "start",
                   slidesToScroll: 1,
                   skipSnaps: true,
                   breakpoints: {
-                    "(max-width: 768px)": { align: "center" },
+                    "(pointer: fine)": { active: true },
                   },
                 }}
-                className=""
+                className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
               >
-                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) max-md:hidden" />
+                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) pointer-coarse:hidden" />
                 <CarouselContent className="">
                   {slides.map((node, index, all) => {
                     if (!node) return null;
@@ -225,6 +227,7 @@ export default async function RegionsPage({
                           "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                           "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                           "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                          "snap-always snap-center",
                         )}
                         key={id}
                       >
@@ -308,7 +311,7 @@ export default async function RegionsPage({
                     );
                   })}
                 </CarouselContent>
-                <CarouselNext />
+                <CarouselNext className="pointer-coarse:hidden" />
               </CardCarousel>
             </div>
           </section>
@@ -316,7 +319,7 @@ export default async function RegionsPage({
       })}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--_gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/app/(main)/tags/social_tags/page.tsx
+++ b/src/app/(main)/tags/social_tags/page.tsx
@@ -88,15 +88,14 @@ export default async function SocialTagsPage({
     <main
       style={
         {
-          "--_menu-width": "max(var(--gutter-left), var(--spacing) * 20)",
+          "--_menu-width": "var(--gutter-left)",
           "--_gutter-left": "calc(var(--_menu-width) + (var(--spacing) * 10))",
         } as CSSProperties
       }
       className="grid gap-y-10 mt-10"
     >
-      {nodes?.map((socialTag: SocialTag, carouselIndex) => {
-        const { id, name, link, count, contentNodes, taxonomyImages } =
-          socialTag;
+      {nodes?.map((tag: SocialTag, carouselIndex) => {
+        const { id, name, link, count, contentNodes, taxonomyImages } = tag;
         const countString = count?.toLocaleString(undefined, {
           notation: "compact",
         });
@@ -120,6 +119,7 @@ export default async function SocialTagsPage({
               "nth-of-type-[5n+3]:**:data-[slot=avatar]:bg-red",
               "nth-of-type-[5n+4]:**:data-[slot=avatar]:bg-burnt-orange",
               "nth-of-type-[5n+5]:**:data-[slot=avatar]:bg-navy-blue",
+              "snap-always snap-center",
             )}
             key={id}
           >
@@ -147,7 +147,7 @@ export default async function SocialTagsPage({
                 </Avatar>
               </div>
               <div className="flex flex-col justify-center gap-2">
-                <h2 className="text-xl font-semibold">{name}</h2>
+                <h2 className="text-xl font-semibold capitalize">{name}</h2>
                 {!!info.length && (
                   <div className="text-sm/none font-light [&>*+*]:before:content-['\2022'] [&>*+*]:before:mx-1">
                     {info.map((v) => (
@@ -161,16 +161,17 @@ export default async function SocialTagsPage({
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
                 opts={{
+                  active: false,
                   align: "start",
                   slidesToScroll: 1,
                   skipSnaps: true,
                   breakpoints: {
-                    "(max-width: 768px)": { align: "center" },
+                    "(pointer: fine)": { active: true },
                   },
                 }}
-                className=""
+                className="**:data-[slot=carousel-content]:pointer-coarse:overflow-x-auto **:data-[slot=carousel-content]:snap-proximity **:data-[slot=carousel-content]:snap-x"
               >
-                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) max-md:hidden" />
+                <CarouselPrevious className="w-auto opacity-100 pl-(--_gutter-left) pointer-coarse:hidden" />
                 <CarouselContent className="">
                   {slides.map((node, index, all) => {
                     if (!node) return null;
@@ -226,6 +227,7 @@ export default async function SocialTagsPage({
                           "grid aspect-300/480 basis-[calc(min(300px,80dvw))] h-120 transition-all",
                           "nth-of-type-[1]:aspect-square nth-of-type-[1]:basis-[calc(min(480px,80dvw))]",
                           "md:nth-of-type-[1]:ml-[calc(var(--_gutter-left)+var(--spacing)*2)]",
+                          "snap-always snap-center",
                         )}
                         key={id}
                       >
@@ -309,7 +311,7 @@ export default async function SocialTagsPage({
                     );
                   })}
                 </CarouselContent>
-                <CarouselNext />
+                <CarouselNext className="pointer-coarse:hidden" />
               </CardCarousel>
             </div>
           </section>
@@ -317,7 +319,7 @@ export default async function SocialTagsPage({
       })}
 
       {shownContentEndMessage && (
-        <div className="px-4 mt-20 ml-(--_gutter-left)">
+        <div className="px-4 mt-20 md:ml-(--_gutter-left)">
           <CtaRegion cta={shownContentEndMessage} />
         </div>
       )}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -149,7 +149,7 @@ function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       ref={carouselRef}
-      className="overflow-hidden rounded-sm"
+      className="overflow-hidden rounded-sm no-scrollbar"
       data-slot="carousel-content"
     >
       <div

--- a/src/lib/fetch/contributor/fetchGqlContributors.ts
+++ b/src/lib/fetch/contributor/fetchGqlContributors.ts
@@ -36,9 +36,11 @@ const CONTRIBUTOR_CARD_PROPS = gql`
       position
       teaser
       program {
-        id
-        link
-        name
+        nodes {
+          id
+          link
+          name
+        }
       }
       image {
         node {
@@ -130,6 +132,8 @@ const GET_CONTRIBUTORS = gql`
 
 export async function fetchGqlContributors(query: ContributorQueryOptions) {
   let data: { nodes: Contributor[] } | undefined;
+
+  console.log(query);
 
   if (query?.where?.search) {
     // Query contributors when search param is provided.

--- a/src/lib/fetch/contributor/fetchGqlContributors.ts
+++ b/src/lib/fetch/contributor/fetchGqlContributors.ts
@@ -133,8 +133,6 @@ const GET_CONTRIBUTORS = gql`
 export async function fetchGqlContributors(query: ContributorQueryOptions) {
   let data: { nodes: Contributor[] } | undefined;
 
-  console.log(query);
-
   if (query?.where?.search) {
     // Query contributors when search param is provided.
     const response = await gqlClient.query<{


### PR DESCRIPTION
Closes #545, Closes #543

- fix janky carousels on mobile
- fix contributors fetch query
- fix left margin in taxonomy page layouts
- hide logo text on small viewport sizes
- show search input on small viewport sizes
- adjust search input layout for small viewport sizes

## To Review

- [ ] Use the Preview link located in the Now comment below.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev:start`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Inspect page and activate the device toolbar. Select a mobile device from Dimensions.
- [x] Ensure scrolling of carousels is smooth.
  - [x] Homepage
  - [x] Episode segments
  - [x] Taxonomy pages
    - [x] `/categories`
    - [x] `/contributors`
    - [x] `/programs`
    - [x] `/tags`
    - [x] `/tags/countries`
    - [x] Check all the `/tags/taxonomy_plural_name` routes
- [x] Ensure back and next buttons are not shown.
- [x] Ensure search input in header looks and works as expected.
