### PR TITLE
575: Fix content routes invalid time errors

### DIFF
--- a/src/app/(main)/@browser/episodes/[year]/[month]/[day]/[slug]/_components/EpisodeBrowserUI.tsx
+++ b/src/app/(main)/@browser/episodes/[year]/[month]/[day]/[slug]/_components/EpisodeBrowserUI.tsx
@@ -58,7 +58,7 @@ function useContentInMonth(date: Date) {
 
 export type EpisodeBrowserProps = {
   selected: Date;
-  currentEpisode: Episode;
+  currentEpisode?: Episode;
 };
 
 export default function EpisodeBrowserUI({

--- a/src/app/(main)/@browser/episodes/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(main)/@browser/episodes/[year]/[month]/[day]/[slug]/page.tsx
@@ -6,14 +6,28 @@ export default async function EpisodeBrowser({
 }: {
   params: Promise<Record<"year" | "month" | "day" | "slug", string>>;
 }) {
-  const { slug, year, month, day } = await params;
-  const data = await getCachedEpisode(slug);
+  const {
+    slug,
+    year: yearParam,
+    month: monthParam,
+    day: dayParam,
+  } = await params;
 
-  if (!data) {
+  const year = parseInt(yearParam, 10);
+  const month = parseInt(monthParam, 10);
+  const day = parseInt(dayParam, 10);
+  const hasNanParams = [year, month, day].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
     return null;
   }
 
-  const selected = new Date(`${year}/${month}/${day}`);
+  const data = await getCachedEpisode(slug);
+
+  const selected = new Date(year, month - 1, day, 12);
 
   selected.setHours(12);
 

--- a/src/app/(main)/@browser/segments/[year]/[month]/[day]/[slug]/_components/SegmentBrowserUI.tsx
+++ b/src/app/(main)/@browser/segments/[year]/[month]/[day]/[slug]/_components/SegmentBrowserUI.tsx
@@ -59,7 +59,7 @@ function useContentInMonth(date: Date) {
 
 export type SegmentBrowserProps = {
   selected: Date;
-  currentSegment: Segment;
+  currentSegment?: Segment;
 };
 
 export default function SegmentBrowserUI({

--- a/src/app/(main)/@browser/segments/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(main)/@browser/segments/[year]/[month]/[day]/[slug]/page.tsx
@@ -7,16 +7,28 @@ export default async function SegmentBrowser({
 }: {
   params: Promise<Record<"year" | "month" | "day" | "slug", string>>;
 }) {
-  const { slug, year, month, day } = await params;
-  const data = await getCachedSegment(slug);
+  const {
+    slug,
+    year: yearParam,
+    month: monthParam,
+    day: dayParam,
+  } = await params;
 
-  if (!data) {
+  const year = parseInt(yearParam, 10);
+  const month = parseInt(monthParam, 10);
+  const day = parseInt(dayParam, 10);
+  const hasNanParams = [year, month, day].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
     return null;
   }
 
-  const selected = new Date(`${year}/${month}/${day}`);
+  const data = await getCachedSegment(slug);
 
-  selected.setHours(12);
+  const selected = new Date(year, month - 1, day, 12);
 
   // Do not render browser for segments published before May 1, 2024.
   // See issue: https://github.com/PRX/The-World-CMS-Wordpress/issues/54

--- a/src/app/(main)/@hero/episodes/[year]/[month]/[day]/page.tsx
+++ b/src/app/(main)/@hero/episodes/[year]/[month]/[day]/page.tsx
@@ -10,14 +10,20 @@ export default async function EpisodesByDateHero({
 }: {
   params: Promise<Record<"year" | "month" | "day", string>>;
 }) {
-  const { year, month, day } = await params;
+  const { year: yearParam, month: monthParam, day: dayParam } = await params;
 
-  const date = new Date(
-    parseInt(year, 10),
-    parseInt(month, 10) - 1,
-    parseInt(day, 10),
-    12,
+  const year = parseInt(yearParam, 10);
+  const month = parseInt(monthParam, 10);
+  const day = parseInt(dayParam, 10);
+  const hasNanParams = [year, month, day].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
   );
+
+  if (hasNanParams) {
+    return null;
+  }
+  const date = new Date(year, month - 1, day, 12);
 
   return (
     <ExplorerHero>

--- a/src/app/(main)/@hero/episodes/[year]/[month]/page.tsx
+++ b/src/app/(main)/@hero/episodes/[year]/[month]/page.tsx
@@ -10,9 +10,20 @@ export default async function EpisodesByMonthHero({
 }: {
   params: Promise<Record<"year" | "month", string>>;
 }) {
-  const { year, month } = await params;
+  const { year: yearParam, month: monthParam } = await params;
 
-  const date = new Date(parseInt(year, 10), parseInt(month, 10) - 1, 1, 12);
+  const year = parseInt(yearParam, 10);
+  const month = parseInt(monthParam, 10);
+  const hasNanParams = [year, month].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
+    return null;
+  }
+
+  const date = new Date(year, month - 1, 1, 12);
 
   return (
     <ExplorerHero>

--- a/src/app/(main)/@hero/episodes/[year]/page.tsx
+++ b/src/app/(main)/@hero/episodes/[year]/page.tsx
@@ -10,9 +10,16 @@ export default async function EpisodesByYearHero({
 }: {
   params: Promise<Record<"year", string>>;
 }) {
-  const { year } = await params;
+  const { year: yearParam } = await params;
 
-  const date = new Date(parseInt(year, 10), 1, 1, 12);
+  const year = parseInt(yearParam, 10);
+  const hasNanParams = Number.isNaN(year);
+
+  if (hasNanParams) {
+    return null;
+  }
+
+  const date = new Date(year, 1, 1, 12);
 
   return (
     <ExplorerHero>

--- a/src/app/(main)/@hero/segments/[year]/[month]/[day]/page.tsx
+++ b/src/app/(main)/@hero/segments/[year]/[month]/[day]/page.tsx
@@ -10,14 +10,20 @@ export default async function SegmentsByDateHero({
 }: {
   params: Promise<Record<"year" | "month" | "day", string>>;
 }) {
-  const { year, month, day } = await params;
+  const { year: yearParam, month: monthParam, day: dayParam } = await params;
 
-  const date = new Date(
-    parseInt(year, 10),
-    parseInt(month, 10) - 1,
-    parseInt(day, 10),
-    12,
+  const year = parseInt(yearParam, 10);
+  const month = parseInt(monthParam, 10);
+  const day = parseInt(dayParam, 10);
+  const hasNanParams = [year, month, day].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
   );
+
+  if (hasNanParams) {
+    return null;
+  }
+  const date = new Date(year, month - 1, day, 12);
 
   return (
     <ExplorerHero>

--- a/src/app/(main)/@hero/segments/[year]/[month]/page.tsx
+++ b/src/app/(main)/@hero/segments/[year]/[month]/page.tsx
@@ -10,9 +10,20 @@ export default async function SegmentsByMonthHero({
 }: {
   params: Promise<Record<"year" | "month", string>>;
 }) {
-  const { year, month } = await params;
+  const { year: yearParam, month: monthParam } = await params;
 
-  const date = new Date(parseInt(year, 10), parseInt(month, 10) - 1, 1, 12);
+  const year = parseInt(yearParam, 10);
+  const month = parseInt(monthParam, 10);
+  const hasNanParams = [year, month].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
+    return null;
+  }
+
+  const date = new Date(year, month - 1, 1, 12);
 
   return (
     <ExplorerHero>

--- a/src/app/(main)/@hero/segments/[year]/page.tsx
+++ b/src/app/(main)/@hero/segments/[year]/page.tsx
@@ -10,9 +10,16 @@ export default async function SegmentsByYearHero({
 }: {
   params: Promise<Record<"year", string>>;
 }) {
-  const { year } = await params;
+  const { year: yearParam } = await params;
 
-  const date = new Date(parseInt(year, 10), 1, 1, 12);
+  const year = parseInt(yearParam, 10);
+  const hasNanParams = Number.isNaN(year);
+
+  if (hasNanParams) {
+    return null;
+  }
+
+  const date = new Date(year, 1, 1, 12);
 
   return (
     <ExplorerHero>

--- a/src/app/(main)/@hero/stories/[year]/[month]/[day]/page.tsx
+++ b/src/app/(main)/@hero/stories/[year]/[month]/[day]/page.tsx
@@ -10,14 +10,20 @@ export default async function StoriesByDateHero({
 }: {
   params: Promise<Record<"year" | "month" | "day", string>>;
 }) {
-  const { year, month, day } = await params;
+  const { year: yearParam, month: monthParam, day: dayParam } = await params;
 
-  const date = new Date(
-    parseInt(year, 10),
-    parseInt(month, 10) - 1,
-    parseInt(day, 10),
-    12,
+  const year = parseInt(yearParam, 10);
+  const month = parseInt(monthParam, 10);
+  const day = parseInt(dayParam, 10);
+  const hasNanParams = [year, month, day].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
   );
+
+  if (hasNanParams) {
+    return null;
+  }
+  const date = new Date(year, month - 1, day, 12);
 
   return (
     <ExplorerHero>

--- a/src/app/(main)/@hero/stories/[year]/[month]/page.tsx
+++ b/src/app/(main)/@hero/stories/[year]/[month]/page.tsx
@@ -10,9 +10,20 @@ export default async function StoriesByMonthHero({
 }: {
   params: Promise<Record<"year" | "month", string>>;
 }) {
-  const { year, month } = await params;
+  const { year: yearParam, month: monthParam } = await params;
 
-  const date = new Date(parseInt(year, 10), parseInt(month, 10) - 1, 1, 12);
+  const year = parseInt(yearParam, 10);
+  const month = parseInt(monthParam, 10);
+  const hasNanParams = [year, month].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
+    return null;
+  }
+
+  const date = new Date(year, month - 1, 1, 12);
 
   return (
     <ExplorerHero>

--- a/src/app/(main)/@hero/stories/[year]/page.tsx
+++ b/src/app/(main)/@hero/stories/[year]/page.tsx
@@ -10,9 +10,16 @@ export default async function StoriesByYearHero({
 }: {
   params: Promise<Record<"year", string>>;
 }) {
-  const { year } = await params;
+  const { year: yearParam } = await params;
 
-  const date = new Date(parseInt(year, 10), 1, 1, 12);
+  const year = parseInt(yearParam, 10);
+  const hasNanParams = Number.isNaN(year);
+
+  if (hasNanParams) {
+    return null;
+  }
+
+  const date = new Date(year, 1, 1, 12);
 
   return (
     <ExplorerHero>

--- a/src/app/(main)/@search/episodes/[year]/[month]/[day]/page.tsx
+++ b/src/app/(main)/@search/episodes/[year]/[month]/[day]/page.tsx
@@ -12,6 +12,15 @@ export default async function EpisodesByDateSearch({
   const year = parseInt(yearParam, 10);
   const month = parseInt(monthParam, 10);
   const day = parseInt(dayParam, 10);
+  const hasNanParams = [year, month, day].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
+    return null;
+  }
+
   return (
     <SearchInput
       searchContext={{

--- a/src/app/(main)/@search/episodes/[year]/[month]/page.tsx
+++ b/src/app/(main)/@search/episodes/[year]/[month]/page.tsx
@@ -11,6 +11,15 @@ export default async function EpisodesByMonthSearch({
 
   const year = parseInt(yearParam, 10);
   const month = parseInt(monthParam, 10);
+  const hasNanParams = [year, month].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
+    return null;
+  }
+
   return (
     <SearchInput
       searchContext={{

--- a/src/app/(main)/@search/episodes/[year]/page.tsx
+++ b/src/app/(main)/@search/episodes/[year]/page.tsx
@@ -9,6 +9,12 @@ export default async function EpisodesByYearSearch({
   const { year: yearParam } = await params;
 
   const year = parseInt(yearParam, 10);
+  const hasNanParams = Number.isNaN(year);
+
+  if (hasNanParams) {
+    return null;
+  }
+
   return (
     <SearchInput
       searchContext={{

--- a/src/app/(main)/@search/segments/[year]/[month]/[day]/page.tsx
+++ b/src/app/(main)/@search/segments/[year]/[month]/[day]/page.tsx
@@ -12,6 +12,15 @@ export default async function SegmentsByDateSearch({
   const year = parseInt(yearParam, 10);
   const month = parseInt(monthParam, 10);
   const day = parseInt(dayParam, 10);
+  const hasNanParams = [year, month, day].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
+    return null;
+  }
+
   return (
     <SearchInput
       searchContext={{

--- a/src/app/(main)/@search/segments/[year]/[month]/page.tsx
+++ b/src/app/(main)/@search/segments/[year]/[month]/page.tsx
@@ -11,6 +11,15 @@ export default async function SegmentsByMonthSearch({
 
   const year = parseInt(yearParam, 10);
   const month = parseInt(monthParam, 10);
+  const hasNanParams = [year, month].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
+    return null;
+  }
+
   return (
     <SearchInput
       searchContext={{

--- a/src/app/(main)/@search/segments/[year]/page.tsx
+++ b/src/app/(main)/@search/segments/[year]/page.tsx
@@ -9,6 +9,12 @@ export default async function SegmentsByYearSearch({
   const { year: yearParam } = await params;
 
   const year = parseInt(yearParam, 10);
+  const hasNanParams = Number.isNaN(year);
+
+  if (hasNanParams) {
+    return null;
+  }
+
   return (
     <SearchInput
       searchContext={{

--- a/src/app/(main)/@search/stories/[year]/[month]/[day]/page.tsx
+++ b/src/app/(main)/@search/stories/[year]/[month]/[day]/page.tsx
@@ -12,6 +12,15 @@ export default async function StoriesByDateSearch({
   const year = parseInt(yearParam, 10);
   const month = parseInt(monthParam, 10);
   const day = parseInt(dayParam, 10);
+  const hasNanParams = [year, month, day].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
+    return null;
+  }
+
   return (
     <SearchInput
       searchContext={{

--- a/src/app/(main)/@search/stories/[year]/[month]/page.tsx
+++ b/src/app/(main)/@search/stories/[year]/[month]/page.tsx
@@ -9,8 +9,19 @@ export default async function StoriesByMonthSearch({
 }) {
   const { year: yearParam, month: monthParam } = await params;
 
+  console.log(yearParam, monthParam);
+
   const year = parseInt(yearParam, 10);
   const month = parseInt(monthParam, 10);
+  const hasNanParams = [year, month].reduce(
+    (a, v) => a || Number.isNaN(v),
+    false,
+  );
+
+  if (hasNanParams) {
+    return null;
+  }
+
   return (
     <SearchInput
       searchContext={{

--- a/src/app/(main)/@search/stories/[year]/[month]/page.tsx
+++ b/src/app/(main)/@search/stories/[year]/[month]/page.tsx
@@ -9,8 +9,6 @@ export default async function StoriesByMonthSearch({
 }) {
   const { year: yearParam, month: monthParam } = await params;
 
-  console.log(yearParam, monthParam);
-
   const year = parseInt(yearParam, 10);
   const month = parseInt(monthParam, 10);
   const hasNanParams = [year, month].reduce(

--- a/src/app/(main)/@search/stories/[year]/page.tsx
+++ b/src/app/(main)/@search/stories/[year]/page.tsx
@@ -9,6 +9,12 @@ export default async function StoriesByYearSearch({
   const { year: yearParam } = await params;
 
   const year = parseInt(yearParam, 10);
+  const hasNanParams = [year].reduce((a, v) => a || Number.isNaN(v), false);
+
+  if (hasNanParams) {
+    return null;
+  }
+
   return (
     <SearchInput
       searchContext={{

--- a/src/app/(main)/categories/[slug]/page.tsx
+++ b/src/app/(main)/categories/[slug]/page.tsx
@@ -29,7 +29,7 @@ import { convertSeoToMetadata } from "@/lib/parse/seo";
 import { sanitizeSearchParamsForSiteSearch } from "@/lib/sanitize";
 
 type Props = {
-  params: Promise<Record<"slugs", string[]>>;
+  params: Promise<Record<"slug", string>>;
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
@@ -59,8 +59,7 @@ export async function generateMetadata(
   { params }: Props,
   parent: ResolvingMetadata,
 ): Promise<Metadata> {
-  const { slugs } = await params;
-  const slug = slugs.pop() || "";
+  const { slug } = await params;
   const metadata = await parent.then((r) => r as Metadata);
 
   // fetch post information
@@ -88,8 +87,7 @@ export async function generateMetadata(
 }
 
 export default async function TaxonomyPage({ params, searchParams }: Props) {
-  const { slugs } = await params;
-  const slug = slugs.pop() || "";
+  const { slug } = await params;
   const resolvedSearchParams = await searchParams;
   let data: Awaited<ReturnType<typeof getCachedCategory>>;
 

--- a/src/app/(main)/categories/page.tsx
+++ b/src/app/(main)/categories/page.tsx
@@ -90,10 +90,13 @@ export default async function CategoriesPage({
     where: {
       ...(search && {
         search,
-        orderby: TermObjectsConnectionOrderbyEnum.Count,
-        order: OrderEnum.Desc,
       }),
-      ...(!search && { parent: 0, exclude: ["1"] }),
+      ...(!search && {
+        parent: 0,
+        exclude: ["1"],
+      }),
+      orderby: TermObjectsConnectionOrderbyEnum.Count,
+      order: OrderEnum.Desc,
     },
   });
 
@@ -176,7 +179,9 @@ export default async function CategoriesPage({
                     </div>
                   )}
                 </div>
-                {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+                {!!href && (
+                  <CardLink href={href} aria-label={name ?? undefined} />
+                )}
               </header>
               <div className="row-start-2 col-span-2 overflow-hidden">
                 <CardCarousel
@@ -252,7 +257,12 @@ export default async function CategoriesPage({
                           key={id}
                         >
                           <Card className={cn("")}>
-                            {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                            {linkHref && (
+                              <CardLink
+                                href={linkHref}
+                                aria-label={title ?? undefined}
+                              />
+                            )}
                             {imageSrc && !isPlaceholderImage && (
                               <CardImage data-image-id={imageId}>
                                 <Image

--- a/src/lib/generate/string/generateAudioUrl.ts
+++ b/src/lib/generate/string/generateAudioUrl.ts
@@ -23,9 +23,8 @@ export const generateAudioUrl = (audioUrl: string) => {
     }
 
     return url.toString();
-  } catch (error) {
-    console.debug(audioUrl);
-    console.debug(error);
+  } catch (err) {
+    console.error(err, { err, audioUrl });
     return undefined;
   }
 };

--- a/src/lib/routing/redirectToValidDatedRoute.ts
+++ b/src/lib/routing/redirectToValidDatedRoute.ts
@@ -9,7 +9,7 @@ export function redirectToValidDatedRoute(
   const { year, month, day } = params;
   const monthPadded = month && padStart(month.replace(/^0+/, "0"), 2, "0");
   const dayPadded = day && padStart(day.replace(/^0+/, "0"), 2, "0");
-  const now = new Date("2025/04");
+  const now = new Date();
   const nowYear = `${now.getFullYear()}`;
   const valid: typeof params = {
     year,
@@ -32,16 +32,16 @@ export function redirectToValidDatedRoute(
   // - 2 digits, padded with "0"
   // - 1 through 12
   if (monthPadded && !/^0?\d$|^1[012]$/.test(monthPadded)) {
-    // At this point, invalid values will be larger than 12, so cap at 12.
-    valid.month = "12";
+    // At this point, invalid values will be larger than 12, so cap at current month.
+    valid.month = padStart(`${now.getMonth() + 1}`, 2, "0");
   }
 
   // Validate day:
   // - 2 digits, padded with "0"
   // - 1 through 31
   if (dayPadded && !/^0?\d$|^1\d$|^2\d$|^3[01]$/.test(dayPadded)) {
-    // At this point, invalid values will be larger than 31, so cap at 31.
-    valid.day = "31";
+    // At this point, invalid values will be larger than 31, so cap at current day.
+    valid.day = padStart(`${now.getDate()}`, 2, "0");
   }
 
   // When we have a valid day, ensure it is capped at the last day of the valid month.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,6 +5,8 @@ import { type NextRequest, NextResponse, type ProxyConfig } from "next/server";
 export function proxy(request: NextRequest) {
   const url = request.nextUrl.clone();
 
+  console.debug("Running proxy on route.", url.pathname);
+
   /**
    * Redirect landing page episodes flag parameter to new search filter param.
    * Example: /programs/the-world?v=episodes to /programs/the-world?sf=CAM
@@ -27,6 +29,9 @@ export function proxy(request: NextRequest) {
     url.pathname.match(
       /^\/(?<contentTypePlural>episodes|segments|stories)\/(?<pubDate>\d{4}-\d{2}-\d{2})\/(?<slug>[\w_-]+)/i,
     )?.groups || {};
+
+  console.debug(contentTypePlural, pubDate, slug);
+
   if (contentTypePlural && pubDate && slug) {
     const newPath = `/${contentTypePlural}/${pubDate.split("-").join("/")}/${slug}`;
 
@@ -46,7 +51,7 @@ export const config: ProxyConfig = {
     },
     // Legacy content route: `/[content_type_plural]/[date]/[slug]`
     {
-      source: "/(episodes|segments|stories)/(\\d{4}-\\d{2}-\\d{2})/([\\w_-]+)",
+      source: "/(episodes|segments|stories)/(\\d{4}-\\d{2}-\\d{2})/(.+)",
       locale: false,
     },
   ],

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,8 +5,6 @@ import { type NextRequest, NextResponse, type ProxyConfig } from "next/server";
 export function proxy(request: NextRequest) {
   const url = request.nextUrl.clone();
 
-  console.debug("Running proxy on route.", url.pathname);
-
   /**
    * Redirect landing page episodes flag parameter to new search filter param.
    * Example: /programs/the-world?v=episodes to /programs/the-world?sf=CAM
@@ -29,8 +27,6 @@ export function proxy(request: NextRequest) {
     url.pathname.match(
       /^\/(?<contentTypePlural>episodes|segments|stories)\/(?<pubDate>\d{4}-\d{2}-\d{2})\/(?<slug>[\w_-]+)/i,
     )?.groups || {};
-
-  console.debug(contentTypePlural, pubDate, slug);
 
   if (contentTypePlural && pubDate && slug) {
     const newPath = `/${contentTypePlural}/${pubDate.split("-").join("/")}/${slug}`;


### PR DESCRIPTION
Closes #575 

- adds validation to routes that include date part segments to ensure the parm values are numbers before using value to create a Date object
- widens slug matching pattern of routs with full date segments on proxy

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Go to `/episodes/news/rss.xml`.
- [x] Ensure your are redirected to `/episodes/2026/06` and page loads.
- [x] Go to `/stories/2016-01-30/Referral%26amp;c_src2=website-footer%22`.
- [x] Ensure you are redirected to `/stories/2016/01/30/Referral` and pages loads. 404 error expected. Should not cause a server error.
