### PR TITLE
569: Deduplicate shared routes' fetch requests

### DIFF
--- a/src/app/(main)/[...alias]/page.tsx
+++ b/src/app/(main)/[...alias]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import type { Metadata, ResolvingMetadata } from "next";
 import { unstable_cache } from "next/cache";
 import { notFound, permanentRedirect, redirect } from "next/navigation";
@@ -20,17 +21,12 @@ export const getCachedAliasData = unstable_cache(
   ["alias"],
   {
     tags: ["page", "alias"],
-    revalidate: 60,
+    revalidate: 86400,
   },
 );
 
-export const getCachedPage = unstable_cache(
-  async (id) => fetchGqlPage(id, PageIdType.Id),
-  ["page"],
-  {
-    tags: ["page", "content"],
-    revalidate: 60,
-  },
+export const getCachedPage = cache(async (id: string) =>
+  fetchGqlPage(id, PageIdType.Id),
 );
 
 export async function generateMetadata(
@@ -47,7 +43,7 @@ export async function generateMetadata(
 
   const aliasData = await getCachedAliasData(aliasPath);
 
-  if (!aliasData || aliasData.type !== "post--page") {
+  if (!aliasData?.id || aliasData.type !== "post--page") {
     return notFound();
   }
 
@@ -104,7 +100,7 @@ export default async function PagePage({ params }: Props) {
     }
   }
 
-  if (resourceType !== "post--page") {
+  if (!resourceId || resourceType !== "post--page") {
     return notFound();
   }
 

--- a/src/app/(main)/_components/MiniMenu/MiniMenu.tsx
+++ b/src/app/(main)/_components/MiniMenu/MiniMenu.tsx
@@ -92,7 +92,7 @@ export default function MiniMenu() {
             </NavigationMenuLink>
 
             <NavigationMenuLink asChild>
-              <Link href="/episodes">
+              <Link href="/stories">
                 <BookOpenIcon /> Stories
               </Link>
             </NavigationMenuLink>

--- a/src/app/(main)/categories/[...slugs]/page.tsx
+++ b/src/app/(main)/categories/[...slugs]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { decodeContentSearchFiltersParam } from "@/lib/util/binaryData";
@@ -33,13 +34,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedCategory = unstable_cache(
-  async (slug) => fetchGqlCategory(slug, CategoryIdType.Slug),
-  ["category"],
-  {
-    tags: ["category", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedCategory = cache(async (slug: string) =>
+  fetchGqlCategory(slug, CategoryIdType.Slug),
 );
 
 export const getCachedCategoryContent = unstable_cache(
@@ -51,7 +47,7 @@ export const getCachedCategoryContent = unstable_cache(
   ["content", "category"],
   {
     tags: ["content", "category", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/categories/[slug]/page.tsx
+++ b/src/app/(main)/categories/[slug]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { decodeContentSearchFiltersParam } from "@/lib/util/binaryData";
@@ -33,13 +34,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedCategory = unstable_cache(
-  async (slug) => fetchGqlCategory(slug, CategoryIdType.Slug),
-  ["category"],
-  {
-    tags: ["category", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedCategory = cache(async (slug: string) =>
+  fetchGqlCategory(slug, CategoryIdType.Slug),
 );
 
 export const getCachedCategoryContent = unstable_cache(
@@ -51,7 +47,7 @@ export const getCachedCategoryContent = unstable_cache(
   ["content", "category"],
   {
     tags: ["content", "category", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/categories/page.tsx
+++ b/src/app/(main)/categories/page.tsx
@@ -55,7 +55,7 @@ export const getCachedCategories = unstable_cache(
   ["categories"],
   {
     tags: ["categories", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/contributors/[slug]/page.tsx
+++ b/src/app/(main)/contributors/[slug]/page.tsx
@@ -5,6 +5,7 @@ import {
   SFTaxonomyEnum,
   TaxonomyContextSchema,
 } from "@/gen/search_filters_pb";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import {
@@ -34,13 +35,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedContributor = unstable_cache(
-  async (slug) => fetchGqlContributor(slug, ContributorIdType.Slug),
-  ["contributor"],
-  {
-    tags: ["contributor", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedContributor = cache(async (slug: string) =>
+  fetchGqlContributor(slug, ContributorIdType.Slug),
 );
 
 export const getCachedContributorContent = unstable_cache(
@@ -52,7 +48,7 @@ export const getCachedContributorContent = unstable_cache(
   ["content", "contributor"],
   {
     tags: ["content", "contributor", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/contributors/page.tsx
+++ b/src/app/(main)/contributors/page.tsx
@@ -57,7 +57,7 @@ export const getCachedContributors = unstable_cache(
   ["contributors"],
   {
     tags: ["contributors", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 
@@ -192,7 +192,9 @@ export default async function ContributorsPage({
                       </div>
                     )}
                   </div>
-                  {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+                  {!!href && (
+                    <CardLink href={href} aria-label={name ?? undefined} />
+                  )}
                 </header>
                 <div className="row-start-2 col-span-2 overflow-hidden">
                   <CardCarousel
@@ -272,7 +274,12 @@ export default async function ContributorsPage({
                             key={id}
                           >
                             <Card className={cn("")}>
-                              {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                              {linkHref && (
+                                <CardLink
+                                  href={linkHref}
+                                  aria-label={title ?? undefined}
+                                />
+                              )}
                               {imageSrc && !isPlaceholderImage && (
                                 <CardImage data-image-id={imageId}>
                                   <Image

--- a/src/app/(main)/episodes/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(main)/episodes/[year]/[month]/[day]/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, ResolvingMetadata } from "next";
-import { unstable_cache } from "next/cache";
+import { cache } from "react";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 import ContentBody from "@/app/(main)/_components/ContentBody";
@@ -40,13 +40,8 @@ type Props = {
   params: Promise<{ slug: string }>;
 };
 
-export const getCachedEpisode = unstable_cache(
-  async (slug) => fetchGqlEpisode(slug, EpisodeIdType.Slug),
-  ["episode"],
-  {
-    tags: ["episodes", "content"],
-    revalidate: 60,
-  },
+export const getCachedEpisode = cache(async (slug: string) =>
+  fetchGqlEpisode(slug, EpisodeIdType.Slug),
 );
 
 export async function generateMetadata(
@@ -197,7 +192,10 @@ export default async function EpisodePage({ params }: Props) {
                         >
                           <Card className={cn("aspect-260/360")}>
                             {segmentLinkHref && (
-                              <CardLink href={segmentLinkHref} aria-label={title ?? undefined} />
+                              <CardLink
+                                href={segmentLinkHref}
+                                aria-label={title ?? undefined}
+                              />
                             )}
                             {segmentImageSrc && (
                               <CardImage>

--- a/src/app/(main)/episodes/[year]/[month]/[day]/page.tsx
+++ b/src/app/(main)/episodes/[year]/[month]/[day]/page.tsx
@@ -20,7 +20,7 @@ export const getCachedEpisodesByDate = unstable_cache(
   ["content", "episodes", "year", "month", "day"],
   {
     tags: ["content", "episodes"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/episodes/[year]/[month]/page.tsx
+++ b/src/app/(main)/episodes/[year]/[month]/page.tsx
@@ -20,7 +20,7 @@ export const getCachedEpisodesByMonth = unstable_cache(
   ["content", "episodes", "year", "month"],
   {
     tags: ["content", "episodes"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/episodes/[year]/page.tsx
+++ b/src/app/(main)/episodes/[year]/page.tsx
@@ -20,7 +20,7 @@ export const getCachedEpisodesByYear = unstable_cache(
   ["content", "episodes", "year"],
   {
     tags: ["content", "episodes"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/episodes/page.tsx
+++ b/src/app/(main)/episodes/page.tsx
@@ -26,7 +26,7 @@ export const getCachedEpisodes = unstable_cache(
   ["content", "episodes"],
   {
     tags: ["content", "episodes"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/explore/page.tsx
+++ b/src/app/(main)/explore/page.tsx
@@ -25,7 +25,7 @@ export const getCachedExploreContent = unstable_cache(
   ["content"],
   {
     tags: ["content"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -17,7 +17,7 @@ export const getCachedAppData = unstable_cache(
   ["app"],
   {
     tags: ["app"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/newsletters/[slug]/page.tsx
+++ b/src/app/(main)/newsletters/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, ResolvingMetadata } from "next";
-import { unstable_cache } from "next/cache";
+import { cache } from "react";
 import { NewsletterIdType } from "@/interfaces";
 import { fetchGqlNewsletter } from "@/lib/fetch";
 import { notFound } from "next/navigation";
@@ -13,13 +13,8 @@ type Props = {
   params: Promise<{ slug: string }>;
 };
 
-export const getCachedNewsletter = unstable_cache(
-  async (slug) => fetchGqlNewsletter(slug, NewsletterIdType.Slug),
-  ["newsletter"],
-  {
-    tags: ["newsletter"],
-    revalidate: 60,
-  },
+export const getCachedNewsletter = cache(async (slug: string) =>
+  fetchGqlNewsletter(slug, NewsletterIdType.Slug),
 );
 
 export async function generateMetadata(

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { cn } from "@/lib/util/css";
-import { unstable_cache } from "next/cache";
+import { cache } from "react";
 import Image from "next/image";
 import { fetchGqlHomepage } from "@/lib/fetch";
 import {
@@ -35,14 +35,7 @@ import type { CSSProperties } from "react";
 import { getCtaRegionMessages, getShownMessage } from "@/lib/cta";
 import CtaRegion from "./_components/CtaRegion";
 
-export const getCachedHomepage = unstable_cache(
-  async () => fetchGqlHomepage(),
-  ["homepage"],
-  {
-    tags: ["homepage", "content"],
-    revalidate: 60,
-  },
-);
+export const getCachedHomepage = cache(async () => fetchGqlHomepage());
 
 export default async function Home() {
   const data = await getCachedHomepage();

--- a/src/app/(main)/podcasts/page.tsx
+++ b/src/app/(main)/podcasts/page.tsx
@@ -28,7 +28,7 @@ export const getCachedRssFeeds = unstable_cache(
   ["podcasts"],
   {
     tags: ["podcasts"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/programs/[slug]/page.tsx
+++ b/src/app/(main)/programs/[slug]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { taxonomySlugToSingularName } from "@/lib/map/taxonomy";
@@ -34,13 +35,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedProgram = unstable_cache(
-  async (slug) => fetchGqlProgram(slug, ProgramIdType.Slug),
-  ["program"],
-  {
-    tags: ["program", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedProgram = cache(async (slug: string) =>
+  fetchGqlProgram(slug, ProgramIdType.Slug),
 );
 
 export const getCachedProgramContent = unstable_cache(
@@ -52,7 +48,7 @@ export const getCachedProgramContent = unstable_cache(
   ["content", "program"],
   {
     tags: ["content", "program", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/programs/page.tsx
+++ b/src/app/(main)/programs/page.tsx
@@ -48,7 +48,7 @@ export const getCachedPrograms = unstable_cache(
   ["programs"],
   {
     tags: ["programs", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 
@@ -168,7 +168,9 @@ export default async function ProgramsPage({
                     </div>
                   )}
                 </div>
-                {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+                {!!href && (
+                  <CardLink href={href} aria-label={name ?? undefined} />
+                )}
               </header>
               <div className="row-start-2 col-span-2 overflow-hidden">
                 <CardCarousel
@@ -244,7 +246,12 @@ export default async function ProgramsPage({
                           key={id}
                         >
                           <Card className={cn("")}>
-                            {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                            {linkHref && (
+                              <CardLink
+                                href={linkHref}
+                                aria-label={title ?? undefined}
+                              />
+                            )}
                             {imageSrc && !isPlaceholderImage && (
                               <CardImage data-image-id={imageId}>
                                 <Image

--- a/src/app/(main)/segments/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(main)/segments/[year]/[month]/[day]/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, ResolvingMetadata } from "next";
-import { unstable_cache } from "next/cache";
+import { cache } from "react";
 import { notFound } from "next/navigation";
 import { Plausible, type PlausibleEventArgs } from "@/components/Plausible";
 import ContentBody from "@/app/(main)/_components/ContentBody";
@@ -14,13 +14,8 @@ type Props = {
   params: Promise<{ slug: string }>;
 };
 
-export const getCachedSegment = unstable_cache(
-  async (slug) => fetchGqlSegment(slug, SegmentIdType.Slug),
-  ["segment"],
-  {
-    tags: ["segment", "content"],
-    revalidate: 60,
-  },
+export const getCachedSegment = cache(async (slug: string) =>
+  fetchGqlSegment(slug, SegmentIdType.Slug),
 );
 
 export async function generateMetadata(

--- a/src/app/(main)/segments/[year]/[month]/[day]/page.tsx
+++ b/src/app/(main)/segments/[year]/[month]/[day]/page.tsx
@@ -20,7 +20,7 @@ export const getCachedSegmentsByDate = unstable_cache(
   ["content", "segments", "year", "month", "day"],
   {
     tags: ["content", "segments"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/segments/[year]/[month]/page.tsx
+++ b/src/app/(main)/segments/[year]/[month]/page.tsx
@@ -20,7 +20,7 @@ export const getCachedSegmentsByMonth = unstable_cache(
   ["content", "segments", "year", "month"],
   {
     tags: ["content", "segments"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/segments/[year]/page.tsx
+++ b/src/app/(main)/segments/[year]/page.tsx
@@ -20,7 +20,7 @@ export const getCachedSegmentsByYear = unstable_cache(
   ["content", "segments", "year"],
   {
     tags: ["content", "segments"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/segments/page.tsx
+++ b/src/app/(main)/segments/page.tsx
@@ -22,7 +22,7 @@ export const getCachedSegments = unstable_cache(
   ["content", "segments"],
   {
     tags: ["content", "segments"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/stations/page.tsx
+++ b/src/app/(main)/stations/page.tsx
@@ -13,7 +13,7 @@ export const getCachedStations = unstable_cache(
   ["stations"],
   {
     tags: ["stations"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/stories/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(main)/stories/[year]/[month]/[day]/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { PostIdType } from "@/interfaces";
 import { getCtaRegionMessages, getShownMessage } from "@/lib/cta";
 import { fetchGqlStory } from "@/lib/fetch";
 import { parseDateParts } from "@/lib/parse/date";
-import { unstable_cache } from "next/cache";
+import { cache } from "react";
 import { Tags } from "@/app/(main)/_components/Tags";
 import { Separator } from "@/components/ui/separator";
 import { convertSeoToMetadata } from "@/lib/parse/seo";
@@ -16,13 +16,8 @@ type Props = {
   params: Promise<{ slug: string }>;
 };
 
-export const getCachedStory = unstable_cache(
-  async (slug) => fetchGqlStory(slug, PostIdType.Slug),
-  ["story"],
-  {
-    tags: ["story", "content"],
-    revalidate: 60,
-  },
+export const getCachedStory = cache(async (slug: string) =>
+  fetchGqlStory(slug, PostIdType.Slug),
 );
 
 export async function generateMetadata(

--- a/src/app/(main)/stories/[year]/[month]/[day]/page.tsx
+++ b/src/app/(main)/stories/[year]/[month]/[day]/page.tsx
@@ -20,7 +20,7 @@ export const getCachedStoriesByDate = unstable_cache(
   ["content", "stories", "year", "month", "day"],
   {
     tags: ["content", "stories"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/stories/[year]/[month]/page.tsx
+++ b/src/app/(main)/stories/[year]/[month]/page.tsx
@@ -20,7 +20,7 @@ export const getCachedStoriesByMonth = unstable_cache(
   ["content", "stories", "year", "month"],
   {
     tags: ["content", "stories"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/stories/[year]/page.tsx
+++ b/src/app/(main)/stories/[year]/page.tsx
@@ -20,7 +20,7 @@ export const getCachedStoriesByYear = unstable_cache(
   ["content", "stories", "year"],
   {
     tags: ["content", "stories"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/stories/page.tsx
+++ b/src/app/(main)/stories/page.tsx
@@ -22,7 +22,7 @@ export const getCachedStories = unstable_cache(
   ["content", "stories"],
   {
     tags: ["content", "stories"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/tags/[slug]/page.tsx
+++ b/src/app/(main)/tags/[slug]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { taxonomySlugToSingularName } from "@/lib/map/taxonomy";
@@ -34,13 +35,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedTag = unstable_cache(
-  async (slug) => fetchGqlTag(slug, TagIdType.Slug),
-  ["tag"],
-  {
-    tags: ["tag", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedTag = cache(async (slug: string) =>
+  fetchGqlTag(slug, TagIdType.Slug),
 );
 
 export const getCachedTagContent = unstable_cache(
@@ -52,7 +48,7 @@ export const getCachedTagContent = unstable_cache(
   ["content", "tag"],
   {
     tags: ["content", "tag", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/tags/cities/[slug]/page.tsx
+++ b/src/app/(main)/tags/cities/[slug]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { decodeContentSearchFiltersParam } from "@/lib/util/binaryData";
@@ -33,13 +34,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedCity = unstable_cache(
-  async (slug) => fetchGqlTag(slug, TagIdType.Slug),
-  ["city"],
-  {
-    tags: ["city", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedCity = cache(async (slug: string) =>
+  fetchGqlTag(slug, TagIdType.Slug),
 );
 
 export const getCachedCityContent = unstable_cache(
@@ -51,7 +47,7 @@ export const getCachedCityContent = unstable_cache(
   ["content", "city"],
   {
     tags: ["content", "city", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/tags/cities/page.tsx
+++ b/src/app/(main)/tags/cities/page.tsx
@@ -41,7 +41,7 @@ export const getCachedCities = unstable_cache(
   ["cities"],
   {
     tags: ["cities", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 
@@ -156,7 +156,9 @@ export default async function CitiesPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+              {!!href && (
+                <CardLink href={href} aria-label={name ?? undefined} />
+              )}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +234,12 @@ export default async function CitiesPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                          {linkHref && (
+                            <CardLink
+                              href={linkHref}
+                              aria-label={title ?? undefined}
+                            />
+                          )}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/continents/[slug]/page.tsx
+++ b/src/app/(main)/tags/continents/[slug]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { taxonomySlugToSingularName } from "@/lib/map/taxonomy";
@@ -34,13 +35,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedContinent = unstable_cache(
-  async (slug) => fetchGqlTag(slug, TagIdType.Slug),
-  ["continent"],
-  {
-    tags: ["continent", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedContinent = cache(async (slug: string) =>
+  fetchGqlTag(slug, TagIdType.Slug),
 );
 
 export const getCachedContinentContent = unstable_cache(
@@ -52,7 +48,7 @@ export const getCachedContinentContent = unstable_cache(
   ["content", "continent"],
   {
     tags: ["content", "continent", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/tags/continents/page.tsx
+++ b/src/app/(main)/tags/continents/page.tsx
@@ -41,7 +41,7 @@ export const getCachedContinents = unstable_cache(
   ["continents"],
   {
     tags: ["continents", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 
@@ -156,7 +156,9 @@ export default async function ContinentsPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+              {!!href && (
+                <CardLink href={href} aria-label={name ?? undefined} />
+              )}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +234,12 @@ export default async function ContinentsPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                          {linkHref && (
+                            <CardLink
+                              href={linkHref}
+                              aria-label={title ?? undefined}
+                            />
+                          )}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/countries/[slug]/page.tsx
+++ b/src/app/(main)/tags/countries/[slug]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { taxonomySlugToSingularName } from "@/lib/map/taxonomy";
@@ -34,13 +35,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedCountry = unstable_cache(
-  async (slug) => fetchGqlTag(slug, TagIdType.Slug),
-  ["country"],
-  {
-    tags: ["country", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedCountry = cache(async (slug: string) =>
+  fetchGqlTag(slug, TagIdType.Slug),
 );
 
 export const getCachedCountryContent = unstable_cache(
@@ -52,7 +48,7 @@ export const getCachedCountryContent = unstable_cache(
   ["content", "country"],
   {
     tags: ["content", "country", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/tags/countries/page.tsx
+++ b/src/app/(main)/tags/countries/page.tsx
@@ -41,7 +41,7 @@ export const getCachedCountries = unstable_cache(
   ["countries"],
   {
     tags: ["countries", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 
@@ -156,7 +156,9 @@ export default async function CountriesPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+              {!!href && (
+                <CardLink href={href} aria-label={name ?? undefined} />
+              )}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +234,12 @@ export default async function CountriesPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                          {linkHref && (
+                            <CardLink
+                              href={linkHref}
+                              aria-label={title ?? undefined}
+                            />
+                          )}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/page.tsx
+++ b/src/app/(main)/tags/page.tsx
@@ -41,7 +41,7 @@ export const getCachedTags = unstable_cache(
   ["tags"],
   {
     tags: ["tags", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 
@@ -156,7 +156,9 @@ export default async function TagsPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+              {!!href && (
+                <CardLink href={href} aria-label={name ?? undefined} />
+              )}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +234,12 @@ export default async function TagsPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                          {linkHref && (
+                            <CardLink
+                              href={linkHref}
+                              aria-label={title ?? undefined}
+                            />
+                          )}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/people/[slug]/page.tsx
+++ b/src/app/(main)/tags/people/[slug]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { taxonomySlugToSingularName } from "@/lib/map/taxonomy";
@@ -34,13 +35,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedPerson = unstable_cache(
-  async (slug) => fetchGqlTag(slug, TagIdType.Slug),
-  ["person"],
-  {
-    tags: ["person", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedPerson = cache(async (slug: string) =>
+  fetchGqlTag(slug, TagIdType.Slug),
 );
 
 export const getCachedPersonContent = unstable_cache(
@@ -52,7 +48,7 @@ export const getCachedPersonContent = unstable_cache(
   ["content", "person"],
   {
     tags: ["content", "person", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/tags/people/page.tsx
+++ b/src/app/(main)/tags/people/page.tsx
@@ -41,7 +41,7 @@ export const getCachedPeople = unstable_cache(
   ["people"],
   {
     tags: ["people", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 
@@ -156,7 +156,9 @@ export default async function PeoplePage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+              {!!href && (
+                <CardLink href={href} aria-label={name ?? undefined} />
+              )}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +234,12 @@ export default async function PeoplePage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                          {linkHref && (
+                            <CardLink
+                              href={linkHref}
+                              aria-label={title ?? undefined}
+                            />
+                          )}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/provinces_or_states/[slug]/page.tsx
+++ b/src/app/(main)/tags/provinces_or_states/[slug]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { taxonomySlugToSingularName } from "@/lib/map/taxonomy";
@@ -34,13 +35,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedProvinceOrState = unstable_cache(
-  async (slug) => fetchGqlTag(slug, TagIdType.Slug),
-  ["provinceOrState"],
-  {
-    tags: ["provinceOrState", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedProvinceOrState = cache(async (slug: string) =>
+  fetchGqlTag(slug, TagIdType.Slug),
 );
 
 export const getCachedProvinceOrStateContent = unstable_cache(
@@ -52,7 +48,7 @@ export const getCachedProvinceOrStateContent = unstable_cache(
   ["content", "provinceOrState"],
   {
     tags: ["content", "provinceOrState", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/tags/provinces_or_states/page.tsx
+++ b/src/app/(main)/tags/provinces_or_states/page.tsx
@@ -45,7 +45,7 @@ export const getCachedProvincesOrStates = unstable_cache(
   ["provincesOrStates"],
   {
     tags: ["provincesOrStates", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 
@@ -160,7 +160,9 @@ export default async function ProvincesOrStatesPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+              {!!href && (
+                <CardLink href={href} aria-label={name ?? undefined} />
+              )}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -236,7 +238,12 @@ export default async function ProvincesOrStatesPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                          {linkHref && (
+                            <CardLink
+                              href={linkHref}
+                              aria-label={title ?? undefined}
+                            />
+                          )}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/regions/[slug]/page.tsx
+++ b/src/app/(main)/tags/regions/[slug]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { taxonomySlugToSingularName } from "@/lib/map/taxonomy";
@@ -34,13 +35,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedRegion = unstable_cache(
-  async (slug) => fetchGqlTag(slug, TagIdType.Slug),
-  ["region"],
-  {
-    tags: ["region", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedRegion = cache(async (slug: string) =>
+  fetchGqlTag(slug, TagIdType.Slug),
 );
 
 export const getCachedRegionContent = unstable_cache(
@@ -52,7 +48,7 @@ export const getCachedRegionContent = unstable_cache(
   ["content", "region"],
   {
     tags: ["content", "region", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/tags/regions/page.tsx
+++ b/src/app/(main)/tags/regions/page.tsx
@@ -41,7 +41,7 @@ export const getCachedRegions = unstable_cache(
   ["regions"],
   {
     tags: ["regions", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 
@@ -156,7 +156,9 @@ export default async function RegionsPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+              {!!href && (
+                <CardLink href={href} aria-label={name ?? undefined} />
+              )}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +234,12 @@ export default async function RegionsPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                          {linkHref && (
+                            <CardLink
+                              href={linkHref}
+                              aria-label={title ?? undefined}
+                            />
+                          )}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/(main)/tags/social_tags/[slug]/page.tsx
+++ b/src/app/(main)/tags/social_tags/[slug]/page.tsx
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerDateFilter,
   ExplorerSortFilter,
 } from "@/app/(main)/_components/Explorer";
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { taxonomySlugToSingularName } from "@/lib/map/taxonomy";
@@ -34,13 +35,8 @@ type Props = {
   searchParams: Promise<Record<string, string | string[]>>;
 };
 
-export const getCachedSocialTag = unstable_cache(
-  async (slug) => fetchGqlTag(slug, TagIdType.Slug),
-  ["socialTag"],
-  {
-    tags: ["socialTag", "taxonomy"],
-    revalidate: 60,
-  },
+export const getCachedSocialTag = cache(async (slug: string) =>
+  fetchGqlTag(slug, TagIdType.Slug),
 );
 
 export const getCachedSocialTagContent = unstable_cache(
@@ -52,7 +48,7 @@ export const getCachedSocialTagContent = unstable_cache(
   ["content", "socialTag"],
   {
     tags: ["content", "socialTag", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 

--- a/src/app/(main)/tags/social_tags/page.tsx
+++ b/src/app/(main)/tags/social_tags/page.tsx
@@ -41,7 +41,7 @@ export const getCachedSocialTags = unstable_cache(
   ["socialTags"],
   {
     tags: ["socialTags", "taxonomy"],
-    revalidate: 60,
+    revalidate: 3600,
   },
 );
 
@@ -156,7 +156,9 @@ export default async function SocialTagsPage({
                   </div>
                 )}
               </div>
-              {!!href && <CardLink href={href} aria-label={name ?? undefined} />}
+              {!!href && (
+                <CardLink href={href} aria-label={name ?? undefined} />
+              )}
             </header>
             <div className="row-start-2 col-span-2 overflow-hidden">
               <CardCarousel
@@ -232,7 +234,12 @@ export default async function SocialTagsPage({
                         key={id}
                       >
                         <Card className={cn("")}>
-                          {linkHref && <CardLink href={linkHref} aria-label={title ?? undefined} />}
+                          {linkHref && (
+                            <CardLink
+                              href={linkHref}
+                              aria-label={title ?? undefined}
+                            />
+                          )}
                           {imageSrc && !isPlaceholderImage && (
                             <CardImage data-image-id={imageId}>
                               <Image

--- a/src/app/embed/audio/[id]/page.tsx
+++ b/src/app/embed/audio/[id]/page.tsx
@@ -17,51 +17,44 @@ import { parseAudioData } from "@/lib/parse/audio";
 import { cn } from "@/lib/util/css";
 import { encode } from "base-64";
 import { DownloadIcon } from "lucide-react";
-import { unstable_cache } from "next/cache";
+import { cache } from "react";
 import { notFound, redirect, RedirectType } from "next/navigation";
 
-export const getCachedAudioEmbedData = unstable_cache(
-  async (id: string) => {
-    const story = await fetchGqlStory(id);
-    if (story) {
-      const audioId = story?.additionalMedia?.audio?.node?.id;
-      const audioData =
-        (!!audioId && (await fetchGqlAudio(audioId))) || undefined;
+export const getCachedAudioEmbedData = cache(async (id: string) => {
+  const story = await fetchGqlStory(id);
+  if (story) {
+    const audioId = story?.additionalMedia?.audio?.node?.id;
+    const audioData =
+      (!!audioId && (await fetchGqlAudio(audioId))) || undefined;
 
-      return audioData && parseAudioData(audioData, { linkResource: story });
-    }
+    return audioData && parseAudioData(audioData, { linkResource: story });
+  }
 
-    const segment = await fetchGqlSegment(id);
-    if (segment) {
-      const audioId = segment?.segmentContent?.audio?.node?.id;
-      const audioData =
-        (!!audioId && (await fetchGqlAudio(audioId))) || undefined;
+  const segment = await fetchGqlSegment(id);
+  if (segment) {
+    const audioId = segment?.segmentContent?.audio?.node?.id;
+    const audioData =
+      (!!audioId && (await fetchGqlAudio(audioId))) || undefined;
 
-      return audioData && parseAudioData(audioData, { linkResource: segment });
-    }
+    return audioData && parseAudioData(audioData, { linkResource: segment });
+  }
 
-    const episode = await fetchGqlEpisode(id);
-    if (episode) {
-      const audioId = episode?.episodeAudio?.audio?.node?.id;
-      const audioData =
-        (!!audioId && (await fetchGqlAudio(audioId))) || undefined;
+  const episode = await fetchGqlEpisode(id);
+  if (episode) {
+    const audioId = episode?.episodeAudio?.audio?.node?.id;
+    const audioData =
+      (!!audioId && (await fetchGqlAudio(audioId))) || undefined;
 
-      return audioData && parseAudioData(audioData, { linkResource: episode });
-    }
+    return audioData && parseAudioData(audioData, { linkResource: episode });
+  }
 
-    const audio = await fetchGqlAudio(id);
-    if (audio) {
-      return parseAudioData(audio);
-    }
+  const audio = await fetchGqlAudio(id);
+  if (audio) {
+    return parseAudioData(audio);
+  }
 
-    return undefined;
-  },
-  ["embed"],
-  {
-    tags: ["embed", "audio"],
-    revalidate: 60,
-  },
-);
+  return undefined;
+});
 
 export default async function AudioEmbed({
   params,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -29,5 +35,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Closes #569 

- convert shared routes fetches to react cache
- increase unstable_cache fetch revalidate to 1 hour
- increase unstable_cache fetch revalidate for alias routes alias lookup fetch to 1 day

## To Review

- [x] Checkout Branch.
- [x] Start up local TW WP server. You should see requests logged to the terminal you ran `docker compose up` in.
- [x] Update your .env file to use your local TW WP domain for `API_URL_BASE`.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Navigate to a story.
- [x] Ensure only one request was logged in WP terminal.
- [ ] Repeat for all similar leaf routes ending with a slug.
