### PR TITLE
fix(heroepisodecarousel): segment carousel layout in firefox

### DIFF
--- a/src/app/(main)/_components/HeroEpisodesCarousel/HeroEpisodesCarousel.tsx
+++ b/src/app/(main)/_components/HeroEpisodesCarousel/HeroEpisodesCarousel.tsx
@@ -177,7 +177,7 @@ export default function HeroEpisodesCarousel({
           {!!segmentsList?.nodes?.length && (
             <div
               className={cn(
-                "grid grid-cols-[0_max-content] align-items-start gap-y-2 w-fit -mb-1",
+                "grid grid-cols-[0_max-content] align-items-start gap-y-2 -mb-1",
                 "lg:overflow-hidden lg:grid-cols-[--spacing(8)_1fr] lg:mask-[linear-gradient(90deg,transparent_--spacing(2),black_--spacing(8))]",
               )}
             >


### PR DESCRIPTION
Closes #567 

- hero episode carousel segment carousel layout in firefox

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Use Firefox to go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure hero episode carousel segment carousel stretches to fill horizontal area and scrolls as expected in desktop and mobile.
