### PR TITLE
576: Add HtmlContent replacer to remove legacy entity embeds

### DIFF
--- a/src/components/HtmlContent/HtmlContent.tsx
+++ b/src/components/HtmlContent/HtmlContent.tsx
@@ -22,6 +22,7 @@ import {
   fixBlockInParagraph,
   fixNestedSpans,
   removeImgWIthRelativeSrc,
+  removeLegacyEntityEmbed,
   //   instagramEmbed,
   removeUnsupportedElementTypes,
   unwrapLegacyWrappers,
@@ -66,6 +67,7 @@ export const HtmlContent = ({
 
         removeUnsupportedElementTypes,
         removeImgWIthRelativeSrc,
+        removeLegacyEntityEmbed,
         fbRootRemove,
         unwrapLegacyWrappers,
 

--- a/src/components/HtmlContent/replacers/index.ts
+++ b/src/components/HtmlContent/replacers/index.ts
@@ -3,5 +3,6 @@ export * from "./fbRootRemove";
 export * from "./fixBlockInParagraph";
 export * from "./fixNestedSpans";
 export * from "./removeImgWIthRelativeSrc";
+export * from "./removeLegacyEntityEmbed";
 export * from "./removeUnsupportedElementTypes";
 export * from "./unwrapLegacyWrappers";

--- a/src/components/HtmlContent/replacers/removeLegacyEntityEmbed.tsx
+++ b/src/components/HtmlContent/replacers/removeLegacyEntityEmbed.tsx
@@ -1,0 +1,15 @@
+import { replaceElement } from "@/app/(main)/_components/ContentBody/replacers";
+import { has } from "lodash";
+
+/**
+ * @file removeLegacyEntityEmbed.ts
+ * Remove placeholder div elements for legacy entity embeds.
+ */
+export const removeLegacyEntityEmbed = replaceElement("div", (el) => {
+  if (has(el.attribs, "data-entity-type")) {
+    // biome-ignore lint/complexity/noUselessFragments: See docs: https://github.com/remarkablemark/html-react-parser?tab=readme-ov-file#replace-and-remove-element
+    return <></>;
+  }
+
+  return undefined;
+});


### PR DESCRIPTION
Closes #576 

- remove entity embed placeholder elements from rendered HTML content.

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to http://localhost:3000/stories/2020/02/03/china-accuses-us-whipping-panic-over-virus-stocks-tumble

> ...then...

- [ ] Ensure entity embed placeholder text isn't rendered in the content.

> Find other posts to test by searching for posts containing `data-entity-id=`.
