### PR TITLE
fix(embed): validate audio id param

### DIFF
--- a/next.headers.ts
+++ b/next.headers.ts
@@ -31,7 +31,7 @@ export const headers: NextConfig["headers"] = async () => {
             },
             {
               key: "Content-Security-Policy",
-              value: "frame-ancestors https://admin.theworld.org",
+              value: "frame-ancestors 'self' https://admin.theworld.org",
             },
           ],
         },

--- a/next.headers.ts
+++ b/next.headers.ts
@@ -1,45 +1,49 @@
 import type { NextConfig } from "next";
 
+const deploymentEnv = process.env.NODE_ENV || "development";
+
 export const headers: NextConfig["headers"] = async () => {
-  return [
-    {
-      source: "/(.*)",
-      headers: [
+  return deploymentEnv !== "development"
+    ? [
         {
-          key: "Cache-Control",
-          value:
-            "public, max-age=3600, s-maxage=3600, stale-while-revalidate=300",
+          source: "/(.*)",
+          headers: [
+            {
+              key: "Strict-Transport-Security",
+              value: "max-age=63072000; includeSubDomains; preload",
+            },
+            {
+              key: "X-XSS-Protection",
+              value: "1; mode=block",
+            },
+            {
+              key: "X-Content-Type-Options",
+              value: "nosniff",
+            },
+            {
+              key: "Permissions-Policy",
+              value: "interest-cohort=()",
+            },
+            {
+              key: "Cache-Control",
+              value:
+                "public, max-age=3600, s-maxage=3600, stale-while-revalidate=300",
+            },
+            {
+              key: "Content-Security-Policy",
+              value: "frame-ancestors https://admin.theworld.org",
+            },
+          ],
         },
         {
-          key: "Strict-Transport-Security",
-          value: "max-age=63072000; includeSubDomains; preload",
+          source: "/_next/static/(.*)",
+          headers: [
+            {
+              key: "Cache-Control",
+              value: "public, max-age=31536000, immutable",
+            },
+          ],
         },
-        {
-          key: "Content-Security-Policy",
-          value: "frame-ancestors https://admin.theworld.org",
-        },
-        {
-          key: "X-XSS-Protection",
-          value: "1; mode=block",
-        },
-        {
-          key: "X-Content-Type-Options",
-          value: "nosniff",
-        },
-        {
-          key: "Permissions-Policy",
-          value: "interest-cohort=()",
-        },
-      ],
-    },
-    {
-      source: "/_next/static/(.*)",
-      headers: [
-        {
-          key: "Cache-Control",
-          value: "public, max-age=31536000, immutable",
-        },
-      ],
-    },
-  ];
+      ]
+    : [];
 };

--- a/src/app/(main)/_components/CtaRegion/_components/NewsletterCta.tsx
+++ b/src/app/(main)/_components/CtaRegion/_components/NewsletterCta.tsx
@@ -207,11 +207,8 @@ export default function NewsletterCta({
                 }}
                 value="agree"
               />
-              <FieldContent>
-                <FieldLabel
-                  htmlFor="cta-newsletter-opt-in"
-                  className="whitespace-nowrap"
-                >
+              <FieldContent className="inline-block">
+                <FieldLabel htmlFor="cta-newsletter-opt-in" className="w-auto">
                   <em>
                     I have read and agree to your{" "}
                     <Link

--- a/src/app/(main)/_components/MainUI/MainUI.tsx
+++ b/src/app/(main)/_components/MainUI/MainUI.tsx
@@ -311,7 +311,7 @@ export default function MainUI({
           </div>
         </div>
 
-        <div
+        <nav
           id="main-menu"
           aria-label="Main navigation"
           className={cn(
@@ -405,7 +405,7 @@ export default function MainUI({
               </p>
             </div>
           </div>
-        </div>
+        </nav>
 
         <div
           ref={uiBottomRef}
@@ -445,7 +445,9 @@ export default function MainUI({
                           className="rounded-full cursor-pointer"
                           size="icon"
                           variant="ghost"
-                          aria-label={isPlaylistOpen ? "Hide Playlist" : "Show Playlist"}
+                          aria-label={
+                            isPlaylistOpen ? "Hide Playlist" : "Show Playlist"
+                          }
                           onClick={handlePlaylistToggle}
                         >
                           <ChevronUpIcon

--- a/src/app/embed/audio/[id]/page.tsx
+++ b/src/app/embed/audio/[id]/page.tsx
@@ -69,9 +69,16 @@ export default async function AudioEmbed({
   params: Promise<{ id: string }>;
 }) {
   const resolvedParams = await params;
-  const { id } = resolvedParams;
+  const { id: idParam } = resolvedParams;
 
-  if (!id) {
+  if (!idParam?.length) {
+    notFound();
+  }
+
+  const id = decodeURIComponent(idParam);
+  const isValidId = /^[\w=]+$/.test(id);
+
+  if (!isValidId) {
     notFound();
   }
 
@@ -95,7 +102,7 @@ export default async function AudioEmbed({
     }
   }
 
-  const audio = await getCachedAudioEmbedData(decodeURIComponent(id));
+  const audio = await getCachedAudioEmbedData(id);
 
   return (
     audio && (
@@ -119,7 +126,7 @@ export default async function AudioEmbed({
                 "**:data-[slot=slider-range]:bg-white",
                 "[&>button]:size-8 [&>button>svg]:size-6",
               )}
-              muteButtonProps={{ disableTooltip: true }}
+              disableTooltips
             />
           </div>
           <div className="row-span-2 grid place-items-stretch aspect-square p-0 z-1">

--- a/src/components/HtmlContent/replacers/removeImgWIthRelativeSrc.tsx
+++ b/src/components/HtmlContent/replacers/removeImgWIthRelativeSrc.tsx
@@ -1,11 +1,15 @@
 import { replaceElement } from "@/app/(main)/_components/ContentBody/replacers";
+import { has } from "lodash";
 
 /**
  * @file removeImgWithRelativeSrc.ts
  * Remove img tags with relative src URL's.
  */
 export const removeImgWIthRelativeSrc = replaceElement("img", (el) => {
-  if (el.attribs.src.startsWith("/") && !el.attribs.src.startsWith("//:")) {
+  if (
+    !has(el.attribs, "src") ||
+    (el.attribs.src.startsWith("/") && !el.attribs.src.startsWith("//:"))
+  ) {
     // biome-ignore lint/complexity/noUselessFragments: See docs: https://github.com/remarkablemark/html-react-parser?tab=readme-ov-file#replace-and-remove-element
     return <></>;
   }

--- a/src/components/Player/components/EmbedModalContent/EmbedModalContent.tsx
+++ b/src/components/Player/components/EmbedModalContent/EmbedModalContent.tsx
@@ -74,7 +74,7 @@ export function EmbedModalContent({
           src={`/embed/audio/${embedUrlId}`}
           height="50"
           width="100%"
-          className="my-4 bg-transparent"
+          className="my-4 bg-navy-blue rounded-sm"
           allowTransparency
           style={{ colorScheme: "auto" }}
         />

--- a/src/components/Player/components/PlayerMenu/PlayerMenu.tsx
+++ b/src/components/Player/components/PlayerMenu/PlayerMenu.tsx
@@ -37,8 +37,10 @@ export function PlayerMenu({
   contentProps,
   ...props
 }: PlayerMenuProps) {
-  const { className: triggerClassName } = triggerProps || {};
-  const { className: contentClassName } = contentProps || {};
+  const { className: triggerClassName, ...otherTriggerProps } =
+    triggerProps || {};
+  const { className: contentClassName, ...otherContentProps } =
+    contentProps || {};
   const { state, clearPlaylist, removeTrack } = useContext(PlayerContext);
   const { currentTrackIndex, tracks } = state;
   const currentTrack =
@@ -51,7 +53,7 @@ export function PlayerMenu({
       <DropdownMenu {...props}>
         <DropdownMenuTrigger
           className={cn("rounded-full cursor-pointer", triggerClassName)}
-          {...triggerProps}
+          {...otherTriggerProps}
           asChild
         >
           <Button size="icon" variant="ghost" aria-label="Player options">
@@ -60,7 +62,7 @@ export function PlayerMenu({
         </DropdownMenuTrigger>
         <DropdownMenuContent
           className={cn("", contentClassName)}
-          {...contentProps}
+          {...otherContentProps}
         >
           <DropdownMenuGroup>
             <DropdownMenuItem
@@ -107,7 +109,7 @@ export function PlayerMenu({
       {/* Embed Dialog */}
       <Drawer open={isEmbedDialogOpen} onOpenChange={setIsEmbedDialogOpen}>
         <DrawerContent
-          className="z-(--z-ui) pb-8"
+          className="z-(--z-ui) pb-[calc(var(--gutter-bottom)+--spacing(4))]"
           aria-describedby="menu-embed-audio"
         >
           <DrawerHeader>

--- a/src/components/Player/components/VolumeControls/VolumeControls.tsx
+++ b/src/components/Player/components/VolumeControls/VolumeControls.tsx
@@ -20,13 +20,13 @@ import { Slider } from "@/components/ui/slider";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 
 export type VolumeControlsProps = React.ComponentProps<"div"> & {
-  muteButtonProps?: React.ComponentProps<typeof Button> & {
-    disableTooltip?: boolean;
-  };
+  disableTooltips?: boolean;
+  muteButtonProps?: React.ComponentProps<typeof Button>;
 };
 
 export const VolumeControls: React.FC<VolumeControlsProps> = ({
   className,
+  disableTooltips,
   muteButtonProps,
   ...other
 }: VolumeControlsProps) => {
@@ -34,7 +34,8 @@ export const VolumeControls: React.FC<VolumeControlsProps> = ({
   const { volume = 0.8 } = audioElm || {};
   const [vol, setVol] = useState(volume);
   const [muted, setMuted] = useState(!!audioElm?.muted);
-  const { disableTooltip, ...otherMuteButtonProps } = muteButtonProps || {};
+  const { className: muteButtonClassName, ...otherMuteButtonProps } =
+    muteButtonProps || {};
   let VolumeIcon = Volume2Icon;
 
   if (volume === 0) {
@@ -83,9 +84,30 @@ export const VolumeControls: React.FC<VolumeControlsProps> = ({
     };
   }, [audioElm, vol, muted]);
 
+  const renderSlider = () => (
+    <Slider
+      className={cn(
+        "w-25 pl-2 cursor-pointer transition-all transition-discrete",
+        "media-hover:hidden media-hover:animate-out media-hover:fade-out-0",
+        // "group-hover/volume:grid group-focus-within/volume:opacity-100",
+        // "group-hover/volume:translate-0 group-focus-within/volume:translate-0",
+        "group-hover/volume:grid group-hover/volume:animate-in group-hover/volume:fade-in-100",
+      )}
+      max={1}
+      step={0.01}
+      value={[vol]}
+      onValueChange={handleSliderChange}
+      aria-label="Volume"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={vol * 100}
+      aria-valuetext={`${vol * 100}%`}
+    />
+  );
+
   const renderMuteButton = () => (
     <Button
-      className="rounded-full cursor-pointer"
+      className={cn("rounded-full cursor-pointer", muteButtonClassName)}
       size="icon"
       variant="ghost"
       {...otherMuteButtonProps}
@@ -109,44 +131,30 @@ export const VolumeControls: React.FC<VolumeControlsProps> = ({
         className,
       )}
     >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Slider
-            className={cn(
-              "w-25 pl-2 cursor-pointer transition-all transition-discrete",
-              "media-hover:hidden media-hover:animate-out media-hover:fade-out-0",
-              // "group-hover/volume:grid group-focus-within/volume:opacity-100",
-              // "group-hover/volume:translate-0 group-focus-within/volume:translate-0",
-              "group-hover/volume:grid group-hover/volume:animate-in group-hover/volume:fade-in-100",
-            )}
-            max={1}
-            step={0.01}
-            value={[vol]}
-            onValueChange={handleSliderChange}
-            aria-label="Volume"
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-valuenow={vol * 100}
-            aria-valuetext={`${vol * 100}%`}
-          />
-        </TooltipTrigger>
-        <TooltipContent className="flex gap-x-2 items-center z-(--z-ui-player)">
-          Volume{" "}
-          <KbdGroup>
-            <Kbd>-</Kbd>,<Kbd>=</Kbd>
-          </KbdGroup>
-        </TooltipContent>
-      </Tooltip>
-
-      {disableTooltip ? (
-        renderMuteButton()
+      {disableTooltips ? (
+        <>
+          {renderSlider()}
+          {renderMuteButton()}
+        </>
       ) : (
-        <Tooltip>
-          <TooltipTrigger asChild>{renderMuteButton()}</TooltipTrigger>
-          <TooltipContent className="flex gap-x-2 items-center z-(--z-ui-player)">
-            {muted ? "Unmute" : "Mute"} <Kbd>M</Kbd>
-          </TooltipContent>
-        </Tooltip>
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>{renderSlider()}</TooltipTrigger>
+            <TooltipContent className="flex gap-x-2 items-center z-(--z-ui-player)">
+              Volume{" "}
+              <KbdGroup>
+                <Kbd>-</Kbd>,<Kbd>=</Kbd>
+              </KbdGroup>
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>{renderMuteButton()}</TooltipTrigger>
+            <TooltipContent className="flex gap-x-2 items-center z-(--z-ui-player)">
+              {muted ? "Unmute" : "Mute"} <Kbd>M</Kbd>
+            </TooltipContent>
+          </Tooltip>
+        </>
       )}
     </div>
   );

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -6,6 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/util/css";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { uniqueId } from "lodash";
 
 function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
   return (
@@ -46,7 +47,7 @@ function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="field-group"
       className={cn(
-        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
         className,
       )}
       {...props}
@@ -116,7 +117,7 @@ function FieldLabel({
       data-slot="field-label"
       className={cn(
         "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
-        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border *:data-[slot=field]:p-4",
         "has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10",
         className,
       )}
@@ -143,7 +144,7 @@ function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
     <div
       data-slot="field-description"
       className={cn(
-        "text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "text-muted-foreground text-sm leading-normal font-normal group-has-data-[orientation=horizontal]/field:text-balance",
         "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
         "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
         className,
@@ -208,15 +209,15 @@ function FieldError({
       ...new Map(errors.map((error) => [error?.message, error])).values(),
     ];
 
-    if (uniqueErrors?.length == 1) {
+    if (uniqueErrors?.length === 1) {
       return uniqueErrors[0]?.message;
     }
 
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
         {uniqueErrors.map(
-          (error, index) =>
-            error?.message && <li key={index}>{error.message}</li>,
+          (error) =>
+            error?.message && <li key={uniqueId()}>{error.message}</li>,
         )}
       </ul>
     );


### PR DESCRIPTION
- prevent bad audio embed URL's from throwing errors, should 404
- do not configure headers in development (breaks hot reloading of changes)
- remove tooltips from audio embed volume controls
- fix bottom padding of embed modal content
- fix content overflow of newsletter cta on thin viewport sizes

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.

> ...then...

- [x] Go to http://localhost:3000/embed/audio/${x}
- [x] Ensure you get a 404 page instead of a server error
- [x] Go to http://localhost:3000
- [x] Ensure newsletter CTA content doesn't overflow in smaller/thinner mobile devices (Galaxy Z Fold)
- [x] Play some audio then open the player option > Embed Audio
- [x] Ensure content of embed drawer is not covered by player.
- [x] Ensure embed preview loads player.
- [x] Ensure interacting with the player volume controls does not show a tooltip (was getting clipped by iframe size)
