### PR TITLE
feat(next): add headers to config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import { withPlausibleProxy } from "next-plausible";
+import { headers } from "./next.headers";
 import { redirects } from "./next.redirects";
 
 const nextConfig: NextConfig = withPlausibleProxy({
@@ -7,6 +8,7 @@ const nextConfig: NextConfig = withPlausibleProxy({
 })({
   output: "standalone",
   trailingSlash: false,
+  headers,
   redirects,
   experimental: {
     turbopackFileSystemCacheForDev: false,

--- a/next.headers.ts
+++ b/next.headers.ts
@@ -32,5 +32,14 @@ export const headers: NextConfig["headers"] = async () => {
         },
       ],
     },
+    {
+      source: "/_next/static/(.*)",
+      headers: [
+        {
+          key: "Cache-Control",
+          value: "public, max-age=31536000, immutable",
+        },
+      ],
+    },
   ];
 };

--- a/next.headers.ts
+++ b/next.headers.ts
@@ -1,0 +1,36 @@
+import type { NextConfig } from "next";
+
+export const headers: NextConfig["headers"] = async () => {
+  return [
+    {
+      source: "/(.*)",
+      headers: [
+        {
+          key: "Cache-Control",
+          value:
+            "public, max-age=3600, s-maxage=3600, stale-while-revalidate=300",
+        },
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload",
+        },
+        {
+          key: "Content-Security-Policy",
+          value: "frame-ancestors https://admin.theworld.org",
+        },
+        {
+          key: "X-XSS-Protection",
+          value: "1; mode=block",
+        },
+        {
+          key: "X-Content-Type-Options",
+          value: "nosniff",
+        },
+        {
+          key: "Permissions-Policy",
+          value: "interest-cohort=()",
+        },
+      ],
+    },
+  ];
+};


### PR DESCRIPTION
- adds headers to next config.

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `docker build .`.
- [ ] Run `docker run --env-file .env -p 3000:3000 sha256:BUILD_IMAGE_ID`
- [ ] Got http://localhost:3000

> ...then...

- [ ] Inspect network request headers in browser.
