### PR TITLE
fix: change content type of metadata images to image/jpeg

### DIFF
--- a/src/app/(main)/contributors/[slug]/opengraph-image.tsx
+++ b/src/app/(main)/contributors/[slug]/opengraph-image.tsx
@@ -12,7 +12,7 @@ export const size = {
   width: 1200,
   height: 630,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image({ params }: Props) {
   const slug = (await params).slug;

--- a/src/app/(main)/contributors/[slug]/twitter-image.tsx
+++ b/src/app/(main)/contributors/[slug]/twitter-image.tsx
@@ -12,7 +12,7 @@ export const size = {
   width: 1200,
   height: 675,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image({ params }: Props) {
   const slug = (await params).slug;

--- a/src/app/(main)/episodes/[year]/[month]/[day]/[slug]/opengraph-image.tsx
+++ b/src/app/(main)/episodes/[year]/[month]/[day]/[slug]/opengraph-image.tsx
@@ -12,7 +12,7 @@ export const size = {
   width: 1200,
   height: 630,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image({ params }: Props) {
   const slug = (await params).slug;

--- a/src/app/(main)/episodes/[year]/[month]/[day]/[slug]/twitter-image.tsx
+++ b/src/app/(main)/episodes/[year]/[month]/[day]/[slug]/twitter-image.tsx
@@ -12,7 +12,7 @@ export const size = {
   width: 1200,
   height: 675,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image({ params }: Props) {
   const slug = (await params).slug;

--- a/src/app/(main)/newsletters/[slug]/opengraph-image.tsx
+++ b/src/app/(main)/newsletters/[slug]/opengraph-image.tsx
@@ -12,7 +12,7 @@ export const size = {
   width: 1200,
   height: 630,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image({ params }: Props) {
   const slug = (await params).slug;

--- a/src/app/(main)/newsletters/[slug]/twitter-image.tsx
+++ b/src/app/(main)/newsletters/[slug]/twitter-image.tsx
@@ -12,7 +12,7 @@ export const size = {
   width: 1200,
   height: 675,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image({ params }: Props) {
   const slug = (await params).slug;

--- a/src/app/(main)/segments/[year]/[month]/[day]/[slug]/opengraph-image.tsx
+++ b/src/app/(main)/segments/[year]/[month]/[day]/[slug]/opengraph-image.tsx
@@ -12,7 +12,7 @@ export const size = {
   width: 1200,
   height: 630,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image({ params }: Props) {
   const slug = (await params).slug;

--- a/src/app/(main)/segments/[year]/[month]/[day]/[slug]/twitter-image.tsx
+++ b/src/app/(main)/segments/[year]/[month]/[day]/[slug]/twitter-image.tsx
@@ -12,7 +12,7 @@ export const size = {
   width: 1200,
   height: 675,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image({ params }: Props) {
   const slug = (await params).slug;

--- a/src/app/(main)/stories/[year]/[month]/[day]/[slug]/opengraph-image.tsx
+++ b/src/app/(main)/stories/[year]/[month]/[day]/[slug]/opengraph-image.tsx
@@ -12,7 +12,7 @@ export const size = {
   width: 1200,
   height: 630,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image({ params }: Props) {
   const slug = (await params).slug;

--- a/src/app/(main)/stories/[year]/[month]/[day]/[slug]/twitter-image.tsx
+++ b/src/app/(main)/stories/[year]/[month]/[day]/[slug]/twitter-image.tsx
@@ -12,7 +12,7 @@ export const size = {
   width: 1200,
   height: 675,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image({ params }: Props) {
   const slug = (await params).slug;

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -6,7 +6,7 @@ export const size = {
   width: 1200,
   height: 630,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image() {
   return createMetaImage({

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -6,7 +6,7 @@ export const size = {
   width: 1200,
   height: 675,
 };
-export const contentType = "image/png";
+export const contentType = "image/jpeg";
 
 export default async function Image() {
   return createMetaImage({


### PR DESCRIPTION
## To Review

- [ ] Checkout Branch.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Inspect page and ensure `og:image:type` meta tag is set to `image/jpeg`.
- [ ] Repeat for:
  - [x] Story page
  - [x] Episode page
  - [x] Segment page
  - [x] Contributor page
  - [ ] Newsletter page
