### PR TITLE
577: Homepage latest headlines header changed to "From Our Newsroom"

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -75,7 +75,7 @@ export default async function Home() {
   // Prepend Latest Headlines carousel config.
   carouselsData.unshift({
     key: id,
-    header: <>Featured Headlines</>,
+    header: <>From Our Newsroom</>,
     featuredPostsNodes,
     postsNodes,
   });
@@ -202,7 +202,12 @@ export default async function Home() {
                             key={id}
                           >
                             <Card className={cn("")}>
-                              {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                              {linkHref && (
+                                <CardLink
+                                  href={linkHref}
+                                  aria-label={title ?? undefined}
+                                />
+                              )}
                               {imageSrc && (
                                 <CardImage>
                                   <Image
@@ -322,7 +327,10 @@ export default async function Home() {
                         >
                           <Card>
                             {contributorLink && (
-                              <CardLink href={contributorLink} aria-label={name ?? undefined} />
+                              <CardLink
+                                href={contributorLink}
+                                aria-label={name ?? undefined}
+                              />
                             )}
                             {imageSrc && (
                               <CardImage>


### PR DESCRIPTION
Closes #577 

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Ensure latest headlines carousel heading is "From Our Newsroom".
