### PR TITLE
Newsletter CTA Tweaks

### DIFF
--- a/src/app/(main)/_components/CtaRegion/CtaRegion.tsx
+++ b/src/app/(main)/_components/CtaRegion/CtaRegion.tsx
@@ -25,7 +25,7 @@ export const ctaRegionVariants = cva(
         donation: "from-light-blue to-purple",
         info: "from-green to-light-blue [--button-background:var(--color-blue)] [--button-background-end:var(--color-dark-purple)]",
         newsletter:
-          "from-light-blue to-navy-blue [--button-background-end:var(--color-burnt-orange)]",
+          "from-navy-blue to-purple [--button-background-end:var(--color-burnt-orange)]",
       },
     },
     defaultVariants: {

--- a/src/app/(main)/_components/CtaRegion/_components/NewsletterCta.tsx
+++ b/src/app/(main)/_components/CtaRegion/_components/NewsletterCta.tsx
@@ -162,7 +162,6 @@ export default function NewsletterCta({
                   placeholder="Email Address..."
                   autoComplete="off"
                   aria-invalid={!!errors?.emailAddress}
-                  aria-valid={!errors?.emailAddress}
                 />
                 <Button
                   className="max-md:hidden"

--- a/src/app/(main)/_components/HeroImageBackground/HeroImageBackground.tsx
+++ b/src/app/(main)/_components/HeroImageBackground/HeroImageBackground.tsx
@@ -74,6 +74,7 @@ export default function HeroImageBackground({ data }: { data: MediaItem }) {
         fill
         preload
         loading="eager"
+        fetchPriority="high"
       />
       <div className="absolute inset-0 opacity-60 bg-linear-to-r from-navy-blue to-10%"></div>
       <div className="absolute inset-0 bg-linear-to-t from-navy-blue to-navy-blue/25 to-75%"></div>


### PR DESCRIPTION
- Removes an unrecognized aria label (`aria-valid`)
- Adjusts the newsletter CTA background color to provide more contrast to the fields

## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Ensure newsletter CTA has more contrast for the fields to stand out
- [ ] Run the Axe A11y inspector or run lighthouse to confirm no a11y errors
