### PR TITLE
fix(htmlcontent): add replacer to img tags with relative src

### DIFF
--- a/src/components/HtmlContent/HtmlContent.tsx
+++ b/src/components/HtmlContent/HtmlContent.tsx
@@ -21,6 +21,7 @@ import {
   //   fbRootRemove,
   fixBlockInParagraph,
   fixNestedSpans,
+  removeImgWIthRelativeSrc,
   //   instagramEmbed,
   removeUnsupportedElementTypes,
   unwrapLegacyWrappers,
@@ -64,6 +65,7 @@ export const HtmlContent = ({
         /* GLOBAL FIXES */
 
         removeUnsupportedElementTypes,
+        removeImgWIthRelativeSrc,
         fbRootRemove,
         unwrapLegacyWrappers,
 

--- a/src/components/HtmlContent/replacers/index.ts
+++ b/src/components/HtmlContent/replacers/index.ts
@@ -2,5 +2,6 @@ export * from "./anchorToLink";
 export * from "./fbRootRemove";
 export * from "./fixBlockInParagraph";
 export * from "./fixNestedSpans";
+export * from "./removeImgWIthRelativeSrc";
 export * from "./removeUnsupportedElementTypes";
 export * from "./unwrapLegacyWrappers";

--- a/src/components/HtmlContent/replacers/removeImgWIthRelativeSrc.tsx
+++ b/src/components/HtmlContent/replacers/removeImgWIthRelativeSrc.tsx
@@ -1,0 +1,14 @@
+import { replaceElement } from "@/app/(main)/_components/ContentBody/replacers";
+
+/**
+ * @file removeImgWithRelativeSrc.ts
+ * Remove img tags with relative src URL's.
+ */
+export const removeImgWIthRelativeSrc = replaceElement("img", (el) => {
+  if (el.attribs.src.startsWith("/") && !el.attribs.src.startsWith("//:")) {
+    // biome-ignore lint/complexity/noUselessFragments: See docs: https://github.com/remarkablemark/html-react-parser?tab=readme-ov-file#replace-and-remove-element
+    return <></>;
+  }
+
+  return undefined;
+});


### PR DESCRIPTION
Closes #[ISSUE_ID]

- removes `<img>` tags with relative `src` URL's. These would have been legacy theme related images, which are not used in this site.

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [ ] Go to http://localhost:3000/stories/2017/03/10/australians-debate-response-bushfires.

> ...then...

- [ ] Ensure content contains no broken images.

> You can find additional stories to test by searching your local WP posts for `/sites/all/themes/globalpostinternal/images/related-item-holder.gif`
