### PR TITLE
566: Prevent UTC midnight dates from rendering as previous day

### DIFF
--- a/src/lib/sanitize/sanitizeIso8601Date.ts
+++ b/src/lib/sanitize/sanitizeIso8601Date.ts
@@ -45,5 +45,14 @@ export const sanitizeIso8601Date = (
     }
   }
 
+  // Make sure date values that are UTC midnight get time set to noon.
+  // Prevents day rollbacks when rendering date on client.
+  if (/T00:00:00\+00:00$/.test(usedDateValue)) {
+    usedDateValue = usedDateValue.replace(
+      /T00:00:00\+00:00$/,
+      "T12:00:00+00:00",
+    );
+  }
+
   return usedDateValue;
 };


### PR DESCRIPTION
Closes #566

- update date sanitization to force time to noon for UTC midnight dates to prevent render of date as previous day.

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure dates that come from a ACF date fields are rendering the correct day. (Episode broadcast date, story updated date)
