### PR TITLE
A11y Audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 # next.js
 /.next/
 /out/
+next-env.d.ts
 
 # production
 /build

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/(main)/_components/CtaRegion/CtaRegion.tsx
+++ b/src/app/(main)/_components/CtaRegion/CtaRegion.tsx
@@ -67,6 +67,7 @@ export default function CtaRegion({
     >
       {dismissible && (
         <Button
+          aria-label="Dismiss Banner"
           variant="ghost"
           size="icon-sm"
           className={cn(

--- a/src/app/(main)/_components/Explorer/ExplorerCard.tsx
+++ b/src/app/(main)/_components/Explorer/ExplorerCard.tsx
@@ -72,7 +72,7 @@ export function ExplorerCard({
 
   return (
     <Card className={cn("aspect-2/3", className)} {...props}>
-      {linkHref && <CardLink href={linkHref} />}
+      {linkHref && <CardLink href={linkHref} aria-label={title} />}
       {imageSrc && !isPlaceholderImage && (
         <CardImage data-image-id={imageId}>
           <Image

--- a/src/app/(main)/_components/Explorer/ExplorerContentTypeFilter.tsx
+++ b/src/app/(main)/_components/Explorer/ExplorerContentTypeFilter.tsx
@@ -101,7 +101,7 @@ export function ExplorerContentTypeFilter({
       defaultValue={defaultValue?.value}
       value={selected?.value}
     >
-      <SelectTrigger data-slot="explorer-filter-control-content-type">
+      <SelectTrigger data-slot="explorer-filter-control-content-type" aria-label="Filter by content type">
         <SelectValue placeholder="Filter By Type" />
       </SelectTrigger>
       <SelectContent className={cn("", className)} {...props}>

--- a/src/app/(main)/_components/Explorer/ExplorerDateFilter.tsx
+++ b/src/app/(main)/_components/Explorer/ExplorerDateFilter.tsx
@@ -124,12 +124,13 @@ export function ExplorerDateFilter({
               className="cursor-pointer"
               variant="frosted"
               size="icon"
+              aria-label="Clear date filter"
               onClick={handleClearDate}
             >
               <XIcon />
             </Button>
           )}
-          <Button className="cursor-pointer" variant="frosted" size="icon">
+          <Button className="cursor-pointer" variant="frosted" size="icon" aria-label="Filter by date">
             <CalendarIcon />
           </Button>
         </ButtonGroup>

--- a/src/app/(main)/_components/Explorer/ExplorerSort.tsx
+++ b/src/app/(main)/_components/Explorer/ExplorerSort.tsx
@@ -101,7 +101,7 @@ export function ExplorerSortFilter({
       defaultValue={defaultValue?.value}
       value={selected?.value}
     >
-      <SelectTrigger data-slot="explorer-filter-control-sort">
+      <SelectTrigger data-slot="explorer-filter-control-sort" aria-label="Sort order">
         <SelectValue placeholder="Sort Order" />
       </SelectTrigger>
       <SelectContent className={cn("", className)} align="end" {...props}>

--- a/src/app/(main)/_components/HeroEpisodesCarousel/HeroEpisodesCarousel.tsx
+++ b/src/app/(main)/_components/HeroEpisodesCarousel/HeroEpisodesCarousel.tsx
@@ -135,6 +135,7 @@ export default function HeroEpisodesCarousel({
               {linkHref && (
                 <Link
                   href={linkHref}
+                  aria-label={title ?? undefined}
                   className="absolute inset-0 focus-visible:outline-none"
                 ></Link>
               )}
@@ -282,7 +283,7 @@ export default function HeroEpisodesCarousel({
                             >
                               <Card className={cn("aspect-260/360")}>
                                 {segmentLinkHref && (
-                                  <CardLink href={segmentLinkHref} />
+                                  <CardLink href={segmentLinkHref} aria-label={title ?? undefined} />
                                 )}
                                 {segmentImageSrc && (
                                   <CardImage>

--- a/src/app/(main)/_components/HeroEpisodesCarousel/HeroEpisodesCarousel.tsx
+++ b/src/app/(main)/_components/HeroEpisodesCarousel/HeroEpisodesCarousel.tsx
@@ -139,9 +139,9 @@ export default function HeroEpisodesCarousel({
                   className="absolute inset-0 focus-visible:outline-none"
                 ></Link>
               )}
-              <h3 className="text-[clamp(2rem,6vw,3rem)] leading-none font-bold text-balance">
+              <h2 className="text-[clamp(2rem,6vw,3rem)] leading-none font-bold text-balance">
                 {title}
-              </h3>
+              </h2>
               <div className="flex flex-wrap items-center gap-x-4">
                 <span className="text-cyan font-serif font-bold italic uppercase">
                   Full Episode

--- a/src/app/(main)/_components/MainUI/MainUI.tsx
+++ b/src/app/(main)/_components/MainUI/MainUI.tsx
@@ -313,8 +313,7 @@ export default function MainUI({
 
         <div
           id="main-menu"
-          role="menu"
-          aria-labelledby="main-menu-button"
+          aria-label="Main navigation"
           className={cn(
             "fixed inset-0 flex flex-col justify-stretch transition-transform z-(--z-dialog) bg-linear-to-r from-blue to-green",
             "md:top-(--gutter-top) md:bottom-(--gutter-bottom) md:right-auto md:w-min md:z-(--z-ui) md:bg-none md:delay-(--default-transition-duration)",
@@ -385,7 +384,7 @@ export default function MainUI({
           {/* Footer */}
           <div className="grid gap-2 p-4 text-xs/4 max-w-62">
             {footerNav && (
-              <nav className="flex flex-wrap gap-x-2">
+              <nav className="flex flex-wrap gap-x-3 gap-y-2">
                 {footerNav.map(({ key, url, label, attributes }) => (
                   <Link
                     className="hover:underline underline-offset-2"

--- a/src/app/(main)/_components/MainUI/MainUI.tsx
+++ b/src/app/(main)/_components/MainUI/MainUI.tsx
@@ -445,6 +445,7 @@ export default function MainUI({
                           className="rounded-full cursor-pointer"
                           size="icon"
                           variant="ghost"
+                          aria-label={isPlaylistOpen ? "Hide Playlist" : "Show Playlist"}
                           onClick={handlePlaylistToggle}
                         >
                           <ChevronUpIcon

--- a/src/app/(main)/categories/page.tsx
+++ b/src/app/(main)/categories/page.tsx
@@ -176,7 +176,7 @@ export default async function CategoriesPage({
                     </div>
                   )}
                 </div>
-                {!!href && <CardLink href={href} />}
+                {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
               </header>
               <div className="row-start-2 col-span-2 overflow-hidden">
                 <CardCarousel
@@ -252,7 +252,7 @@ export default async function CategoriesPage({
                           key={id}
                         >
                           <Card className={cn("")}>
-                            {linkHref && <CardLink href={linkHref} />}
+                            {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                             {imageSrc && !isPlaceholderImage && (
                               <CardImage data-image-id={imageId}>
                                 <Image

--- a/src/app/(main)/contributors/page.tsx
+++ b/src/app/(main)/contributors/page.tsx
@@ -192,7 +192,7 @@ export default async function ContributorsPage({
                       </div>
                     )}
                   </div>
-                  {!!href && <CardLink href={href} />}
+                  {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
                 </header>
                 <div className="row-start-2 col-span-2 overflow-hidden">
                   <CardCarousel
@@ -272,7 +272,7 @@ export default async function ContributorsPage({
                             key={id}
                           >
                             <Card className={cn("")}>
-                              {linkHref && <CardLink href={linkHref} />}
+                              {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                               {imageSrc && !isPlaceholderImage && (
                                 <CardImage data-image-id={imageId}>
                                   <Image

--- a/src/app/(main)/episodes/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(main)/episodes/[year]/[month]/[day]/[slug]/page.tsx
@@ -197,7 +197,7 @@ export default async function EpisodePage({ params }: Props) {
                         >
                           <Card className={cn("aspect-260/360")}>
                             {segmentLinkHref && (
-                              <CardLink href={segmentLinkHref} />
+                              <CardLink href={segmentLinkHref} aria-label={title ?? undefined} />
                             )}
                             {segmentImageSrc && (
                               <CardImage>

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -202,7 +202,7 @@ export default async function Home() {
                             key={id}
                           >
                             <Card className={cn("")}>
-                              {linkHref && <CardLink href={linkHref} />}
+                              {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                               {imageSrc && (
                                 <CardImage>
                                   <Image
@@ -322,7 +322,7 @@ export default async function Home() {
                         >
                           <Card>
                             {contributorLink && (
-                              <CardLink href={contributorLink} />
+                              <CardLink href={contributorLink} aria-label={name ?? undefined} />
                             )}
                             {imageSrc && (
                               <CardImage>

--- a/src/app/(main)/programs/[slug]/team/page.tsx
+++ b/src/app/(main)/programs/[slug]/team/page.tsx
@@ -93,7 +93,7 @@ export default async function TaxonomyPage({ params }: Props) {
 
             return (
               <Card className={cn("aspect-2/3")} key={id}>
-                {linkHref && <CardLink href={linkHref} />}
+                {linkHref && <CardLink href={linkHref} aria-label={name ?? undefined} />}
                 {imageSrc && (
                   <CardImage data-image-id={image.node.id}>
                     <Image

--- a/src/app/(main)/programs/page.tsx
+++ b/src/app/(main)/programs/page.tsx
@@ -168,7 +168,7 @@ export default async function ProgramsPage({
                     </div>
                   )}
                 </div>
-                {!!href && <CardLink href={href} />}
+                {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
               </header>
               <div className="row-start-2 col-span-2 overflow-hidden">
                 <CardCarousel
@@ -244,7 +244,7 @@ export default async function ProgramsPage({
                           key={id}
                         >
                           <Card className={cn("")}>
-                            {linkHref && <CardLink href={linkHref} />}
+                            {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                             {imageSrc && !isPlaceholderImage && (
                               <CardImage data-image-id={imageId}>
                                 <Image

--- a/src/app/(main)/stations/_components/StationFinder.tsx
+++ b/src/app/(main)/stations/_components/StationFinder.tsx
@@ -146,7 +146,7 @@ export function StationFinder({
                 )}
                 key={id}
               >
-                {website && <CardLink href={website} />}
+                {website && <CardLink href={website} aria-label={callLetters ?? undefined} />}
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <span className="grow flex items-start gap-x-1">

--- a/src/app/(main)/tags/cities/page.tsx
+++ b/src/app/(main)/tags/cities/page.tsx
@@ -156,7 +156,7 @@ export default async function CitiesPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} />}
+              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +232,7 @@ export default async function CitiesPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} />}
+                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/continents/page.tsx
+++ b/src/app/(main)/tags/continents/page.tsx
@@ -156,7 +156,7 @@ export default async function ContinentsPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} />}
+              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +232,7 @@ export default async function ContinentsPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} />}
+                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/countries/page.tsx
+++ b/src/app/(main)/tags/countries/page.tsx
@@ -156,7 +156,7 @@ export default async function CountriesPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} />}
+              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +232,7 @@ export default async function CountriesPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} />}
+                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/page.tsx
+++ b/src/app/(main)/tags/page.tsx
@@ -156,7 +156,7 @@ export default async function TagsPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} />}
+              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +232,7 @@ export default async function TagsPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} />}
+                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/people/page.tsx
+++ b/src/app/(main)/tags/people/page.tsx
@@ -156,7 +156,7 @@ export default async function PeoplePage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} />}
+              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +232,7 @@ export default async function PeoplePage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} />}
+                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/provinces_or_states/page.tsx
+++ b/src/app/(main)/tags/provinces_or_states/page.tsx
@@ -160,7 +160,7 @@ export default async function ProvincesOrStatesPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} />}
+              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -236,7 +236,7 @@ export default async function ProvincesOrStatesPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} />}
+                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/regions/page.tsx
+++ b/src/app/(main)/tags/regions/page.tsx
@@ -156,7 +156,7 @@ export default async function RegionsPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} />}
+              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +232,7 @@ export default async function RegionsPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} />}
+                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/social_tags/page.tsx
+++ b/src/app/(main)/tags/social_tags/page.tsx
@@ -156,7 +156,7 @@ export default async function SocialTagsPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} />}
+              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +232,7 @@ export default async function SocialTagsPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} />}
+                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/components/Player/components/PlayerMenu/PlayerMenu.tsx
+++ b/src/components/Player/components/PlayerMenu/PlayerMenu.tsx
@@ -54,7 +54,7 @@ export function PlayerMenu({
           {...triggerProps}
           asChild
         >
-          <Button size="icon" variant="ghost">
+          <Button size="icon" variant="ghost" aria-label="Player options">
             <EllipsisVerticalIcon />
           </Button>
         </DropdownMenuTrigger>

--- a/src/components/Player/components/Playlist/PlaylistItem.tsx
+++ b/src/components/Player/components/Playlist/PlaylistItem.tsx
@@ -122,6 +122,7 @@ export const PlaylistItem = ({
               size="icon"
               variant="ghost"
               className="cursor-pointer"
+              aria-label={isPlaying(id) ? `Pause "${title}"` : `Play "${title}"`}
               onClick={handlePlayClick}
             >
               {isPlaying(id) ? <PauseIcon /> : <PlayIcon />}
@@ -136,6 +137,7 @@ export const PlaylistItem = ({
               size="icon"
               variant="ghost"
               className="cursor-pointer"
+              aria-label={`Remove "${title}" from playlist`}
               onClick={handleRemoveTrackClick}
             >
               <ListMinusIcon />

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -43,12 +43,16 @@ function Card({ className, children, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function CardLink({ href, ...props }: React.ComponentProps<typeof Link>) {
+function CardLink({
+  href,
+  className,
+  ...props
+}: React.ComponentProps<typeof Link>) {
   return (
     <Link
       data-slot="link"
       href={href}
-      className="absolute inset-0 focus-visible:outline-none"
+      className={cn("absolute inset-0 focus-visible:outline-none", className)}
       {...props}
     ></Link>
   );

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -43,12 +43,13 @@ function Card({ className, children, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function CardLink({ href }: React.ComponentProps<typeof Link>) {
+function CardLink({ href, ...props }: React.ComponentProps<typeof Link>) {
   return (
     <Link
       data-slot="link"
       href={href}
       className="absolute inset-0 focus-visible:outline-none"
+      {...props}
     ></Link>
   );
 }


### PR DESCRIPTION
Closes #559 

- Fixes a whole bunch of a11y errors found by the axe DevTools
- Mostly provides discernible labels for links, selects filters
- When menu is expanded there were a few issues as well. Had to remove the role=Menu and label it with aria-labels instead.

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] [Download the Axe Dev Tools Extension](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) if you don't already have it.
- [ ] Go to homepage open the menu and scan for issues, there should be zero issues detected!
- [ ] Run a lighthouse scan against the homepage (checking accessibility only is fine) ensure a score of 100
- [ ] Repeat for Stories, Episodes, Segments, Search, etc.
