### PR TITLE
fix(homepage): add caching to youtube data fetch

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { cn } from "@/lib/util/css";
 import { cache } from "react";
+import { unstable_cache } from "next/cache";
 import Image from "next/image";
-import { fetchGqlHomepage } from "@/lib/fetch";
+import { fetchGqlHomepage, fetchYouTubePlaylistVideos } from "@/lib/fetch";
 import {
   CarouselContent,
   CarouselItem,
@@ -40,21 +41,31 @@ import CtaRegion from "./_components/CtaRegion";
 import { parseYoutubeVideoData } from "@/lib/parse/video";
 import YouTubeIcon from "@/assets/svg/icons/brands/youtube.svg";
 
-export const getCachedHomepage = cache(async () => fetchGqlHomepage());
+export const getCachedHomepage = cache(async () =>
+  unstable_cache(() => fetchGqlHomepage(), ["homepage"], {
+    tags: ["homepage"],
+    revalidate: 3600,
+  })(),
+);
+
+const getYouTubePlaylistVideos = unstable_cache(
+  async (playlistId: string) => fetchYouTubePlaylistVideos(playlistId),
+  ["youtube"],
+  {
+    tags: ["homepage", "youtube"],
+    revalidate: 3600,
+  },
+);
 
 export default async function Home() {
-  const data = await getCachedHomepage();
+  const [data, youtubePlaylistVideos] = await Promise.all([
+    getCachedHomepage(),
+    getYouTubePlaylistVideos("PLroz2B1RPf0GiDwdj6NLexB5-v5NQnkFf"),
+  ]);
 
   if (!data) return null;
 
-  const {
-    id,
-    programContributors,
-    posts,
-    landingPage,
-    menus,
-    youtubePlaylistVideos,
-  } = data;
+  const { id, programContributors, posts, landingPage, menus } = data;
   const { team } = programContributors || {};
   const { quickLinks } = menus;
   const quickLinksMenu = parseMenu(quickLinks);

--- a/src/interfaces/content/homepage.types.ts
+++ b/src/interfaces/content/homepage.types.ts
@@ -6,5 +6,4 @@ import type { MenuItem, Program } from "@/interfaces/api";
 
 export type Homepage = Program & {
   menus: Record<"quickLinks", MenuItem[]>;
-  youtubePlaylistVideos?: GoogleAppsScript.YouTube.Schema.Video[];
 };

--- a/src/lib/fetch/homepage/fetchGqlHomepage.ts
+++ b/src/lib/fetch/homepage/fetchGqlHomepage.ts
@@ -104,45 +104,6 @@ export async function fetchGqlHomepage() {
     },
   } as Homepage;
 
-  // Fetch YouTube playlist data.
-  if (process.env.YT_API_KEY) {
-    const ytApiUrl = new URL(
-      "https://youtube.googleapis.com/youtube/v3/playlistItems",
-    );
-
-    ytApiUrl.searchParams.set("key", process.env.YT_API_KEY);
-    ytApiUrl.searchParams.set("part", "contentDetails");
-    ytApiUrl.searchParams.set(
-      "playlistId",
-      "PLroz2B1RPf0GiDwdj6NLexB5-v5NQnkFf",
-    );
-    ytApiUrl.searchParams.set("maxResults", "50");
-
-    const ytPlaylistItemsResponse: GoogleAppsScript.YouTube.Schema.PlaylistItemListResponse =
-      await fetch(ytApiUrl.toString(), {
-        headers: [["Accept", "application/json"]],
-      }).then((resp) => resp.ok && resp.json());
-
-    if (ytPlaylistItemsResponse.items?.length) {
-      const videoIds = ytPlaylistItemsResponse.items.map(
-        ({ contentDetails }) => contentDetails?.videoId,
-      );
-      ytApiUrl.pathname = "/youtube/v3/videos";
-      ytApiUrl.searchParams.delete("playlistId");
-      ytApiUrl.searchParams.set("part", "contentDetails,snippet,player");
-      ytApiUrl.searchParams.set("maxHeight", "1200");
-      ytApiUrl.searchParams.set("maxWidth", "1200");
-      ytApiUrl.searchParams.set("id", videoIds.join(","));
-
-      const ytVideosResponse: GoogleAppsScript.YouTube.Schema.VideoListResponse =
-        await fetch(ytApiUrl.toString(), {
-          headers: [["Accept", "application/json"]],
-        }).then((resp) => resp.ok && resp.json());
-
-      returnData.youtubePlaylistVideos = ytVideosResponse.items;
-    }
-  }
-
   return returnData;
 }
 

--- a/src/lib/fetch/homepage/fetchYouTubePlaylistVideos.ts
+++ b/src/lib/fetch/homepage/fetchYouTubePlaylistVideos.ts
@@ -1,0 +1,56 @@
+export async function fetchYouTubePlaylistVideos(playlistId: string) {
+  if (process.env.YT_API_KEY && playlistId) {
+    const ytApiUrl = new URL(
+      "https://youtube.googleapis.com/youtube/v3/playlistItems",
+    );
+
+    ytApiUrl.searchParams.set("key", process.env.YT_API_KEY);
+    ytApiUrl.searchParams.set("part", "contentDetails");
+    ytApiUrl.searchParams.set("playlistId", playlistId);
+    ytApiUrl.searchParams.set("maxResults", "50");
+
+    const ytPlaylistItemsResponse = await fetch(ytApiUrl.toString(), {
+      headers: [["Accept", "application/json"]],
+    })
+      .then((resp) => resp.json())
+      .then((data) => {
+        if (data.error) {
+          console.error("Unable to fetch YouTube playlist.", {
+            ...data,
+          });
+          return undefined;
+        }
+        return data as GoogleAppsScript.YouTube.Schema.PlaylistItemListResponse;
+      });
+
+    if (ytPlaylistItemsResponse?.items?.length) {
+      const videoIds = ytPlaylistItemsResponse.items.map(
+        ({ contentDetails }) => contentDetails?.videoId,
+      );
+      ytApiUrl.pathname = "/youtube/v3/videos";
+      ytApiUrl.searchParams.delete("playlistId");
+      ytApiUrl.searchParams.set("part", "contentDetails,snippet,player");
+      ytApiUrl.searchParams.set("maxHeight", "1200");
+      ytApiUrl.searchParams.set("maxWidth", "1200");
+      ytApiUrl.searchParams.set("id", videoIds.join(","));
+
+      const ytVideosResponse = await fetch(ytApiUrl.toString(), {
+        headers: [["Accept", "application/json"]],
+      })
+        .then((resp) => resp.json())
+        .then((data) => {
+          if (data.error) {
+            console.error("Unable to fetch YouTube videos.", {
+              ...data,
+            });
+            return undefined;
+          }
+          return data as GoogleAppsScript.YouTube.Schema.VideoListResponse;
+        });
+
+      return ytVideosResponse?.items;
+    }
+  }
+
+  return undefined;
+}

--- a/src/lib/fetch/homepage/index.ts
+++ b/src/lib/fetch/homepage/index.ts
@@ -1,1 +1,2 @@
-export * from './fetchGqlHomepage';
+export * from "./fetchGqlHomepage";
+export * from "./fetchYouTubePlaylistVideos";


### PR DESCRIPTION
- add caching to youtube data fetch
- separate youtube playlist data from homepage model
- add logging for youtube api response errors
- fetch homepage and youtube data in parallel

## To Review

- [x] Checkout Branch.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [x] Expect to see an "Unable to fetch YouTube playlist." error in your console due to being over request quota, and no video carousel on the page.
- [x] When you reload the homepage, you should NOT see any additional errors logged for YouTube API requests since the last result should be cached for an hour.
- [x] Stop the server and run `rm -rf .next`, then restart dev server. This will clear the next data caches, simulating 1 hour has passed.
- [x] Expect the same results as steps 1 and 2.
